### PR TITLE
Change espv_times_h to epsv

### DIFF
--- a/docs/source/tutorial/getting_started.rst
+++ b/docs/source/tutorial/getting_started.rst
@@ -364,16 +364,16 @@ Now we can compute the friction dissipative potential using the ``FrictionConstr
         .. code-block:: c++
 
             double friction_potential = friction_constraints.compute_potential(
-                collision_mesh, velocity, epsv_times_h);
+                collision_mesh, velocity, epsv);
 
     .. md-tab-item:: Python
 
         .. code-block:: python
 
             friction_potential = friction_constraints.compute_potential(
-                collision_mesh, velocity, epsv_times_h)
+                collision_mesh, velocity, epsv)
 
-Here ``epsv_times_h`` (:math:`\epsilon_v h`) is the static friction threshold (in units of velocity) used to smoothly transition from dynamic to static friction.
+Here ``epsv`` (:math:`\epsilon_v`) is the static friction threshold (in units of velocity) used to smoothly transition from dynamic to static friction.
 
 .. important::
    The friction potential is a function of the velocities rather than the positions. We can compute the velocities directly from the current and previous position(s) based on our time-integration scheme. For example, if we are using backward Euler integration, then the velocity is
@@ -388,7 +388,7 @@ This returns a scalar value ``friction_potential`` which is the sum of the indiv
 Mathematically this is defined as
 
 .. math::
-   D(x) = \sum_{k \in C} \mu\lambda_k^nf_0\left(\|T_k^Tv\|; \epsilon_v h\right),
+   D(x) = \sum_{k \in C} \mu\lambda_k^nf_0\left(\|T_k^Tv\|; \epsilon_v\right),
 
 where :math:`C` is the lagged collision constraints, :math:`\lambda_k^n` is the normal force magnitude for the :math:`k`-th contact, :math:`T_k` is the tangential basis for the :math:`k`-th contact, and :math:`f_0` is the smooth friction function used to approximate the non-smooth transition from dynamic to static friction.
 
@@ -405,21 +405,21 @@ We can also compute the first and second derivatives of the friction dissipative
 
             Eigen::VectorXd friction_potential_grad =
                 friction_constraints.compute_potential_gradient(
-                    collision_mesh, velocity, epsv_times_h);
+                    collision_mesh, velocity, epsv);
 
             Eigen::SparseMatrix<double> friction_potential_hess =
                 friction_constraints.compute_potential_hessian(
-                    collision_mesh, velocity, epsv_times_h);
+                    collision_mesh, velocity, epsv);
 
     .. md-tab-item:: Python
 
         .. code-block:: python
 
             friction_potential_grad = friction_constraints.compute_potential_gradient(
-                collision_mesh, velocity, epsv_times_h)
+                collision_mesh, velocity, epsv)
 
             friction_potential_hess = friction_constraints.compute_potential_hessian(
-                collision_mesh, velocity, epsv_times_h)
+                collision_mesh, velocity, epsv)
 
 Continuous Collision Detection
 ------------------------------

--- a/python/src/friction/constraints/friction_constraint.cpp
+++ b/python/src/friction/constraints/friction_constraint.cpp
@@ -18,9 +18,21 @@ void define_friction_constraint(py::module_& m)
 
     friction_constraint
         .def(
-            "compute_potential", &FrictionConstraint::compute_potential, "",
+            "compute_potential", &FrictionConstraint::compute_potential,
+            R"ipc_Qu8mg5v7(
+            Compute the friction dissapative potential.
+
+            Parameters:
+                velocities: Velocities of the vertices (rowwise)
+                edges: Edges of the mesh
+                faces: Faces of the mesh
+                epsv: Smooth friction mollifier parameter :math:`\epsilon_v`.
+
+            Returns:
+                The friction dissapative potential.
+            )ipc_Qu8mg5v7",
             py::arg("velocities"), py::arg("edges"), py::arg("faces"),
-            py::arg("epsv_times_h"))
+            py::arg("epsv"))
         .def(
             "compute_potential_gradient",
             &FrictionConstraint::compute_potential_gradient,
@@ -31,13 +43,13 @@ void define_friction_constraint(py::module_& m)
                 velocities: Velocities of the vertices (rowwise)
                 edges: Edges of the mesh
                 faces: Faces of the mesh
-                epsv_times_h: $\epsilon_vh$
+                epsv: Smooth friction mollifier parameter :math:`\epsilon_v`.
 
             Returns:
                 Gradient of the friction dissapative potential wrt velocities
             )ipc_Qu8mg5v7",
             py::arg("velocities"), py::arg("edges"), py::arg("faces"),
-            py::arg("epsv_times_h"))
+            py::arg("epsv"))
         .def(
             "compute_potential_hessian",
             &FrictionConstraint::compute_potential_hessian,
@@ -48,14 +60,14 @@ void define_friction_constraint(py::module_& m)
                 velocities: Velocities of the vertices (rowwise)
                 edges: Edges of the mesh
                 faces: Faces of the mesh
-                epsv_times_h: $\epsilon_vh$
+                epsv: Smooth friction mollifier parameter :math:`\epsilon_v`.
                 project_hessian_to_psd: Project the hessian to PSD
 
             Returns:
                 Hessian of the friction dissapative potential wrt velocities
             )ipc_Qu8mg5v7",
             py::arg("velocities"), py::arg("edges"), py::arg("faces"),
