### PR TITLE
Fix Python Bindings for Numpy 2

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,6 +1,12 @@
 name: clang-format Check
 on:
   push:
+    paths:
+      - '.github/workflows/clang-format-check.yml'
+      - '.clang-format'
+      - 'src/**'
+      - 'tests/src/**'
+      - 'python/src/**'
   pull_request:
     paths:
       - '.github/workflows/clang-format-check.yml'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         include:
           - os: ubuntu-latest
             name: Linux

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -65,8 +65,7 @@ jobs:
         uses: actions/cache@v3.0.11
         with:
           path: ${{ env.CACHE_PATH }}
-          key: ${{ runner.os }}-Python-cache
-          restore-keys: ${{ runner.os }}-Release-cache
+          key: ${{ runner.os }}-Python${{ matrix.python-version }}-cache
 
       - name: Prepare Ccache
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: ubuntu-latest
             name: Linux

--- a/cmake/recipes/pybind11.cmake
+++ b/cmake/recipes/pybind11.cmake
@@ -26,4 +26,4 @@ find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
 
 include(CPM)
-CPMAddPackage("gh:pybind/pybind11@2.11.1")
+CPMAddPackage("gh:pybind/pybind11@2.13.1")

--- a/python/tests/find_ipctk.py
+++ b/python/tests/find_ipctk.py
@@ -11,9 +11,10 @@ except ImportError:
         repo_root / "build" / "debug" / "python",
     ]
     for path in possible_paths:
-        if path.exists():
+        if path.exists() and len(list(path.glob("ipctk.*"))) > 0:
             sys.path.append(str(path))
             break
     else:
         raise ImportError("Could not find the ipctk module")
+    print(f"Using found ipctk module at {path}")
     import ipctk  # Try again

--- a/python/tests/test_ipc.py
+++ b/python/tests/test_ipc.py
@@ -30,7 +30,7 @@ def check_ipc_derivatives(broad_phase_method, use_convergent_formulation, mesh_n
     assert np.linalg.norm(grad_b) > 1e-8
     assert np.allclose(grad_b, fgrad_b)
 
-    hess_b = B.hessian(collisions, mesh, vertices).A
+    hess_b = B.hessian(collisions, mesh, vertices).toarray()
     fhess_b = utils.finite_jacobian(
         vertices.flatten(), lambda x: B.gradient(collisions, mesh, x.reshape(vertices.shape)))
 


### PR DESCRIPTION
# Description

The version of Pybind11 in use (v2.11.1) is incompatible with Numpy 2.0.

This PR updates Pybind11 to v2.13.1 which is compatible with Numpy 2.0 (and older version of Numpy I believe).

Fixes #102 