### PR TITLE
Fix scaling for physical units in barrier

### DIFF
--- a/notebooks/physical_barrier.ipynb
+++ b/notebooks/physical_barrier.ipynb
@@ -2,16 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sympy"
+    "import sympy\n",
+    "from generate_cpp_code import *"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -77,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -89,7 +90,7 @@
        "1/\\hat{d}"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -100,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -112,7 +113,7 @@
        "\\hat{d}**(-3)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -123,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -135,7 +136,7 @@
        "1/(\\hat{d}*(\\hat{d} + 2*d_{\\text{min}})**2)"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -145,6 +146,71 @@
     "dhat_param = 2 * dmin * dhat + dhat**2\n",
     "(physical_barrier(d_param, dhat_param) / barrier(d_param, dhat_param)).simplify()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "const auto t0 = d/\\hat{d};\n",
+      "r = -std::pow(1 - t0, 2)*std::log(t0);\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(generate_code(normalized_barrier(d, dhat), \"r\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "const auto t0 = 1.0/dhat;\n",
+      "const auto t1 = d*t0;\n",
+      "const auto t2 = 1 - t1;\n",
+      "r = t2*(2*t0*std::log(t1) - t2/d);\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(generate_code(normalized_barrier(d, dhat).diff(d), \"r\").replace(\"\\hat{d}\", \"dhat\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "const auto t0 = 1.0/dhat;\n",
+      "const auto t1 = d*t0;\n",
+      "const auto t2 = 1 - t1;\n",
+      "r = 4*t0*t2/d + std::pow(t2, 2)/std::pow(d, 2) - 2*std::log(t1)/std::pow(dhat, 2);\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(generate_code(normalized_barrier(d, dhat).diff(d).diff(d), \"r\").replace(\"\\hat{d}\", \"dhat\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/physical_barrier.ipynb
+++ b/notebooks/physical_barrier.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sympy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dhat = sympy.Symbol('\\hat{d}')\n",
+    "d = sympy.Symbol('d')\n",
+    "dmin = sympy.Symbol('d_{\\\\text{min}}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - \\left(- \\hat{d} + d\\right)^{2} \\log{\\left(\\frac{d}{\\hat{d}} \\right)}$"
+      ],
+      "text/plain": [
+       "-(-\\hat{d} + d)**2*log(d/\\hat{d})"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - \\left(-1 + \\frac{d}{\\hat{d}}\\right)^{2} \\log{\\left(\\frac{d}{\\hat{d}} \\right)}$"
+      ],
+      "text/plain": [
+       "-(-1 + d/\\hat{d})**2*log(d/\\hat{d})"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - \\hat{d} \\left(-1 + \\frac{d}{\\hat{d}}\\right)^{2} \\log{\\left(\\frac{d}{\\hat{d}} \\right)}$"
+      ],
+      "text/plain": [
+       "-\\hat{d}*(-1 + d/\\hat{d})**2*log(d/\\hat{d})"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def barrier(d, dhat):\n",
+    "    return -(d - dhat)**2 * sympy.log(d/dhat)\n",
+    "\n",
+    "def normalized_barrier(d, dhat):\n",
+    "    return -(d/dhat - 1)**2 * sympy.log(d/dhat)\n",
+    "\n",
+    "def physical_barrier(d, p_dhat):\n",
+    "    return dhat * normalized_barrier(d, p_dhat)\n",
+    "\n",
+    "display(barrier(d, dhat), normalized_barrier(d, dhat), physical_barrier(d, dhat))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\frac{1}{\\hat{d}}$"
+      ],
+      "text/plain": [
+       "1/\\hat{d}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(physical_barrier(d, dhat) / barrier(d, dhat)).simplify()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\frac{1}{\\hat{d}^{3}}$"
+      ],
+      "text/plain": [
+       "\\hat{d}**(-3)"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(physical_barrier(d**2, dhat**2) / barrier(d**2, dhat**2)).simplify()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\frac{1}{\\hat{d} \\left(\\hat{d} + 2 d_{\\text{min}}\\right)^{2}}$"
+      ],
+      "text/plain": [
+       "1/(\\hat{d}*(\\hat{d} + 2*d_{\\text{min}})**2)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d_param = d**2 - dmin**2\n",
+    "dhat_param = 2 * dmin * dhat + dhat**2\n",
+    "(physical_barrier(d_param, dhat_param) / barrier(d_param, dhat_param)).simplify()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/physical_barrier.ipynb
+++ b/notebooks/physical_barrier.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -90,7 +90,7 @@
        "1/\\hat{d}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -113,7 +113,7 @@
        "\\hat{d}**(-3)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -136,7 +136,7 @@
        "1/(\\hat{d}*(\\hat{d} + 2*d_{\\text{min}})**2)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -156,18 +156,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "const auto t0 = d/\\hat{d};\n",
+      "const auto t0 = d/dhat;\n",
       "r = -std::pow(1 - t0, 2)*std::log(t0);\n"
      ]
     }
    ],
    "source": [
-    "print(generate_code(normalized_barrier(d, dhat), \"r\"))"
+    "print(generate_code(normalized_barrier(d, dhat), \"r\").replace(\"\\hat{d}\", \"dhat\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/tests/barrier/test_barrier.cpp
+++ b/tests/barrier/test_barrier.cpp
@@ -6,7 +6,7 @@
 #include <ipc/barrier/barrier.hpp>
 
 namespace {
-double physical_barrier(const double d, const double dhat)
+double normalized_barrier(const double d, const double dhat)
 {
     // units(d) = m and units(d̂) = m ⟹ units(b(d)) = m
     // units(κ) = Pa ⟹ units(κ b(d)) = Pa m
@@ -19,34 +19,39 @@ double physical_barrier(const double d, const double dhat)
     }
 
     // b(d) = -d̂(d/d̂-1)²ln(d / d̂)
-    const double d_over_dhat = d / dhat;
-    const double d_over_dhat_minus_1 = d_over_dhat - 1;
-    return -dhat * d_over_dhat_minus_1 * d_over_dhat_minus_1 * log(d_over_dhat);
+    const double t0 = d / dhat;
+    return -dhat * std::pow(1 - t0, 2) * std::log(t0);
 }
 
-double physical_barrier_gradient(const double d, const double dhat)
+double normalized_barrier_gradient(const double d, const double dhat)
 {
     if (d <= 0.0 || d >= dhat) {
         return 0.0;
     }
-    return (d - dhat) * (-2 * d * log(d / dhat) - d + dhat) / (d * dhat);
+    const double t0 = 1.0 / dhat;
+    const double t1 = d * t0;
+    const double t2 = 1 - t1;
+    return t2 * (2 * t0 * std::log(t1) - t2 / d);
 }
 
-double physical_barrier_hessian(const double d, const double dhat)
+double normalized_barrier_hessian(const double d, const double dhat)
 {
     if (d <= 0.0 || d >= dhat) {
         return 0.0;
     }
-    const double d_minus_dhat = d - dhat;
-    return (-2 * log(d / dhat) + (d_minus_dhat * d_minus_dhat) / (d * d) - 4)
-        / dhat
-        + 4 / d;
+
+    const double t0 = 1.0 / dhat;
+    const double t1 = d * t0;
+    const double t2 = 1 - t1;
+    return 4 * t0 * t2 / d + std::pow(t2, 2) / std::pow(d, 2)
+        - 2 * std::log(t1) / std::pow(dhat, 2);
 }
 } // namespace
 
 TEST_CASE("Test barrier derivatives", "[barrier]")
 {
-    double dhat = GENERATE(range(-5, 2));
+    bool use_dist_sqr = GENERATE(false, true);
+    double dhat = GENERATE_COPY(range(use_dist_sqr ? -2 : -5, 0));
     dhat = pow(10, dhat);
 
     double d =
@@ -64,11 +69,29 @@ TEST_CASE("Test barrier derivatives", "[barrier]")
         barrier_gradient = ipc::barrier_gradient;
         barrier_hessian = ipc::barrier_hessian;
     }