-            py::arg("epsv_times_h"), py::arg("project_hessian_to_psd"))
+            py::arg("epsv"), py::arg("project_hessian_to_psd"))
         .def(
             "compute_force",
             py::overload_cast<
@@ -73,7 +85,7 @@ void define_friction_constraint(py::module_& m)
                 faces: Collision mesh faces
                 dhat: Barrier activation distance
                 barrier_stiffness: Barrier stiffness
-                epsv_times_h: $\epsilon_vh$
+                epsv: Smooth friction mollifier parameter :math:`\epsilon_v`.
                 dmin: Minimum distance
                 no_mu: Whether to not multiply by mu
 
@@ -81,9 +93,8 @@ void define_friction_constraint(py::module_& m)
                 Friction force
             )ipc_Qu8mg5v7",
             py::arg("X"), py::arg("U"), py::arg("edges"), py::arg("faces"),
-            py::arg("dhat"), py::arg("barrier_stiffness"),
-            py::arg("epsv_times_h"), py::arg("dmin") = 0,
-            py::arg("no_mu") = false)
+            py::arg("dhat"), py::arg("barrier_stiffness"), py::arg("epsv"),
+            py::arg("dmin") = 0, py::arg("no_mu") = false)
         .def(
             "compute_force",
             py::overload_cast<
@@ -103,7 +114,7 @@ void define_friction_constraint(py::module_& m)
                 faces: Collision mesh faces
                 dhat: Barrier activation distance
                 barrier_stiffness: Barrier stiffness
-                epsv_times_h: $\epsilon_vh$
+                epsv: Smooth friction mollifier parameter :math:`\epsilon_v`.
                 dmin: Minimum distance
                 no_mu: Whether to not multiply by mu
 
@@ -112,8 +123,7 @@ void define_friction_constraint(py::module_& m)
             )ipc_Qu8mg5v7",
             py::arg("X"), py::arg("Ut"), py::arg("U"), py::arg("edges"),
             py::arg("faces"), py::arg("dhat"), py::arg("barrier_stiffness"),
-            py::arg("epsv_times_h"), py::arg("dmin") = 0,
-            py::arg("no_mu") = false)
+            py::arg("epsv"), py::arg("dmin") = 0, py::arg("no_mu") = false)
         .def(
             "compute_force_jacobian",
             py::overload_cast<
@@ -132,7 +142,7 @@ void define_friction_constraint(py::module_& m)
                 faces: Collision mesh faces
                 dhat: Barrier activation distance
                 barrier_stiffness: Barrier stiffness
-                epsv_times_h: $\epsilon_vh$
+                epsv: Smooth friction mollifier parameter :math:`\epsilon_v`.
                 wrt: Variable to differentiate the friction force with respect to.
                 dmin: Minimum distance
 
@@ -140,8 +150,8 @@ void define_friction_constraint(py::module_& m)
                 Friction force Jacobian
             )ipc_Qu8mg5v7",
             py::arg("X"), py::arg("U"), py::arg("edges"), py::arg("faces"),
-            py::arg("dhat"), py::arg("barrier_stiffness"),
-            py::arg("epsv_times_h"), py::arg("wrt"), py::arg("dmin") = 0)
+            py::arg("dhat"), py::arg("barrier_stiffness"), py::arg("epsv"),
+            py::arg("wrt"), py::arg("dmin") = 0)
         .def(
             "compute_force_jacobian",
             py::overload_cast<
@@ -161,7 +171,7 @@ void define_friction_constraint(py::module_& m)
                 faces: Collision mesh faces
                 dhat: Barrier activation distance
                 barrier_stiffness: Barrier stiffness
-                epsv_times_h: $\epsilon_vh$
+                epsv: Smooth friction mollifier parameter :math:`\epsilon_v`.
                 wrt: Variable to differentiate the friction force with respect to.
                 dmin: Minimum distance
 
@@ -170,7 +180,7 @@ void define_friction_constraint(py::module_& m)
             )ipc_Qu8mg5v7",
             py::arg("X"), py::arg("Ut"), py::arg("U"), py::arg("edges"),
             py::arg("faces"), py::arg("dhat"), py::arg("barrier_stiffness"),
-            py::arg("epsv_times_h"), py::arg("wrt"), py::arg("dmin") = 0)
+            py::arg("epsv"), py::arg("wrt"), py::arg("dmin") = 0)
         .def_readwrite(
             "normal_force_magnitude",
             &FrictionConstraint::normal_force_magnitude,

--- a/python/src/friction/friction_constraints.cpp
+++ b/python/src/friction/friction_constraints.cpp
@@ -22,8 +22,9 @@ void define_friction_constraints(py::module_& m)
             "build",
             [](FrictionConstraints& self, const CollisionMesh& mesh,
                const Eigen::MatrixXd& vertices,
-               const CollisionConstraints& contact_constraints, double dhat,
-               double barrier_stiffness, const Eigen::VectorXd& mus) {
+               const CollisionConstraints& contact_constraints,
+               const double dhat, const double barrier_stiffness,
+               const Eigen::VectorXd& mus) {
                 self.build(
                     mesh, vertices, contact_constraints, dhat,
                     barrier_stiffness, mus);
@@ -35,7 +36,7 @@ void define_friction_constraints(py::module_& m)
             "build",
             py::overload_cast<
                 const CollisionMesh&, const Eigen::MatrixXd&,
-                const CollisionConstraints&, double, double,
+                const CollisionConstraints&, const double, const double,
                 const Eigen::VectorXd&,
                 const std::function<double(double, double)>&>(
                 &FrictionConstraints::build),
@@ -50,11 +51,12 @@ void define_friction_constraints(py::module_& m)
             Parameters:
                 mesh: The collision mesh.
                 velocity: Current vertex velocity (rowwise).
+                epsv: Mollifier parameter :math:`\epsilon_v`.
 
             Returns:
                 The friction dissapative potential.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("velocity"), py::arg("epsv_times_h"))
+            py::arg("mesh"), py::arg("velocity"), py::arg("epsv"))
         .def(
             "compute_potential_gradient",
             &FrictionConstraints::compute_potential_gradient,
@@ -64,11 +66,12 @@ void define_friction_constraints(py::module_& m)
             Parameters:
                 mesh: The collision mesh.
                 velocity: Current vertex velocity (rowwise).
+                epsv: Mollifier parameter :math:`\epsilon_v`.
 
             Returns:
                 The gradient of the friction dissapative potential wrt the velocity.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("velocity"), py::arg("epsv_times_h"))
