### PR TITLE
Fixed incorrect return value policy in python bind

### DIFF
--- a/python/src/candidates/candidates.cpp
+++ b/python/src/candidates/candidates.cpp
@@ -19,7 +19,7 @@ void define_candidates(py::module_& m)
             "__getitem__",
             [](Candidates& self, size_t idx) -> ContinuousCollisionCandidate* {
                 return &self[idx];
-            })
+            }, py::return_value_policy::reference)
         .def(
             "save_obj", &Candidates::save_obj, "", py::arg("filename"),
             py::arg("V"), py::arg("E"), py::arg("F"))


### PR DESCRIPTION
# Description

The python binding was taking ownership of an item in candidates leading to crashes when the destructor was called

- [ X] Bug fix (non-breaking change which fixes an issue)