+    // SECTION("Normalized barrier")
+    // {
+    //     barrier = normalized_barrier;
+    //     barrier_gradient = normalized_barrier_gradient;
+    //     barrier_hessian = normalized_barrier_hessian;
+    // }
     SECTION("Barrier with physical units")
     {
-        barrier = physical_barrier;
-        barrier_gradient = physical_barrier_gradient;
-        barrier_hessian = physical_barrier_hessian;
+        barrier = [dhat](double d, double p_dhat) {
+            return dhat * normalized_barrier(d, p_dhat);
+        };
+        barrier_gradient = [dhat](double d, double p_dhat) {
+            return dhat * normalized_barrier_gradient(d, p_dhat);
+        };
+        barrier_hessian = [dhat](double d, double p_dhat) {
+            return dhat * normalized_barrier_hessian(d, p_dhat);
+        };
+    }
+
+    if (use_dist_sqr) {
+        d_vec *= d;
+        d *= d;
+        dhat *= dhat;
     }
 
     Eigen::VectorXd fgrad(1);
@@ -79,7 +102,7 @@ TEST_CASE("Test barrier derivatives", "[barrier]")
     Eigen::VectorXd grad(1);
     grad << barrier_gradient(d, dhat);
 
-    CAPTURE(dhat, d, fgrad(0), grad(0));
+    CAPTURE(dhat, d, fgrad(0), grad(0), use_dist_sqr);
     CHECK(fd::compare_gradient(fgrad, grad));
 
     // Check hessian