+            py::arg("mesh"), py::arg("velocity"), py::arg("epsv"))
         .def(
             "compute_potential_hessian",
             &FrictionConstraints::compute_potential_hessian,
@@ -78,12 +81,13 @@ void define_friction_constraints(py::module_& m)
             Parameters:
                 mesh: The collision mesh.
                 velocity: Current vertex velocity (rowwise).
+                epsv: Mollifier parameter :math:`\epsilon_v`.
                 project_hessian_to_psd: If true, project the Hessian to be positive semi-definite.
 
             Returns:
                 The Hessian of the friction dissapative potential wrt the velocity.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("velocity"), py::arg("epsv_times_h"),
+            py::arg("mesh"), py::arg("velocity"), py::arg("epsv"),
             py::arg("project_hessian_to_psd") = false)
         .def(
             "compute_force",
@@ -92,10 +96,26 @@ void define_friction_constraints(py::module_& m)
                 const Eigen::MatrixXd&, const Eigen::MatrixXd&, const double,
                 const double, const double, const double, const bool>(
                 &FrictionConstraints::compute_force, py::const_),
-            "", py::arg("mesh"), py::arg("X"), py::arg("Ut"), py::arg("U"),
-            py::arg("dhat"), py::arg("barrier_stiffness"),
-            py::arg("epsv_times_h"), py::arg("dmin") = 0,
-            py::arg("no_mu") = false)
+            R"ipc_Qu8mg5v7(
+            Compute the friction force from the given velocity.
+
+            Parameters:
+                mesh: The collision mesh.
+                X: Rest vertex positions (rowwise).
+                Ut: Previous vertex displacements (rowwise).
+                U: Current vertex displacements (rowwise).
+                dhat: Barrier activation distance.
+                barrier_stiffness: Barrier stiffness.
+                epsv: Mollifier parameter :math:`\epsilon_v`.
+                dmin: Minimum distance to use for the barrier.
+                no_mu: whether to not multiply by mu
+
+            Returns:
+                The friction force.
+            )ipc_Qu8mg5v7",
+            py::arg("mesh"), py::arg("X"), py::arg("Ut"), py::arg("U"),
+            py::arg("dhat"), py::arg("barrier_stiffness"), py::arg("epsv"),
+            py::arg("dmin") = 0, py::arg("no_mu") = false)
         .def(
             "compute_force",
             py::overload_cast<
@@ -103,9 +123,25 @@ void define_friction_constraints(py::module_& m)
                 const Eigen::MatrixXd&, const double, const double,
                 const double, const double, const bool>(
                 &FrictionConstraints::compute_force, py::const_),
-            "", py::arg("mesh"), py::arg("X"), py::arg("U"), py::arg("dhat"),
-            py::arg("barrier_stiffness"), py::arg("epsv_times_h"),
-            py::arg("dmin") = 0, py::arg("no_mu") = false)
+            R"ipc_Qu8mg5v7(
+            Compute the friction force from the given velocity.
+
+            Parameters:
+                mesh: The collision mesh.
+                X: Rest vertex positions (rowwise).
+                U: Current vertex displacements (rowwise).
+                dhat: Barrier activation distance.
+                barrier_stiffness: Barrier stiffness.
+                epsv: Mollifier parameter :math:`\epsilon_v`.
+                dmin: Minimum distance to use for the barrier.
+                no_mu: whether to not multiply by mu
+
+            Returns:
+                The friction force.
+            )ipc_Qu8mg5v7",
+            py::arg("mesh"), py::arg("X"), py::arg("U"), py::arg("dhat"),
+            py::arg("barrier_stiffness"), py::arg("epsv"), py::arg("dmin") = 0,
+            py::arg("no_mu") = false)
         .def(
             "compute_force_jacobian",
             py::overload_cast<
@@ -114,9 +150,26 @@ void define_friction_constraints(py::module_& m)
                 const double, const double, const FrictionConstraint::DiffWRT,
                 const double>(
                 &FrictionConstraints::compute_force_jacobian, py::const_),
-            "", py::arg("mesh"), py::arg("X"), py::arg("Ut"), py::arg("U"),
-            py::arg("dhat"), py::arg("barrier_stiffness"),
-            py::arg("epsv_times_h"), py::arg("wrt"), py::arg("dmin") = 0)
+            R"ipc_Qu8mg5v7(
+            Compute the Jacobian of the friction force wrt the velocity.
+
+            Parameters:
+                mesh: The collision mesh.
+                X: Rest vertex positions (rowwise).
+                Ut: Previous vertex displacements (rowwise).
+                U: Current vertex displacements (rowwise).
+                dhat: Barrier activation distance.
+                barrier_stiffness: Barrier stiffness.
+                epsv: Mollifier parameter :math:`\epsilon_v`.
+                wrt: The variable to take the derivative with respect to.
+                dmin: Minimum distance to use for the barrier.
+
+            Returns:
+                The Jacobian of the friction force wrt the velocity.
+            )ipc_Qu8mg5v7",
+            py::arg("mesh"), py::arg("X"), py::arg("Ut"), py::arg("U"),
+            py::arg("dhat"), py::arg("barrier_stiffness"), py::arg("epsv"),
+            py::arg("wrt"), py::arg("dmin") = 0)
         .def(
             "compute_force_jacobian",
             py::overload_cast<
@@ -124,9 +177,26 @@ void define_friction_constraints(py::module_& m)
                 const Eigen::MatrixXd&, const double, const double,
                 const double, const FrictionConstraint::DiffWRT, const double>(
                 &FrictionConstraints::compute_force_jacobian, py::const_),
-            "", py::arg("mesh"), py::arg("X"), py::arg("U"), py::arg("dhat"),
-            py::arg("barrier_stiffness"), py::arg("epsv_times_h"),
-            py::arg("wrt"), py::arg("dmin") = 0)
+            R"ipc_Qu8mg5v7(
+            Compute the Jacobian of the friction force wrt the velocity.
+
+            Parameters:
+                mesh: The collision mesh.
+                X: Rest vertex positions (rowwise).
+                Ut: Previous vertex displacements (rowwise).
+                U: Current vertex displacements (rowwise).
+                dhat: Barrier activation distance.
+                barrier_stiffness: Barrier stiffness.
+                epsv: Mollifier parameter :math:`\epsilon_v`.
+                wrt: The variable to take the derivative with respect to.
+                dmin: Minimum distance to use for the barrier.
+
+            Returns:
+                The Jacobian of the friction force wrt the velocity.
+            )ipc_Qu8mg5v7",
+            py::arg("mesh"), py::arg("X"), py::arg("U"), py::arg("dhat"),
+            py::arg("barrier_stiffness"), py::arg("epsv"), py::arg("wrt"),
+            py::arg("dmin") = 0)
         .def(
             "__len__", &FrictionConstraints::size,
             "Get the number of friction constraints.")
