### PR TITLE
Fix Hash when not using Abseil

### DIFF
--- a/cmake/ipc_toolkit/ipc_toolkit_warnings.cmake
+++ b/cmake/ipc_toolkit/ipc_toolkit_warnings.cmake
@@ -45,6 +45,7 @@ set(IPC_TOOLKIT_WARNING_FLAGS
   -Werror=int-to-pointer-cast
   -Werror=pointer-to-int-cast
   -Werror=inconsistent-missing-override
+  -Werror=return-stack-address
 
   -Wunused-variable
   -Wunused-but-set-variable

--- a/src/ipc/utils/unordered_map_and_set.cpp
+++ b/src/ipc/utils/unordered_map_and_set.cpp
@@ -8,7 +8,7 @@ namespace ipc {
 
 template <>
 Hash<std::pair<int, int>>
-AbslHashValue(Hash<std::pair<int, int>> h, std::pair<int, int> p)
+AbslHashValue(Hash<std::pair<int, int>> h, const std::pair<int, int> p)
 {
     return Hash<std::pair<int, int>>::combine(std::move(h), p.first, p.second);
 }

--- a/src/ipc/utils/unordered_map_and_set.hpp
+++ b/src/ipc/utils/unordered_map_and_set.hpp
@@ -15,20 +15,21 @@ template <class T> struct Hash {
     Hash() = default;
     Hash(size_t h) : hash(h) {};
 
-    template <typename Value> static Hash&& combine(const Hash&& h, Value value)
+    template <typename Value>
+    static Hash combine(const Hash& h, const Value value)
     {
         if constexpr (std::is_default_constructible<std::hash<Value>>::value) {
             std::hash<Value> hash;
-            return std::move(Hash(
+            return Hash(
                 h.hash
-                ^ (hash(value) + 0x9e3779b9 + (h.hash << 6) + (h.hash >> 2))));
+                ^ (hash(value) + 0x9e3779b9 + (h.hash << 6) + (h.hash >> 2)));
         } else {
-            return std::move(AbslHashValue(h, value));
+            return AbslHashValue(h, value);
         }
     }
 
     template <class First, class... Rest>
-    static Hash&& combine(const Hash&& h, First first, Rest... rest)
+    static Hash combine(const Hash& h, const First first, const Rest... rest)
     {
         if constexpr (sizeof...(Rest) == 0) {
             return Hash::combine<First>(std::move(h), first);


### PR DESCRIPTION
# Description

Fix returning reference to a local temporary object in `Hash` when not using Abseil.

Fixes #89 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)