### PR TITLE
Replace scalar enumerable_thread_specific with parallel_reduce

### DIFF
--- a/src/ipc/collisions/collisions.cpp
+++ b/src/ipc/collisions/collisions.cpp
@@ -9,6 +9,7 @@
 #include <ipc/utils/local_to_global.hpp>
 
 #include <tbb/parallel_for.h>
+#include <tbb/parallel_reduce.h>
 #include <tbb/parallel_sort.h>
 #include <tbb/blocked_range.h>
 #include <tbb/enumerable_thread_specific.h>
@@ -328,25 +329,21 @@ double Collisions::compute_minimum_distance(
     const Eigen::MatrixXi& edges = mesh.edges();
     const Eigen::MatrixXi& faces = mesh.faces();
 
-    tbb::enumerable_thread_specific<double> storage(
-        std::numeric_limits<double>::infinity());
-
-    tbb::parallel_for(
-        tbb::blocked_range<size_t>(0, size()),
-        [&](tbb::blocked_range<size_t> r) {
-            double& local_min_dist = storage.local();
-
+    return tbb::parallel_reduce(
+        /*range=*/tbb::blocked_range<size_t>(0, size()),
+        /*initial_min_distance=*/std::numeric_limits<double>::infinity(),
+        [&](tbb::blocked_range<size_t> r, double partial_min_dist) -> double {
             for (size_t i = r.begin(); i < r.end(); i++) {
                 const double dist = (*this)[i].compute_distance(
                     (*this)[i].dof(vertices, edges, faces));
 
-                if (dist < local_min_dist) {
-                    local_min_dist = dist;
+                if (dist < partial_min_dist) {
+                    partial_min_dist = dist;
                 }
             }
-        });
-
-    return storage.combine([](double a, double b) { return std::min(a, b); });
+            return partial_min_dist;
+        },
+        /*combine=*/[](double a, double b) { return std::min(a, b); });
 }
 
 // ============================================================================

--- a/src/ipc/collisions/collisions.cpp
+++ b/src/ipc/collisions/collisions.cpp
@@ -330,8 +330,8 @@ double Collisions::compute_minimum_distance(
     const Eigen::MatrixXi& faces = mesh.faces();
 
     return tbb::parallel_reduce(
-        /*range=*/tbb::blocked_range<size_t>(0, size()),
-        /*initial_min_distance=*/std::numeric_limits<double>::infinity(),
+        tbb::blocked_range<size_t>(0, size()),
+        std::numeric_limits<double>::infinity(),
         [&](tbb::blocked_range<size_t> r, double partial_min_dist) -> double {
             for (size_t i = r.begin(); i < r.end(); i++) {
                 const double dist = (*this)[i].compute_distance(
@@ -343,7 +343,7 @@ double Collisions::compute_minimum_distance(
             }
             return partial_min_dist;
         },
-        /*combine=*/[](double a, double b) { return std::min(a, b); });
+        [](double a, double b) { return std::min(a, b); });
 }
 
 // ============================================================================

--- a/src/ipc/potentials/friction_potential.cpp
+++ b/src/ipc/potentials/friction_potential.cpp
@@ -28,7 +28,7 @@ Eigen::VectorXd FrictionPotential::force(
     const Eigen::MatrixXi& edges = mesh.edges();
     const Eigen::MatrixXi& faces = mesh.faces();
 
-    tbb::enumerable_thread_specific<Eigen::VectorXd> storage(
+    tbb::combinable<Eigen::VectorXd> storage(
         Eigen::VectorXd::Zero(velocities.size()));
 
     tbb::parallel_for(
@@ -52,8 +52,7 @@ Eigen::VectorXd FrictionPotential::force(
             }
         });
 
-    return storage.combine([](const Eigen::VectorXd& a,
-                              const Eigen::VectorXd& b) { return a + b; });
+    return storage.combine(std::plus<const Eigen::VectorXd&>());
 }
 
 Eigen::SparseMatrix<double> FrictionPotential::force_jacobian(

--- a/src/ipc/potentials/friction_potential.cpp
+++ b/src/ipc/potentials/friction_potential.cpp
@@ -52,7 +52,8 @@ Eigen::VectorXd FrictionPotential::force(
             }
         });
 
-    return storage.combine(std::plus<const Eigen::VectorXd&>());
+    return storage.combine([](const Eigen::VectorXd& a,
+                              const Eigen::VectorXd& b) { return a + b; });
 }
 
 Eigen::SparseMatrix<double> FrictionPotential::force_jacobian(

--- a/src/ipc/potentials/potential.tpp
+++ b/src/ipc/potentials/potential.tpp
@@ -31,7 +31,7 @@ double Potential<TCollisions>::operator()(
             }
             return partial_sum;
         },
-        std::plus<double>());
+        [](double a, double b) { return a + b; });
 }
 
 template <class TCollisions>
@@ -67,7 +67,9 @@ Eigen::VectorXd Potential<TCollisions>::gradient(
             }
         });
 