@@ -152,6 +222,9 @@ void define_friction_constraints(py::module_& m)
                 A reference to the constraint.
             )ipc_Qu8mg5v7",
             py::arg("idx"))
+        .def_static(
+            "default_blend_mu", &FrictionConstraints::default_blend_mu, "",
+            py::arg("mu0"), py::arg("mu1"))
         .def_readwrite(
             "vv_constraints", &FrictionConstraints::vv_constraints, "")
         .def_readwrite(

--- a/python/src/friction/smooth_friction_mollifier.cpp
+++ b/python/src/friction/smooth_friction_mollifier.cpp
@@ -14,71 +14,66 @@ void define_smooth_friction_mollifier(py::module_& m)
 
         .. math::
 
-            f_0(y)= \begin{cases}
-            -\frac{x^3}{3\epsilon_v^2 h^2} + \frac{x^2}{\epsilon_vh}
-            + \frac{\epsilon_v h}{3}, & |x| \in\left[0, \epsilon_v h\right)
+            f_0(s)= \begin{cases}
+            -\frac{s^3}{3\epsilon_v^2} + \frac{s^2}{\epsilon_v}
+            + \frac{\epsilon_v}{3}, & |s| < \epsilon_v
             \newline
-            x, & |x| \geq \epsilon_v h
+            s, & |s| \geq \epsilon_v
             \end{cases}
 
         Parameters:
-            x: The tangential relative speed.
-            epsv_times_h: Mollifier parameter :math:`\epsilon_v h`.
+            s: The tangential relative speed.
+            epsv: Mollifier parameter :math:`\epsilon_v`.
 
         Returns:
-            The value of the mollifier function at x.
+            The value of the mollifier function at s.
         )ipc_Qu8mg5v7",
-        py::arg("x"), py::arg("epsv_times_h"));
+        py::arg("s"), py::arg("epsv"));
 
     m.def(
         "f1_SF_over_x", &f1_SF_over_x,
         R"ipc_Qu8mg5v7(
-        Compute the derivative of f0_SF divided by x (:math:`\frac{f_0'(x)}{x}`).
+        Compute the derivative of f0_SF divided by s (:math:`\frac{f_0'(s)}{s}`).
 
         .. math::
-
-            f_1(x) = f_0'(x) = \begin{cases}
-            -\frac{x^2}{\epsilon_v^2 h^2}+\frac{2 x}{\epsilon_v h}, & |x|
-            \in\left[0, \epsilon_v h \right) \newline
-            1, & |x| \geq h \epsilon_v
+            f_1(s) = f_0'(s) = \begin{cases}
+            -\frac{s^2}{\epsilon_v^2}+\frac{2 s}{\epsilon_v}, & |s| < \epsilon_v
+            \newline 1, & |s| \geq \epsilon_v
             \end{cases}
 
         .. math::
-
-            \frac{f_1(x)}{x} = \begin{cases}
-            -\frac{x}{\epsilon_v^2 h^2}+\frac{2}{\epsilon_v h}, & |x|
-            \in\left[0, \epsilon_v h \right) \newline
-            \frac{1}{x}, & |x| \geq h \epsilon_v
+            \frac{f_1(s)}{s} = \begin{cases}
+            -\frac{s}{\epsilon_v^2}+\frac{2}{\epsilon_v}, & |s| < \epsilon_v
+            \newline \frac{1}{s}, & |s| \geq \epsilon_v
             \end{cases}
 
         Parameters:
-            x: The tangential relative speed.
-            epsv_times_h: Mollifier parameter :math:`\epsilon_v h`.
+            s: The tangential relative speed.
+            epsv: Mollifier parameter :math:`\epsilon_v`.
 
         Returns:
-            The value of the derivative of f0_SF divided by x.
+            The value of the derivative of f0_SF divided by s.
         )ipc_Qu8mg5v7",
