### PR TITLE
compute_collision_free_stepsize gpu issue

### DIFF
--- a/src/ipc/ipc.cpp
+++ b/src/ipc/ipc.cpp
@@ -56,8 +56,8 @@ double compute_collision_free_stepsize(
                 "Sweep and Tiniest Queue is only supported in 3D!");
         }
         // TODO: Use correct min_distance
-        const int max_iterations = 100;
-        const double tolerance = 1e-6;
+        const double tolerance = TightInclusionCCD::DEFAULT_TOLERANCE;
+        const long max_iterations = TightInclusionCCD::DEFAULT_MAX_ITERATIONS;
         const double step_size = scalable_ccd::cuda::ipc_ccd_strategy(
             vertices_t0, vertices_t1, mesh.edges(), mesh.faces(),
             /*min_distance=*/0.0, max_iterations, tolerance);

--- a/src/ipc/ipc.cpp
+++ b/src/ipc/ipc.cpp
@@ -56,7 +56,7 @@ double compute_collision_free_stepsize(
                 "Sweep and Tiniest Queue is only supported in 3D!");
         }
         // TODO: Use correct min_distance
-        const int max_iterations = 1000;
+        const int max_iterations = 100;
         const double tolerance = 1e-6;
         const double step_size = scalable_ccd::cuda::ipc_ccd_strategy(
             vertices_t0, vertices_t1, mesh.edges(), mesh.faces(),

--- a/src/ipc/ipc.cpp
+++ b/src/ipc/ipc.cpp
@@ -56,6 +56,8 @@ double compute_collision_free_stepsize(
                 "Sweep and Tiniest Queue is only supported in 3D!");
         }
         // TODO: Use correct min_distance
+        const int max_iterations = 1000;
+        const double tolerance = 1e-6;
         const double step_size = scalable_ccd::cuda::ipc_ccd_strategy(
             vertices_t0, vertices_t1, mesh.edges(), mesh.faces(),
             /*min_distance=*/0.0, max_iterations, tolerance);


### PR DESCRIPTION
# Description

compute_collision_free_stepsize is missing the max_iterations,tolerance variable

    const int max_iterations = 1000;
    const double tolerance = 1e-6;

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Build on WSL Linux locally
- [ ] Build on Windows locally

**Test Configuration**:
* OS and version: Windows 11
* Compile and version: gcc 10 cuda 12.6

# Checklist:

- [X] I have followed the project [style guide](https://ipctk.xyz/style_guide.html)
- [X] My code follows the clang-format style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