-    return grad.combine(std::plus<const Eigen::VectorXd&>());
+    return grad.combine([](const Eigen::VectorXd& a, const Eigen::VectorXd& b) {
+        return a + b;
+    });
 }
 
 template <class TCollisions>
@@ -127,7 +129,9 @@ Eigen::SparseMatrix<double> Potential<TCollisions>::hessian(
             }
         });
 
-    return hess.combine(std::plus<const Eigen::SparseMatrix<double>&>());
+    return hess.combine(
+        [](const Eigen::SparseMatrix<double>& a,
+           const Eigen::SparseMatrix<double>& b) { return a + b; });
 }
 
 } // namespace ipc

--- a/src/ipc/potentials/potential.tpp
+++ b/src/ipc/potentials/potential.tpp
@@ -4,9 +4,11 @@
 
 #include <ipc/utils/local_to_global.hpp>
 
-#include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
+#include <tbb/combinable.h>
 #include <tbb/enumerable_thread_specific.h>
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_reduce.h>
 
 namespace ipc {
 
@@ -18,25 +20,18 @@ double Potential<TCollisions>::operator()(
 {
     assert(X.rows() == mesh.num_vertices());
 
-    if (collisions.empty()) {
-        return 0;
-    }
-
-    tbb::enumerable_thread_specific<double> storage(0);
-
-    tbb::parallel_for(
-        tbb::blocked_range<size_t>(size_t(0), collisions.size()),
-        [&](const tbb::blocked_range<size_t>& r) {
-            auto& local_potential = storage.local();
+    return tbb::parallel_reduce(
+        tbb::blocked_range<size_t>(size_t(0), collisions.size()), 0.0,
+        [&](const tbb::blocked_range<size_t>& r, double partial_sum) {
             for (size_t i = r.begin(); i < r.end(); i++) {
                 // Quadrature weight is premultiplied by local potential
-                local_potential += (*this)(
+                partial_sum += (*this)(
                     collisions[i],
                     collisions[i].dof(X, mesh.edges(), mesh.faces()));
             }
-        });
-
-    return storage.combine([](double a, double b) { return a + b; });
+            return partial_sum;
+        },
+        std::plus<double>());
 }
 
 template <class TCollisions>
@@ -53,14 +48,11 @@ Eigen::VectorXd Potential<TCollisions>::gradient(
 
     const int dim = X.cols();
 
-    tbb::enumerable_thread_specific<Eigen::VectorXd> storage(
-        Eigen::VectorXd::Zero(X.size()));
+    tbb::combinable<Eigen::VectorXd> grad(Eigen::VectorXd::Zero(X.size()));
 
     tbb::parallel_for(
         tbb::blocked_range<size_t>(size_t(0), collisions.size()),
         [&](const tbb::blocked_range<size_t>& r) {
-            auto& global_grad = storage.local();
-
             for (size_t i = r.begin(); i < r.end(); i++) {
                 const TCollision& collision = collisions[i];
 
@@ -71,12 +63,11 @@ Eigen::VectorXd Potential<TCollisions>::gradient(
                     collision.vertex_ids(mesh.edges(), mesh.faces());
 
                 local_gradient_to_global_gradient(
-                    local_grad, vids, dim, global_grad);
+                    local_grad, vids, dim, grad.local());
             }
         });
 
-    return storage.combine([](const Eigen::VectorXd& a,
-                              const Eigen::VectorXd& b) { return a + b; });
+    return grad.combine(std::plus<const Eigen::VectorXd&>());
 }
 
 template <class TCollisions>
@@ -121,14 +112,22 @@ Eigen::SparseMatrix<double> Potential<TCollisions>::hessian(
             }
         });
 
-    Eigen::SparseMatrix<double> hess(ndof, ndof);
-    for (const auto& local_hess_triplets : storage) {
-        Eigen::SparseMatrix<double> local_hess(ndof, ndof);
-        local_hess.setFromTriplets(
-            local_hess_triplets.begin(), local_hess_triplets.end());
-        hess += local_hess;
-    }
-    return hess;
+    // Combine the local hessians
+    tbb::combinable<Eigen::SparseMatrix<double>> hess(
+        Eigen::SparseMatrix<double>(ndof, ndof));
+
+    tbb::parallel_for(
+        tbb::blocked_range<decltype(storage)::iterator>(
+            storage.begin(), storage.end()),
+        [&](const tbb::blocked_range<decltype(storage)::iterator>& r) {
+            for (auto it = r.begin(); it != r.end(); ++it) {
+                Eigen::SparseMatrix<double> local_hess(ndof, ndof);
+                local_hess.setFromTriplets(it->begin(), it->end());
+                hess.local() += local_hess;
+            }
+        });
+
+    return hess.combine(std::plus<const Eigen::SparseMatrix<double>&>());
 }
 
 } // namespace ipc


### PR DESCRIPTION
# Description

Replace scalar enumerable_thread_specific with parallel_reduce.

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves existing functionality)

# How Has This Been Tested?

Existing unit tests.

# Checklist:

- [x] I have followed the project [style guide](https://ipctk.xyz/style_guide.html)
- [x] My code follows the clang-format style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