-        py::arg("x"), py::arg("epsv_times_h"));
+        py::arg("s"), py::arg("epsv"));
 
     m.def(
         "df1_x_minus_f1_over_x3", &df1_x_minus_f1_over_x3,
         R"ipc_Qu8mg5v7(
-        The derivative of f1 times x minus f1 all divided by x cubed.
+        The derivative of f1 times s minus f1 all divided by s cubed.
 
         .. math::
 
-            \frac{f_1'(x) x - f_1(x)}{x^3} = \begin{cases}
-            -\frac{1}{x \epsilon_v^2 h^2}, & |x|
-            \in\left[0, \epsilon_v h \right) \newline
-            -\frac{1}{x^3}, & |x| \geq h \epsilon_v
+            \frac{f_1'(s) s - f_1(s)}{s^3} = \begin{cases}
+            -\frac{1}{s \epsilon_v^2}, & |s| < \epsilon_v \newline
+            -\frac{1}{s^3}, & |s| \geq \epsilon_v
             \end{cases}
 
         Parameters:
-            x: The tangential relative speed.
-            epsv_times_h: Mollifier parameter :math:`\epsilon_v h`.
+            s: The tangential relative speed.
+            epsv: Mollifier parameter :math:`\epsilon_v`.
 
         Returns:
-            The derivative of f1 times x minus f1 all divided by x cubed.
+            The derivative of f1 times s minus f1 all divided by s cubed.
         )ipc_Qu8mg5v7",
-        py::arg("x"), py::arg("epsv_times_h"));
+        py::arg("s"), py::arg("epsv"));
 }

--- a/src/ipc/friction/constraints/friction_constraint.hpp
+++ b/src/ipc/friction/constraints/friction_constraint.hpp
@@ -33,38 +33,38 @@ public:
     /// @param velocities Velocities of the vertices (rowwise)
     /// @param edges Edges of the mesh
     /// @param faces Faces of the mesh
-    /// @param epsv_times_h $\epsilon_vh$
+    /// @param epsv Smooth friction mollifier parameter \f$\epsilon_v\f$.
     /// @return The friction dissapative potential.
     double compute_potential(
         const Eigen::MatrixXd& velocities,
         const Eigen::MatrixXi& edges,
         const Eigen::MatrixXi& faces,
-        const double epsv_times_h) const;
+        const double epsv) const;
 
     /// @brief Compute the friction dissapative potential gradient wrt velocities.
     /// @param velocities Velocities of the vertices (rowwise)
     /// @param edges Edges of the mesh
     /// @param faces Faces of the mesh
-    /// @param epsv_times_h $\epsilon_vh$
+    /// @param epsv Smooth friction mollifier parameter \f$\epsilon_v\f$.
     /// @return Gradient of the friction dissapative potential wrt velocities
     VectorMax12d compute_potential_gradient(
         const Eigen::MatrixXd& velocities,
         const Eigen::MatrixXi& edges,
         const Eigen::MatrixXi& faces,
-        const double epsv_times_h) const;
+        const double epsv) const;
 
     /// @brief Compute the friction dissapative potential hessian wrt velocities.
     /// @param velocities Velocities of the vertices (rowwise)
     /// @param edges Edges of the mesh
     /// @param faces Faces of the mesh
-    /// @param epsv_times_h $\epsilon_vh$
+    /// @param epsv Smooth friction mollifier parameter \f$\epsilon_v\f$.
     /// @param project_hessian_to_psd Project the hessian to PSD
     /// @return Hessian of the friction dissapative potential wrt velocities
     MatrixMax12d compute_potential_hessian(
         const Eigen::MatrixXd& velocities,
         const Eigen::MatrixXi& edges,
         const Eigen::MatrixXi& faces,
-        const double epsv_times_h,
+        const double epsv,
         const bool project_hessian_to_psd) const;
 
     /// @brief Compute the friction force.
@@ -74,7 +74,7 @@ public:
     /// @param faces Collision mesh faces
     /// @param dhat Barrier activation distance
     /// @param barrier_stiffness Barrier stiffness
-    /// @param epsv_times_h $\epsilon_vh$
+    /// @param epsv Smooth friction mollifier parameter \f$\epsilon_v\f$.
     /// @param dmin Minimum distance
     /// @param no_mu Whether to not multiply by mu
     /// @return Friction force
@@ -85,13 +85,13 @@ public:
         const Eigen::MatrixXi& faces,
         const double dhat,
         const double barrier_stiffness,
-        const double epsv_times_h,
+        const double epsv,
         const double dmin = 0,
         const bool no_mu = false) const //< whether to not multiply by mu
     {
         return compute_force(
             X, Eigen::MatrixXd::Zero(U.rows(), U.cols()), U, edges, faces, dhat,
-            barrier_stiffness, epsv_times_h, dmin, no_mu);
+            barrier_stiffness, epsv, dmin, no_mu);
     }
 
     /// @brief Compute the friction force.