@@ -91,7 +114,7 @@ TEST_CASE("Test barrier derivatives", "[barrier]")
 
     grad << barrier_hessian(d, dhat);
 
-    CAPTURE(dhat, d, fgrad(0), grad(0));
+    CAPTURE(dhat, d, fgrad(0), grad(0), use_dist_sqr);
     CHECK(fd::compare_gradient(fgrad, grad));
 }
 
@@ -104,17 +127,17 @@ TEST_CASE("Test physical barrier", "[barrier]")
         GENERATE_COPY(take(10, random(dhat / 2, 0.9 * dhat))); // ∈ [0, d̂]
 
     double b_original = ipc::barrier(d, dhat) / dhat;
-    double b_new = physical_barrier(d, dhat);
+    double b_new = dhat * normalized_barrier(d, dhat);
 
     CHECK(b_original == Catch::Approx(b_new));
 
     double b_original_gradient = ipc::barrier_gradient(d, dhat) / dhat;
-    double b_new_gradient = physical_barrier_gradient(d, dhat);
+    double b_new_gradient = dhat * normalized_barrier_gradient(d, dhat);
 
     CHECK(b_original_gradient == Catch::Approx(b_new_gradient));
 
     double b_original_hessian = ipc::barrier_hessian(d, dhat) / dhat;
-    double b_new_hessian = physical_barrier_hessian(d, dhat);
+    double b_new_hessian = dhat * normalized_barrier_hessian(d, dhat);
 
     CHECK(b_original_hessian == Catch::Approx(b_new_hessian));
 }

--- a/tests/friction/test_force_jacobian.cpp
+++ b/tests/friction/test_force_jacobian.cpp
@@ -258,7 +258,7 @@ TEST_CASE(
         mu = 0.5;
         dhat = 1e-3;
         // kappa = 67873353;
-        kappa = 67873353 / 10;
+        kappa = 67873353 / 10 * dhat;
         epsv_dt = 1e-4;
     }
     SECTION("square-circle-dense")


### PR DESCRIPTION
# Description

This fixes the bug pointed out in #41. Namely, in order to get units of distance in the barrier we should divide the original function by $\hat{d}\cdot(\hat{d} + 2d_\min)^2$ when using distance squared. Before it was being divided by $2d_\min * \hat{d} + \hat{d}^2$.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Added unit tests for each kind of barrier (vanilla and physical)x(distance and squared distance)

**Test Configuration**:
* OS and version: macOS
* Compile and version: Apple clang 14.0.0

# Checklist:

- [x] I have followed the project [style guide](https://ipc-sim.github.io/ipc-toolkit/style_guide.html)
- [x] My code follows the clang-format style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

