### PR TITLE
Mark single argument constructors explicit

### DIFF
--- a/src/ipc/broad_phase/spatial_hash.hpp
+++ b/src/ipc/broad_phase/spatial_hash.hpp
@@ -49,7 +49,7 @@ protected:
     double built_in_radius;
 
 public: // constructor
-    SpatialHash() { }
+    SpatialHash() = default;
 
     SpatialHash(
         const Eigen::MatrixXd& vertices,

--- a/src/ipc/candidates/candidates.hpp
+++ b/src/ipc/candidates/candidates.hpp
@@ -14,7 +14,7 @@ namespace ipc {
 
 class Candidates {
 public:
-    Candidates() { }
+    Candidates() = default;
 
     /// @brief Initialize the set of discrete collision detection candidates.
     /// @param mesh The surface of the collision mesh.

--- a/src/ipc/candidates/continuous_collision_candidate.hpp
+++ b/src/ipc/candidates/continuous_collision_candidate.hpp
@@ -11,7 +11,7 @@ namespace ipc {
 /// Virtual class for candidates that support CCD.
 class ContinuousCollisionCandidate : virtual public CollisionStencil {
 public:
-    virtual ~ContinuousCollisionCandidate() { }
+    virtual ~ContinuousCollisionCandidate() = default;
 
     /// @brief Perform narrow-phase CCD on the candidate.
     /// @param vertices_t0 Stencil vertices at the start of the time step.

--- a/src/ipc/ccd/additive_ccd.cpp
+++ b/src/ipc/ccd/additive_ccd.cpp
@@ -70,7 +70,7 @@ bool additive_ccd(
     const double tmax,
     const double conservative_rescaling)
 {
-    assert(conservative_rescaling > 0 && conservative_rescaling < 1);
+    assert(conservative_rescaling > 0 && conservative_rescaling <= 1);
 
     const double min_distance_sq = min_distance * min_distance;
 

--- a/src/ipc/collision_mesh.hpp
+++ b/src/ipc/collision_mesh.hpp
@@ -12,7 +12,7 @@ class CollisionMesh {
 public:
     /// @brief Construct a new Collision Mesh object.
     /// Collision Mesh objects are immutable, so use the other constructors.
-    CollisionMesh() { }
+    CollisionMesh() = default;
 
     /// @brief Construct a new Collision Mesh object directly from the collision mesh vertices.
     /// @param rest_positions The vertices of the collision mesh at rest (#V × dim).
@@ -64,7 +64,7 @@ public:
     void init_area_jacobians();
 
     /// @brief Destroy the Collision Mesh object
-    ~CollisionMesh() { }
+    ~CollisionMesh() = default;
 
     /// @brief Get the number of vertices in the collision mesh.
     size_t num_vertices() const { return m_vertex_to_full_vertex.size(); }

--- a/src/ipc/collisions/collision.hpp
+++ b/src/ipc/collisions/collision.hpp
@@ -17,7 +17,7 @@ public:
         const double weight,
         const Eigen::SparseVector<double>& weight_gradient);
 
-    virtual ~Collision() { }
+    virtual ~Collision() = default;
 
     // -- Distance mollifier ---------------------------------------------------
 

--- a/src/ipc/collisions/collisions.hpp
+++ b/src/ipc/collisions/collisions.hpp
@@ -22,7 +22,7 @@ public:
     using value_type = Collision;
 
 public:
-    Collisions() { }
+    Collisions() = default;
 
     /// @brief Initialize the set of collisions used to compute the barrier potential.
     /// @param mesh The collision mesh.

--- a/src/ipc/collisions/edge_edge.hpp
+++ b/src/ipc/collisions/edge_edge.hpp
@@ -58,7 +58,7 @@ public:
     /// @param positions The stencil's vertex positions.
     /// @param eps_x The mollifier's tolerance.
     /// @return The mollifier gradient.
-    virtual VectorMax12d mollifier_gradient(
+    VectorMax12d mollifier_gradient(
         const VectorMax12d& positions, double eps_x) const override;
 
     /// @brief Compute the Hessian of the mollifier for the distance w.r.t. positions.
@@ -71,7 +71,7 @@ public:
     /// @param positions The stencil's vertex positions.
     /// @param eps_x The mollifier's tolerance.
     /// @return The mollifier Hessian.
-    virtual MatrixMax12d mollifier_hessian(
+    MatrixMax12d mollifier_hessian(
         const VectorMax12d& positions, double eps_x) const override;
 
     /// @brief Compute the gradient of the mollifier for the distance w.r.t. rest positions.
@@ -92,7 +92,7 @@ public:
 
     // ------------------------------------------------------------------------
 
-    virtual EdgeEdgeDistanceType known_dtype() const override { return dtype; }
+    EdgeEdgeDistanceType known_dtype() const override { return dtype; }
 
     // ------------------------------------------------------------------------
 

--- a/src/ipc/friction/collisions/friction_collision.hpp
+++ b/src/ipc/friction/collisions/friction_collision.hpp
@@ -24,7 +24,7 @@ protected:
         const double barrier_stiffness);
 
 public:
-    virtual ~FrictionCollision() { }
+    virtual ~FrictionCollision() = default;
 
     /// @brief Get the dimension of the collision.
     int dim() const { return tangent_basis.rows(); }

--- a/src/ipc/friction/friction_collisions.hpp
+++ b/src/ipc/friction/friction_collisions.hpp
@@ -21,7 +21,7 @@ public:
     using value_type = FrictionCollision;
 
 public:
-    FrictionCollisions() { }
+    FrictionCollisions() = default;
 
     void build(
         const CollisionMesh& mesh,

--- a/src/ipc/potentials/barrier_potential.hpp
+++ b/src/ipc/potentials/barrier_potential.hpp
@@ -12,7 +12,7 @@ class BarrierPotential : public DistanceBasedPotential {
 public:
     /// @brief Construct a barrier potential.
     /// @param dhat The activation distance of the barrier.
-    BarrierPotential(const double dhat);
+    explicit BarrierPotential(const double dhat);
 
     /// @brief Construct a barrier potential.
     /// @param dhat The activation distance of the barrier.

--- a/src/ipc/potentials/distance_based_potential.hpp
+++ b/src/ipc/potentials/distance_based_potential.hpp
@@ -10,8 +10,8 @@ class DistanceBasedPotential : public Potential<Collisions> {
     using Super = Potential<Collisions>;
 
 public:
-    DistanceBasedPotential() { }
-    virtual ~DistanceBasedPotential() { }
+    DistanceBasedPotential() = default;
+    virtual ~DistanceBasedPotential() = default;
 
     // -- Cumulative methods ---------------------------------------------------
 

--- a/src/ipc/potentials/friction_potential.hpp
+++ b/src/ipc/potentials/friction_potential.hpp
@@ -12,7 +12,7 @@ class FrictionPotential : public Potential<FrictionCollisions> {
 public:
     /// @brief Construct a friction potential.
     /// @param epsv The smooth friction mollifier parameter \f$\epsilon_v\f$.
-    FrictionPotential(const double epsv);
+    explicit FrictionPotential(const double epsv);
 
     /// @brief Get the smooth friction mollifier parameter \f$\epsilon_v\f$.
     double epsv() const { return m_epsv; }

--- a/src/ipc/potentials/potential.hpp
+++ b/src/ipc/potentials/potential.hpp
@@ -12,8 +12,8 @@ protected:
     using TCollision = typename TCollisions::value_type;
 
 public:
-    Potential() { }
-    virtual ~Potential() { }
+    Potential() = default;
+    virtual ~Potential() = default;
 
     // -- Cumulative methods ---------------------------------------------------
 

--- a/tests/src/tests/ccd/test_edge_edge_ccd.cpp
+++ b/tests/src/tests/ccd/test_edge_edge_ccd.cpp
@@ -140,7 +140,7 @@ TEST_CASE("Edge-Edge CCD", "[ccd][3D][edge-edge]")
         is_collision_expected = dy >= d0 / 2;
         conservative_check = false;
     }
-    CAPTURE(int(is_collision_expected));
+    CAPTURE(is_collision_expected);
 
     double toi;
     bool is_colliding = edge_edge_ccd(

--- a/tests/src/tests/friction/test_force_jacobian.cpp
+++ b/tests/src/tests/friction/test_force_jacobian.cpp
@@ -43,7 +43,8 @@ void check_friction_force_jacobian(
 
     FrictionCollisions friction_collisions;
     friction_collisions.build(
-        mesh, X + Ut, collisions, dhat, barrier_stiffness, mu);
+        mesh, X + Ut, collisions, BarrierPotential(dhat), barrier_stiffness,
+        mu);
     CHECK(friction_collisions.size());
 
     const FrictionPotential D(epsv_times_h);
@@ -89,8 +90,8 @@ void check_friction_force_jacobian(
     ///////////////////////////////////////////////////////////////////////////
 
     Eigen::MatrixXd JF_wrt_X = D.force_jacobian(
-        friction_collisions, mesh, X, Ut, velocities, dhat, barrier_stiffness,
-        FrictionPotential::DiffWRT::REST_POSITIONS);
+        friction_collisions, mesh, X, Ut, velocities, BarrierPotential(dhat),
+        barrier_stiffness, FrictionPotential::DiffWRT::REST_POSITIONS);
 
     auto F_X = [&](const Eigen::VectorXd& x) {
         Eigen::MatrixXd fd_X = fd::unflatten(x, X.cols());
@@ -107,14 +108,15 @@ void check_friction_force_jacobian(
             fd_collisions.build(fd_mesh, fd_X + Ut, dhat);
 
             fd_friction_collisions.build(
-                fd_mesh, fd_X + Ut, fd_collisions, dhat, barrier_stiffness, mu);
+                fd_mesh, fd_X + Ut, fd_collisions, BarrierPotential(dhat),
+                barrier_stiffness, mu);
         } else {
             fd_friction_collisions = friction_collisions;
         }
 
         return D.force(
-            fd_friction_collisions, fd_mesh, fd_X, Ut, velocities, dhat,
-            barrier_stiffness);
+            fd_friction_collisions, fd_mesh, fd_X, Ut, velocities,
+            BarrierPotential(dhat), barrier_stiffness);
     };
     Eigen::MatrixXd fd_JF_wrt_X;
     fd::finite_jacobian(fd::flatten(X), F_X, fd_JF_wrt_X);
@@ -127,8 +129,8 @@ void check_friction_force_jacobian(
     ///////////////////////////////////////////////////////////////////////////
 
     Eigen::MatrixXd JF_wrt_Ut = D.force_jacobian(
-        friction_collisions, mesh, X, Ut, velocities, dhat, barrier_stiffness,
-        FrictionPotential::DiffWRT::LAGGED_DISPLACEMENTS);
+        friction_collisions, mesh, X, Ut, velocities, BarrierPotential(dhat),
+        barrier_stiffness, FrictionPotential::DiffWRT::LAGGED_DISPLACEMENTS);
 
     auto F_Ut = [&](const Eigen::VectorXd& ut) {
         Eigen::MatrixXd fd_Ut = fd::unflatten(ut, Ut.cols());
@@ -142,14 +144,15 @@ void check_friction_force_jacobian(
             fd_collisions.build(mesh, X + fd_Ut, dhat);
 
             fd_friction_collisions.build(
-                mesh, X + fd_Ut, fd_collisions, dhat, barrier_stiffness, mu);
+                mesh, X + fd_Ut, fd_collisions, BarrierPotential(dhat),
+                barrier_stiffness, mu);
         } else {
             fd_friction_collisions = friction_collisions;
         }
 
         return D.force(
-            friction_collisions, mesh, X, fd_Ut, velocities, dhat,
-            barrier_stiffness);
+            friction_collisions, mesh, X, fd_Ut, velocities,
+            BarrierPotential(dhat), barrier_stiffness);
     };
     Eigen::MatrixXd fd_JF_wrt_Ut;
     fd::finite_jacobian(fd::flatten(Ut), F_Ut, fd_JF_wrt_Ut);
@@ -162,13 +165,14 @@ void check_friction_force_jacobian(
     ///////////////////////////////////////////////////////////////////////////
 
     Eigen::MatrixXd JF_wrt_V = D.force_jacobian(
-        friction_collisions, mesh, X, Ut, velocities, dhat, barrier_stiffness,
-        FrictionPotential::DiffWRT::VELOCITIES);
+        friction_collisions, mesh, X, Ut, velocities, BarrierPotential(dhat),
+        barrier_stiffness, FrictionPotential::DiffWRT::VELOCITIES);
 
     auto F_V = [&](const Eigen::VectorXd& v) {
         return D.force(
             friction_collisions, mesh, X, Ut,
-            fd::unflatten(v, velocities.cols()), dhat, barrier_stiffness);
+            fd::unflatten(v, velocities.cols()), BarrierPotential(dhat),
+            barrier_stiffness);
     };
     Eigen::MatrixXd fd_JF_wrt_V;
     fd::finite_jacobian(fd::flatten(velocities), F_V, fd_JF_wrt_V);
@@ -198,7 +202,8 @@ void check_friction_force_jacobian(
     ///////////////////////////////////////////////////////////////////////////
 
     const Eigen::VectorXd force = D.force(
-        friction_collisions, mesh, X, Ut, velocities, dhat, barrier_stiffness);
+        friction_collisions, mesh, X, Ut, velocities, BarrierPotential(dhat),
+        barrier_stiffness);
     const Eigen::VectorXd grad_D =
         D.gradient(friction_collisions, mesh, velocities);
     CHECK(fd::compare_gradient(-force, grad_D));
@@ -206,8 +211,8 @@ void check_friction_force_jacobian(
     ///////////////////////////////////////////////////////////////////////////
 
     Eigen::MatrixXd jac_force = D.force_jacobian(
-        friction_collisions, mesh, X, Ut, velocities, dhat, barrier_stiffness,
-        FrictionPotential::DiffWRT::VELOCITIES);
+        friction_collisions, mesh, X, Ut, velocities, BarrierPotential(dhat),
+        barrier_stiffness, FrictionPotential::DiffWRT::VELOCITIES);
     CHECK(fd::compare_jacobian(-jac_force, hess_D));
 }
 

--- a/tests/src/tests/friction/test_friction.cpp
+++ b/tests/src/tests/friction/test_friction.cpp
@@ -195,7 +195,8 @@ TEST_CASE(
 
     FrictionCollisions friction_collisions;
     friction_collisions.build(
-        mesh, V_lagged, collisions, dhat, barrier_stiffness, mu);
+        mesh, V_lagged, collisions, BarrierPotential(dhat), barrier_stiffness,
+        mu);
     REQUIRE(friction_collisions.size() == collisions.size());
     REQUIRE(friction_collisions.size() == expected_friction_collisions.size());
 

--- a/tests/src/tests/potential/test_friction_potential.cpp
+++ b/tests/src/tests/potential/test_friction_potential.cpp
@@ -23,7 +23,7 @@ TEST_CASE("Friction gradient and hessian", "[friction][gradient][hessian]")
 
     FrictionCollisions friction_collisions;
     friction_collisions.build(
-        mesh, V0, collisions, dhat, barrier_stiffness, mu);
+        mesh, V0, collisions, BarrierPotential(dhat), barrier_stiffness, mu);
 
     const FrictionPotential D(epsv_times_h);
 


### PR DESCRIPTION
# Description

Mark `BarrierPotential(double)` and `FrictionPotential(double)` as explicit constructors to avoid implicit conversions from double.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

**Test Configuration**:
* OS and version: macOS 14.2.1
* Compile and version: Apple clang version 15.0.0

# Checklist:

- [x] I have followed the project [style guide](https://ipctk.xyz/style_guide.html)
- [x] My code follows the clang-format style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