@@ -102,7 +102,7 @@ public:
     /// @param faces Collision mesh faces
     /// @param dhat Barrier activation distance
     /// @param barrier_stiffness Barrier stiffness
-    /// @param epsv_times_h $\epsilon_vh$
+    /// @param epsv Smooth friction mollifier parameter \f$\epsilon_v\f$.
     /// @param dmin Minimum distance
     /// @param no_mu Whether to not multiply by mu
     /// @return Friction force
@@ -114,7 +114,7 @@ public:
         const Eigen::MatrixXi& faces,
         const double dhat,
         const double barrier_stiffness,
-        const double epsv_times_h,
+        const double epsv,
         const double dmin = 0,
         const bool no_mu = false) const; //< whether to not multiply by mu
 
@@ -132,7 +132,7 @@ public:
     /// @param faces Collision mesh faces
     /// @param dhat Barrier activation distance
     /// @param barrier_stiffness Barrier stiffness
-    /// @param epsv_times_h $\epsilon_vh$
+    /// @param epsv Smooth friction mollifier parameter \f$\epsilon_v\f$.
     /// @param wrt Variable to differentiate the friction force with respect to.
     /// @param dmin Minimum distance
     /// @return Friction force Jacobian
@@ -143,13 +143,13 @@ public:
         const Eigen::MatrixXi& faces,
         const double dhat,
         const double barrier_stiffness,
-        const double epsv_times_h,
+        const double epsv,
         const DiffWRT wrt,
         const double dmin = 0) const
     {
         return compute_force_jacobian(
             X, Eigen::MatrixXd::Zero(U.rows(), U.cols()), U, edges, faces, dhat,
-            barrier_stiffness, epsv_times_h, wrt, dmin);
+            barrier_stiffness, epsv, wrt, dmin);
     }
 
     /// @brief Compute the friction force Jacobian.
@@ -160,7 +160,7 @@ public:
     /// @param faces Collision mesh faces
     /// @param dhat Barrier activation distance
     /// @param barrier_stiffness Barrier stiffness
-    /// @param epsv_times_h $\epsilon_vh$
+    /// @param epsv Smooth friction mollifier parameter \f$\epsilon_v\f$.
     /// @param wrt Variable to differentiate the friction force with respect to.
     /// @param dmin Minimum distance
     /// @return Friction force Jacobian
@@ -172,7 +172,7 @@ public:
         const Eigen::MatrixXi& faces,
         const double dhat,
         const double barrier_stiffness,
-        const double epsv_times_h,
+        const double epsv,
         const DiffWRT wrt,
         const double dmin = 0) const;
 

--- a/src/ipc/friction/friction_constraints.hpp
+++ b/src/ipc/friction/friction_constraints.hpp
@@ -47,35 +47,48 @@ public:
     /// @brief Compute the friction dissapative potential from the given velocity.
     /// @param mesh The collision mesh.
     /// @param velocity Current vertex velocity (rowwise).
+    /// @param epsv Mollifier parameter \f$\epsilon_v\f$.
     /// @return The friction dissapative potential.
     double compute_potential(
         const CollisionMesh& mesh,
         const Eigen::MatrixXd& velocity,
-        const double epsv_times_h) const;
+        const double epsv) const;
 
     /// @brief Compute the gradient of the friction dissapative potential wrt the velocity.
     /// @param mesh The collision mesh.
     /// @param velocity Current vertex velocity (rowwise).
+    /// @param epsv Mollifier parameter \f$\epsilon_v\f$.
     /// @return The gradient of the friction dissapative potential wrt the velocity.
     Eigen::VectorXd compute_potential_gradient(
         const CollisionMesh& mesh,
         const Eigen::MatrixXd& velocity,
-        const double epsv_times_h) const;
+        const double epsv) const;
 
     /// @brief Compute the Hessian of the friction dissapative potential wrt the velocity.
     /// @param mesh The collision mesh.
     /// @param velocity Current vertex velocity (rowwise).
+    /// @param epsv Mollifier parameter \f$\epsilon_v\f$.
     /// @param project_hessian_to_psd If true, project the Hessian to be positive semi-definite.
     /// @return The Hessian of the friction dissapative potential wrt the velocity.
     Eigen::SparseMatrix<double> compute_potential_hessian(
         const CollisionMesh& mesh,
         const Eigen::MatrixXd& velocity,
-        const double epsv_times_h,
+        const double epsv,
         const bool project_hessian_to_psd = false) const;
 
     // ------------------------------------------------------------------------
 
+    /// @brief Compute the friction force from the given velocity.
+    /// @param mesh The collision mesh.
+    /// @param X Rest vertex positions (rowwise).
+    /// @param Ut Previous vertex displacements (rowwise).
+    /// @param U Current vertex displacements (rowwise).
+    /// @param dhat Barrier activation distance.
+    /// @param barrier_stiffness Barrier stiffness.
+    /// @param epsv Mollifier parameter \f$\epsilon_v\f$.
+    /// @param dmin Minimum distance to use for the barrier.
     /// @param no_mu whether to not multiply by mu
