### PR TITLE
Limit conservative rescaling min distance in CCD

### DIFF
--- a/src/ipc/candidates/candidates.cpp
+++ b/src/ipc/candidates/candidates.cpp
@@ -96,31 +96,32 @@ double Candidates::compute_collision_free_stepsize(
     double earliest_toi = 1;
     std::shared_mutex earliest_toi_mutex;
 
-    tbb::parallel_for(
-        tbb::blocked_range<size_t>(0, size()),
-        [&](tbb::blocked_range<size_t> r) {
-            for (size_t i = r.begin(); i < r.end(); i++) {
-                // Use the mutex to read as well in case writing double takes
-                // more than one clock cycle.
-                double tmax;
-                {
-                    std::shared_lock lock(earliest_toi_mutex);
-                    tmax = earliest_toi;
-                }
+    // tbb::parallel_for(
+    //     tbb::blocked_range<size_t>(0, size()),
+    //     [&](tbb::blocked_range<size_t> r) {
+    //         for (size_t i = r.begin(); i < r.end(); i++) {
+    for (size_t i = 0; i < size(); i++) {
+        // Use the mutex to read as well in case writing double takes
+        // more than one clock cycle.
+        double tmax;
+        {
+            std::shared_lock lock(earliest_toi_mutex);
+            tmax = earliest_toi;
+        }
 
-                double toi = std::numeric_limits<double>::infinity(); // output
-                const bool are_colliding = (*this)[i].ccd(
-                    vertices_t0, vertices_t1, mesh.edges(), mesh.faces(), toi,
-                    min_distance, tmax, tolerance, max_iterations);
+        double toi = std::numeric_limits<double>::infinity(); // output
+        const bool are_colliding = (*this)[i].ccd(
+            vertices_t0, vertices_t1, mesh.edges(), mesh.faces(), toi,
+            min_distance, tmax, tolerance, max_iterations);
 
-                if (are_colliding) {
-                    std::unique_lock lock(earliest_toi_mutex);
-                    if (toi < earliest_toi) {
-                        earliest_toi = toi;
-                    }
-                }
+        if (are_colliding) {
+            std::unique_lock lock(earliest_toi_mutex);
+            if (toi < earliest_toi) {
+                earliest_toi = toi;
             }
-        });
+        }
+    }
+    // });
 
     assert(earliest_toi >= 0 && earliest_toi <= 1.0);
     return earliest_toi;

--- a/src/ipc/ccd/ccd.cpp
+++ b/src/ipc/ccd/ccd.cpp
@@ -53,7 +53,7 @@ bool ccd_strategy(
         (1.0 - conservative_rescaling) * initial_distance;
 #ifdef IPC_TOOLKIT_WITH_CORRECT_CCD
     // Tight Inclusion performs better when the minimum separation is small
-    min_effective_distance = std::min(min_effective_distance, 5e-4);
+    min_effective_distance = std::min(min_effective_distance, 1e-4);
 #endif
     min_effective_distance += min_distance;
 
@@ -61,17 +61,17 @@ bool ccd_strategy(
 
     // Do not use no_zero_toi because the minimum distance is arbitrary and can
     // be removed if the query is challenging (i.e., produces small ToI).
-    ticcd::ccd_times.reset();
-    igl::Timer timer;
-    timer.start();
+    // ticcd::ccd_times.reset();
+    // igl::Timer timer;
+    // timer.start();
     bool is_impacting =
         ccd(max_iterations, min_effective_distance, /*no_zero_toi=*/false, toi);
-    timer.stop();
-    logger().debug(
-        "CCD took {} s; d0={} d_min={} is_impacting={} toi={}",
-        timer.getElapsedTime(), initial_distance, min_effective_distance,
-        is_impacting, toi);
-    ticcd::ccd_times.print();
+    // timer.stop();
+    // logger().debug(
+    //     "CCD took {} s; d0={} d_min={} is_impacting={} toi={}",
+    //     timer.getElapsedTime(), initial_distance, min_effective_distance,
+    //     is_impacting, toi);
+    // ticcd::ccd_times.print();
 
     // #ifdef IPC_TOOLKIT_WITH_CORRECT_CCD
     //     // Tight inclusion will have higher accuracy and better performance

--- a/src/ipc/ccd/ccd.cpp
+++ b/src/ipc/ccd/ccd.cpp
@@ -14,8 +14,6 @@
 #include <CTCD.h>
 #endif
 
-#include <igl/Timer.h>
-
 #include <algorithm> // std::min/max
 #include <array>
 
@@ -61,17 +59,8 @@ bool ccd_strategy(
 
     // Do not use no_zero_toi because the minimum distance is arbitrary and can
     // be removed if the query is challenging (i.e., produces small ToI).
-    // ticcd::ccd_times.reset();
-    // igl::Timer timer;
-    // timer.start();
     bool is_impacting =
         ccd(max_iterations, min_effective_distance, /*no_zero_toi=*/false, toi);
-    // timer.stop();
-    // logger().debug(
-    //     "CCD took {} s; d0={} d_min={} is_impacting={} toi={}",
-    //     timer.getElapsedTime(), initial_distance, min_effective_distance,
-    //     is_impacting, toi);
-    // ticcd::ccd_times.print();
 
     // #ifdef IPC_TOOLKIT_WITH_CORRECT_CCD
     //     // Tight inclusion will have higher accuracy and better performance

--- a/tests/ccd/test_ccd.cpp
+++ b/tests/ccd/test_ccd.cpp
@@ -666,11 +666,6 @@ TEST_CASE("Squash Tet", "[ccd]")
         0, 3, 2,      //
         1, 2, 3;
 
-    logger().info("rest_vertices:\n{}", rest_vertices);
-    logger().info("deformed_vertices:\n{}", deformed_vertices);
-    logger().info("edges:\n{}", edges);
-    logger().info("faces:\n{}", faces);
-
     ipc::CollisionMesh mesh =
         ipc::CollisionMesh::build_from_full_mesh(rest_vertices, edges, faces);
 

--- a/tests/ccd/test_ccd.cpp
+++ b/tests/ccd/test_ccd.cpp
@@ -637,3 +637,48 @@ TEST_CASE("Slow EE CCD 2", "[ccd][edge-edge][slow][thisone]")
     CAPTURE(toi);
     CHECK(is_impacting);
 }
+
+TEST_CASE("Squash Tet", "[ccd]")
+{
+    const double dhat = 1e-3;
+
+    Eigen::MatrixXd rest_vertices(4, 3);
+    rest_vertices << 0.0, 0.0, 0.0, //
+        1.0, 0.0, 0.0,              //
+        0.0, 1.0, 0.0,              //
+        0.0, 0.0, 1.0;
+
+    Eigen::MatrixXd deformed_vertices = rest_vertices;
+    deformed_vertices(3, 0) += 0.1;
+    deformed_vertices(3, 1) -= 0.1;
+    deformed_vertices(3, 2) = -0.5 * dhat;
+
+    Eigen::MatrixXi edges(6, 2);
+    edges << 0, 1, //
+        0, 2,      //
+        0, 3,      //
+        1, 2,      //
+        1, 3,      //
+        2, 3;
+    Eigen::MatrixXi faces(4, 3);
+    faces << 0, 2, 1, //
+        0, 1, 3,      //
+        0, 3, 2,      //
+        1, 2, 3;
+
+    logger().info("rest_vertices:\n{}", rest_vertices);
+    logger().info("deformed_vertices:\n{}", deformed_vertices);
+    logger().info("edges:\n{}", edges);
+    logger().info("faces:\n{}", faces);
+
+    ipc::CollisionMesh mesh =
+        ipc::CollisionMesh::build_from_full_mesh(rest_vertices, edges, faces);
+
+    // BENCHMARK("compute toi")
+    // {
+    logger().debug(
+        "toi={}",
+        ipc::compute_collision_free_stepsize(
+            mesh, rest_vertices, deformed_vertices));
+    // };
+}


### PR DESCRIPTION
# Description

Speed up the CCD by limiting the maximum minimum distance to `1e-4`.

Fixes #39

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Passes unit tests on local machine

**Test Configuration**:
* OS and version: macOS
* Compile and version: Apple clang 14.0.0

# Checklist:

- [x] I have followed the project [style guide](https://ipc-sim.github.io/ipc-toolkit/style_guide.html)
- [x] My code follows the clang-format style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