+    /// @return The friction force.
     Eigen::VectorXd compute_force(
         const CollisionMesh& mesh,
         const Eigen::MatrixXd& X,
@@ -83,26 +96,46 @@ public:
         const Eigen::MatrixXd& U,
         const double dhat,
         const double barrier_stiffness,
-        const double epsv_times_h,
+        const double epsv,
         const double dmin = 0,
         const bool no_mu = false) const;
 
+    /// @brief Compute the friction force from the given velocity.
+    /// @param mesh The collision mesh.
+    /// @param X Rest vertex positions (rowwise).
+    /// @param U Current vertex displacements (rowwise).
+    /// @param dhat Barrier activation distance.
+    /// @param barrier_stiffness Barrier stiffness.
+    /// @param epsv Mollifier parameter \f$\epsilon_v\f$.
+    /// @param dmin Minimum distance to use for the barrier.
     /// @param no_mu whether to not multiply by mu
+    /// @return The friction force.
     Eigen::VectorXd compute_force(
         const CollisionMesh& mesh,
         const Eigen::MatrixXd& X,
         const Eigen::MatrixXd& U,
         const double dhat,
         const double barrier_stiffness,
-        const double epsv_times_h,
+        const double epsv,
         const double dmin = 0,
         const bool no_mu = false) const
     {
         return compute_force(
             mesh, X, Eigen::MatrixXd::Zero(U.rows(), U.cols()), U, dhat,
-            barrier_stiffness, epsv_times_h, dmin, no_mu);
+            barrier_stiffness, epsv, dmin, no_mu);
     }
 
+    /// @brief Compute the Jacobian of the friction force wrt the velocity.
+    /// @param mesh The collision mesh.
+    /// @param X Rest vertex positions (rowwise).
+    /// @param Ut Previous vertex displacements (rowwise).
+    /// @param U Current vertex displacements (rowwise).
+    /// @param dhat Barrier activation distance.
+    /// @param barrier_stiffness Barrier stiffness.
+    /// @param epsv Mollifier parameter \f$\epsilon_v\f$.
+    /// @param wrt The variable to take the derivative with respect to.
+    /// @param dmin Minimum distance to use for the barrier.
+    /// @return The Jacobian of the friction force wrt the velocity.
     Eigen::SparseMatrix<double> compute_force_jacobian(
         const CollisionMesh& mesh,
         const Eigen::MatrixXd& X,
@@ -110,23 +143,34 @@ public:
         const Eigen::MatrixXd& U,
         const double dhat,
         const double barrier_stiffness,
-        const double epsv_times_h,
+        const double epsv,
         const FrictionConstraint::DiffWRT wrt,
         const double dmin = 0) const;
 
+    /// @brief Compute the Jacobian of the friction force wrt the velocity.
+    /// @param mesh The collision mesh.
+    /// @param X Rest vertex positions (rowwise).
+    /// @param Ut Previous vertex displacements (rowwise).
+    /// @param U Current vertex displacements (rowwise).
+    /// @param dhat Barrier activation distance.
+    /// @param barrier_stiffness Barrier stiffness.
+    /// @param epsv Mollifier parameter \f$\epsilon_v\f$.
+    /// @param wrt The variable to take the derivative with respect to.
+    /// @param dmin Minimum distance to use for the barrier.
+    /// @return The Jacobian of the friction force wrt the velocity.
     Eigen::SparseMatrix<double> compute_force_jacobian(
         const CollisionMesh& mesh,
         const Eigen::MatrixXd& X,
         const Eigen::MatrixXd& U,
         const double dhat,
         const double barrier_stiffness,
-        const double epsv_times_h,
+        const double epsv,
         const FrictionConstraint::DiffWRT wrt,
         const double dmin = 0) const
     {
         return compute_force_jacobian(
             mesh, X, Eigen::MatrixXd::Zero(U.rows(), U.cols()), U, dhat,
-            barrier_stiffness, epsv_times_h, wrt, dmin);
+            barrier_stiffness, epsv, wrt, dmin);
     }
 
     // ------------------------------------------------------------------------

--- a/src/ipc/friction/smooth_friction_mollifier.cpp
+++ b/src/ipc/friction/smooth_friction_mollifier.cpp
@@ -5,32 +5,31 @@
 
 namespace ipc {
 
-double f0_SF(const double x, const double epsv_times_h)
+double f0_SF(const double s, const double epsv)
 {
-    assert(epsv_times_h > 0);
-    if (std::abs(x) >= epsv_times_h) {
-        return x;
+    assert(epsv > 0);
+    if (std::abs(s) >= epsv) {
+        return s;
     }
-    return x * x * (-x / (3 * epsv_times_h) + 1) / epsv_times_h
-        + epsv_times_h / 3;
+    return s * s * (-s / (3 * epsv) + 1) / epsv + epsv / 3;
 }
 
-double f1_SF_over_x(const double x, const double epsv_times_h)
+double f1_SF_over_x(const double s, const double epsv)
 {
-    assert(epsv_times_h > 0);
-    if (std::abs(x) >= epsv_times_h) {
-        return 1 / x;
+    assert(epsv > 0);
+    if (std::abs(s) >= epsv) {
+        return 1 / s;
     }
-    return (-x / epsv_times_h + 2) / epsv_times_h;
+    return (-s / epsv + 2) / epsv;
 }
 
-double df1_x_minus_f1_over_x3(const double x, const double epsv_times_h)
+double df1_x_minus_f1_over_x3(const double s, const double epsv)
 {
-    assert(epsv_times_h > 0);
-    if (std::abs(x) >= epsv_times_h) {
-        return -1 / (x * x * x);
+    assert(epsv > 0);
+    if (std::abs(s) >= epsv) {
+        return -1 / (s * s * s);
     }
-    return -1 / (x * epsv_times_h * epsv_times_h);
+    return -1 / (s * epsv * epsv);
 }
 
 } // namespace ipc

--- a/src/ipc/friction/smooth_friction_mollifier.hpp
+++ b/src/ipc/friction/smooth_friction_mollifier.hpp
@@ -5,55 +5,52 @@ namespace ipc {
 /// @brief Smooth friction mollifier function.
 ///
 /// \f\[
-///     f_0(y)= \begin{cases}
-///         -\frac{x^3}{3\epsilon_v^2 h^2} + \frac{x^2}{\epsilon_vh}
-///             + \frac{\epsilon_v h}{3}, & |x| \in\left[0, \epsilon_v h\right)
+///     f_0(s)= \begin{cases}
+///         -\frac{s^3}{3\epsilon_v^2} + \frac{s^2}{\epsilon_v}
+///             + \frac{\epsilon_v}{3}, & |s| < \epsilon_v
 ///             \newline
-///         x, & |x| \geq \epsilon_v h
+///         s, & |s| \geq \epsilon_v
 ///     \end{cases}
 /// \f\]
 ///
-/// @param x The tangential relative speed.
-/// @param epsv_times_h Mollifier parameter \f$\epsilon_v h\f$.
-/// @return The value of the mollifier function at x.
-double f0_SF(const double x, const double epsv_times_h);
+/// @param s The tangential relative speed.
+/// @param epsv Mollifier parameter \f$\epsilon_v\f$.
+/// @return The value of the mollifier function at s.
+double f0_SF(const double s, const double epsv);
 
-/// @brief Compute the derivative of f0_SF divided by x (\f$\frac{f_0'(x)}{x}\f$).
+/// @brief Compute the derivative of f0_SF divided by s (\f$\frac{f_0'(s)}{s}\f$).
 ///
 /// \f\[
-///     f_1(x) = f_0'(x) = \begin{cases}
-///         -\frac{x^2}{\epsilon_v^2 h^2}+\frac{2 x}{\epsilon_v h}, & |x|
-///             \in\left[0, \epsilon_v h \right) \newline
-///         1, & |x| \geq h \epsilon_v
+///     f_1(s) = f_0'(s) = \begin{cases}
+///         -\frac{s^2}{\epsilon_v^2}+\frac{2 s}{\epsilon_v}, & |s| < \epsilon_v
+///         \newline 1, & |s| \geq \epsilon_v
 ///     \end{cases}
 /// \f\]
 ///
 /// \f\[
-///     \frac{f_1(x)}{x} = \begin{cases}
-///         -\frac{x}{\epsilon_v^2 h^2}+\frac{2}{\epsilon_v h}, & |x|
-///             \in\left[0, \epsilon_v h \right) \newline
-///         \frac{1}{x}, & |x| \geq h \epsilon_v
+///     \frac{f_1(s)}{s} = \begin{cases}
+///         -\frac{s}{\epsilon_v^2}+\frac{2}{\epsilon_v}, & |s| < \epsilon_v
+///         \newline \frac{1}{s}, & |s| \geq \epsilon_v
 ///     \end{cases}
 /// \f\]
 ///
-/// @param x The tangential relative speed.
-/// @param epsv_times_h Mollifier parameter \f$\epsilon_v h\f$.
-/// @return The value of the derivative of f0_SF divided by x.
-double f1_SF_over_x(const double x, const double epsv_times_h);
+/// @param s The tangential relative speed.
+/// @param epsv Mollifier parameter \f$\epsilon_v\f$.
+/// @return The value of the derivative of f0_SF divided by s.
+double f1_SF_over_x(const double s, const double epsv);
 
-/// @brief The derivative of f1 times x minus f1 all divided by x cubed.
+/// @brief The derivative of f1 times s minus f1 all divided by s cubed.
 ///
 /// \f\[
-///     \frac{f_1'(x) x - f_1(x)}{x^3} = \begin{cases}
-///         -\frac{1}{x \epsilon_v^2 h^2}, & |x|
-///             \in\left[0, \epsilon_v h \right) \newline
-///         -\frac{1}{x^3}, & |x| \geq h \epsilon_v
+///     \frac{f_1'(s) s - f_1(s)}{s^3} = \begin{cases}
+///         -\frac{1}{s \epsilon_v^2}, & |s| < \epsilon_v \newline
+///         -\frac{1}{s^3}, & |s| \geq \epsilon_v
 ///     \end{cases}
 /// \f\]
 ///
-/// @param x The tangential relative speed.
-/// @param epsv_times_h Mollifier parameter \f$\epsilon_v h\f$.
-/// @return The derivative of f1 times x minus f1 all divided by x cubed.
-double df1_x_minus_f1_over_x3(const double x, const double epsv_times_h);
+/// @param s The tangential relative speed.
+/// @param epsv Mollifier parameter \f$\epsilon_v\f$.
+/// @return The derivative of f1 times s minus f1 all divided by s cubed.
+double df1_x_minus_f1_over_x3(const double s, const double epsv);
 
 } // namespace ipc


### PR DESCRIPTION
# Description

Changed input $\epsilon_vh$ to $\epsilon_v$ to reflect the fact that friction is defined in terms of velocity instead of displacement now.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have followed the project [style guide](https://ipc-sim.github.io/ipc-toolkit/style_guide.html)
- [x] My code follows the clang-format style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

