### PR TITLE
Change const Eigen::Matrix& to Eigen::ConstRef<Matrix>

### DIFF
--- a/python/src/barrier/adaptive_stiffness.cpp
+++ b/python/src/barrier/adaptive_stiffness.cpp
@@ -13,8 +13,8 @@ void define_adaptive_stiffness(py::module_& m)
         "initial_barrier_stiffness",
         [](const double bbox_diagonal, const Barrier& barrier,
            const double dhat, const double average_mass,
-           const Eigen::VectorXd& grad_energy,
-           const Eigen::VectorXd& grad_barrier,
+           Eigen::ConstRef<Eigen::VectorXd> grad_energy,
+           Eigen::ConstRef<Eigen::VectorXd> grad_barrier,
            const double min_barrier_stiffness_scale = 1e11,
            const double dmin = 0) {
             double max_barrier_stiffness;
@@ -73,8 +73,9 @@ void define_adaptive_stiffness(py::module_& m)
         "semi_implicit_stiffness",
         static_cast<double (*)(
             const CollisionStencil&, const std::array<long, 4>&,
-            const VectorMax12d&, const VectorMax4d&, const MatrixMax12d&,
-            const double)>(&semi_implicit_stiffness),
+            Eigen::ConstRef<VectorMax12d>, Eigen::ConstRef<VectorMax4d>,
+            Eigen::ConstRef<MatrixMax12d>, const double)>(
+            &semi_implicit_stiffness),
         R"ipc_Qu8mg5v7(
         Compute the semi-implicit stiffness for a single collision.
 
@@ -97,8 +98,8 @@ void define_adaptive_stiffness(py::module_& m)
     m.def(
         "semi_implicit_stiffness",
         static_cast<Eigen::VectorXd (*)(
-            const CollisionMesh&, const Eigen::MatrixXd&,
-            const NormalCollisions&, const Eigen::VectorXd&,
+            const CollisionMesh&, Eigen::ConstRef<Eigen::MatrixXd>,
+            const NormalCollisions&, Eigen::ConstRef<Eigen::VectorXd>,
             const Eigen::SparseMatrix<double>&, const double)>(
             &semi_implicit_stiffness),
         R"ipc_Qu8mg5v7(
@@ -123,9 +124,10 @@ void define_adaptive_stiffness(py::module_& m)
     m.def(
         "semi_implicit_stiffness",
         static_cast<Eigen::VectorXd (*)(
-            const CollisionMesh&, const Eigen::MatrixXd&, const Candidates&,
-            const Eigen::VectorXd&, const Eigen::SparseMatrix<double>&,
-            const double)>(&semi_implicit_stiffness),
+            const CollisionMesh&, Eigen::ConstRef<Eigen::MatrixXd>,
+            const Candidates&, Eigen::ConstRef<Eigen::VectorXd>,
+            const Eigen::SparseMatrix<double>&, const double)>(
+            &semi_implicit_stiffness),
         R"ipc_Qu8mg5v7(
         Compute the semi-implicit stiffness's for all collisions.
 

--- a/python/src/broad_phase/aabb.cpp
+++ b/python/src/broad_phase/aabb.cpp
@@ -10,8 +10,9 @@ void define_aabb(py::module_& m)
     py::class_<AABB>(m, "AABB")
         .def(py::init())
         .def(
-            py::init<const ArrayMax3d&, const ArrayMax3d&>(), py::arg("min"),
-            py::arg("max"))
+            py::init<
+                Eigen::ConstRef<ArrayMax3d>, Eigen::ConstRef<ArrayMax3d>>(),
+            py::arg("min"), py::arg("max"))
         .def(
             py::init<const AABB&, const AABB&>(), py::arg("aabb1"),
             py::arg("aabb2"))
@@ -20,7 +21,7 @@ void define_aabb(py::module_& m)
             py::arg("aabb2"), py::arg("aabb3"))
         .def_static(
             "from_point",
-            py::overload_cast<const VectorMax3d&, const double>(
+            py::overload_cast<Eigen::ConstRef<VectorMax3d>, const double>(
                 &AABB::from_point),
             R"ipc_Qu8mg5v7(
             Construct an AABB for a static point.
@@ -36,8 +37,8 @@ void define_aabb(py::module_& m)
         .def_static(
             "from_point",
             py::overload_cast<
-                const VectorMax3d&, const VectorMax3d&, const double>(
-                &AABB::from_point),
+                Eigen::ConstRef<VectorMax3d>, Eigen::ConstRef<VectorMax3d>,
+                const double>(&AABB::from_point),
             R"ipc_Qu8mg5v7(
             Construct an AABB for a moving point (i.e. temporal edge).
 
@@ -78,7 +79,8 @@ void define_aabb(py::module_& m)
 
     m.def(
         "build_vertex_boxes",
-        [](const Eigen::MatrixXd& vertices, const double inflation_radius = 0) {
+        [](Eigen::ConstRef<Eigen::MatrixXd> vertices,
+           const double inflation_radius = 0) {
             std::vector<AABB> vertex_boxes;
             build_vertex_boxes(vertices, vertex_boxes, inflation_radius);
             return vertex_boxes;
@@ -97,8 +99,8 @@ void define_aabb(py::module_& m)
 
     m.def(
         "build_vertex_boxes",
-        [](const Eigen::MatrixXd& vertices_t0,
-           const Eigen::MatrixXd& vertices_t1,
+        [](Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+           Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
            const double inflation_radius = 0) {
             std::vector<AABB> vertex_boxes;
             build_vertex_boxes(
@@ -122,7 +124,7 @@ void define_aabb(py::module_& m)
     m.def(
         "build_edge_boxes",
         [](const std::vector<AABB>& vertex_boxes,
-           const Eigen::MatrixXi& edges) {
+           Eigen::ConstRef<Eigen::MatrixXi> edges) {
             std::vector<AABB> edge_boxes;
             build_edge_boxes(vertex_boxes, edges, edge_boxes);
             return edge_boxes;
@@ -142,7 +144,7 @@ void define_aabb(py::module_& m)
     m.def(
         "build_face_boxes",
         [](const std::vector<AABB>& vertex_boxes,
-           const Eigen::MatrixXi& faces) {
+           Eigen::ConstRef<Eigen::MatrixXi> faces) {
             std::vector<AABB> face_boxes;
             build_face_boxes(vertex_boxes, faces, face_boxes);
             return face_boxes;

--- a/python/src/broad_phase/broad_phase.cpp
+++ b/python/src/broad_phase/broad_phase.cpp
@@ -16,9 +16,9 @@ public:
     }
 
     void build(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         const double inflation_radius = 0) override
     {
         PYBIND11_OVERRIDE(
@@ -26,10 +26,10 @@ public:
     }
 
     void build(
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         const double inflation_radius = 0) override
     {
         PYBIND11_OVERRIDE(
@@ -149,8 +149,10 @@ void define_broad_phase(py::module_& m)
         .def(
             "build",
             py::overload_cast<
-                const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                const Eigen::MatrixXi&, const double>(&BroadPhase::build),
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>, const double>(
+                &BroadPhase::build),
             R"ipc_Qu8mg5v7(
             Build the broad phase for static collision detection.
 
@@ -165,8 +167,10 @@ void define_broad_phase(py::module_& m)
         .def(
             "build",
             py::overload_cast<
-                const Eigen::MatrixXd&, const Eigen::MatrixXd&,
-                const Eigen::MatrixXi&, const Eigen::MatrixXi&, const double>(
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>, const double>(
                 &BroadPhase::build),
             R"ipc_Qu8mg5v7(
             Build the broad phase for continuous collision detection.

--- a/python/src/broad_phase/spatial_hash.cpp
+++ b/python/src/broad_phase/spatial_hash.cpp
@@ -12,30 +12,36 @@ void define_spatial_hash(py::module_& m)
         .def(py::init())
         .def(
             py::init<
-                const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                const Eigen::MatrixXi&, double, double>(),
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>, double, double>(),
             py::arg("vertices"), py::arg("edges"), py::arg("faces"),
             py::arg("inflation_radius") = 0, py::arg("voxel_size") = -1)
         .def(
             py::init<
-                const Eigen::MatrixXd&, const Eigen::MatrixXd&,
-                const Eigen::MatrixXi&, const Eigen::MatrixXi&, double,
-                double>(),
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>, double, double>(),
             py::arg("vertices_t0"), py::arg("vertices_t1"), py::arg("edges"),
             py::arg("faces"), py::arg("inflation_radius") = 0,
             py::arg("voxel_size") = -1)
         .def(
             "build",
             py::overload_cast<
-                const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                const Eigen::MatrixXi&, double, double>(&SpatialHash::build),
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>, double, double>(
+                &SpatialHash::build),
             py::arg("vertices"), py::arg("edges"), py::arg("faces"),
             py::arg("inflation_radius") = 0, py::arg("voxel_size") = -1)
         .def(
             "build",
             py::overload_cast<
-                const Eigen::MatrixXd&, const Eigen::MatrixXd&,
-                const Eigen::MatrixXi&, const Eigen::MatrixXi&, double, double>(
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>, double, double>(
                 &SpatialHash::build),
             py::arg("vertices_t0"), py::arg("vertices_t1"), py::arg("edges"),
             py::arg("faces"), py::arg("inflation_radius") = 0,

--- a/python/src/broad_phase/voxel_size_heuristic.cpp
+++ b/python/src/broad_phase/voxel_size_heuristic.cpp
@@ -10,22 +10,24 @@ void define_voxel_size_heuristic(py::module_& m)
     m.def(
         "suggest_good_voxel_size",
         py::overload_cast<
-            const Eigen::MatrixXd&, const Eigen::MatrixXi&, const double>(
-            &suggest_good_voxel_size),
+            Eigen::ConstRef<Eigen::MatrixXd>, Eigen::ConstRef<Eigen::MatrixXi>,
+            const double>(&suggest_good_voxel_size),
         py::arg("vertices"), py::arg("edges"), py::arg("inflation_radius") = 0);
 
     m.def(
         "suggest_good_voxel_size",
         py::overload_cast<
-            const Eigen::MatrixXd&, const Eigen::MatrixXd&,
-            const Eigen::MatrixXi&, const double>(&suggest_good_voxel_size),
+            Eigen::ConstRef<Eigen::MatrixXd>, Eigen::ConstRef<Eigen::MatrixXd>,
+            Eigen::ConstRef<Eigen::MatrixXi>, const double>(
+            &suggest_good_voxel_size),
         py::arg("vertices_t0"), py::arg("vertices_t1"), py::arg("edges"),
         py::arg("inflation_radius") = 0);
 
     m.def(
         "mean_edge_length",
-        [](const Eigen::MatrixXd& vertices_t0,
-           const Eigen::MatrixXd& vertices_t1, const Eigen::MatrixXi& edges) {
+        [](Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+           Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+           Eigen::ConstRef<Eigen::MatrixXi> edges) {
             double std_deviation;
             double r = mean_edge_length(
                 vertices_t0, vertices_t1, edges, std_deviation);
@@ -36,7 +38,7 @@ void define_voxel_size_heuristic(py::module_& m)
 
     m.def(
         "mean_displacement_length",
-        [](const Eigen::MatrixXd& displacements) {
+        [](Eigen::ConstRef<Eigen::MatrixXd> displacements) {
             double std_deviation;
             double r = mean_displacement_length(displacements, std_deviation);
             return std::make_tuple(r, std_deviation);

--- a/python/src/candidates/candidates.cpp
+++ b/python/src/candidates/candidates.cpp
@@ -12,8 +12,8 @@ void define_candidates(py::module_& m)
         .def(
             "build",
             py::overload_cast<
-                const CollisionMesh&, const Eigen::MatrixXd&, const double,
-                std::shared_ptr<BroadPhase>>(&Candidates::build),
+                const CollisionMesh&, Eigen::ConstRef<Eigen::MatrixXd>,
+                const double, std::shared_ptr<BroadPhase>>(&Candidates::build),
             R"ipc_Qu8mg5v7(
             Initialize the set of discrete collision detection candidates.
 
@@ -29,8 +29,8 @@ void define_candidates(py::module_& m)
         .def(
             "build",
             py::overload_cast<
-                const CollisionMesh&, const Eigen::MatrixXd&,
-                const Eigen::MatrixXd&, const double,
+                const CollisionMesh&, Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXd>, const double,
                 std::shared_ptr<BroadPhase>>(&Candidates::build),
             R"ipc_Qu8mg5v7(
             Initialize the set of continuous collision detection candidates.

--- a/python/src/candidates/collision_stencil.cpp
+++ b/python/src/candidates/collision_stencil.cpp
@@ -37,7 +37,7 @@ void define_collision_stencil(py::module_& m)
             )ipc_Qu8mg5v7",
             py::arg("edges"), py::arg("faces"))
         .def(
-            "vertices", &CollisionStencil::vertices<double>,
+            "vertices", &CollisionStencil::vertices,
             R"ipc_Qu8mg5v7(
             Get the vertex attributes of the collision stencil.
 
@@ -53,7 +53,7 @@ void define_collision_stencil(py::module_& m)
             )ipc_Qu8mg5v7",
             py::arg("vertices"), py::arg("edges"), py::arg("faces"))
         .def(
-            "dof", &CollisionStencil::dof<double>,
+            "dof", &CollisionStencil::dof,
             R"ipc_Qu8mg5v7(
             Select this stencil's DOF from the full matrix of DOF.
 
@@ -71,8 +71,9 @@ void define_collision_stencil(py::module_& m)
         .def(
             "compute_distance",
             py::overload_cast<
-                const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                const Eigen::MatrixXi&>(
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>>(
                 &CollisionStencil::compute_distance, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the distance of the stencil.
@@ -89,8 +90,9 @@ void define_collision_stencil(py::module_& m)
         .def(
             "compute_distance_gradient",
             py::overload_cast<
-                const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                const Eigen::MatrixXi&>(
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>>(
                 &CollisionStencil::compute_distance_gradient, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the distance gradient of the stencil w.r.t. the stencil's vertex positions.
@@ -107,8 +109,9 @@ void define_collision_stencil(py::module_& m)
         .def(
             "compute_distance_hessian",
             py::overload_cast<
-                const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                const Eigen::MatrixXi&>(
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>>(
                 &CollisionStencil::compute_distance_hessian, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the distance Hessian of the stencil w.r.t. the stencil's vertex positions.
@@ -124,7 +127,7 @@ void define_collision_stencil(py::module_& m)
             py::arg("vertices"), py::arg("edges"), py::arg("faces"))
         .def(
             "compute_distance",
-            py::overload_cast<const VectorMax12d&>(
+            py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
                 &CollisionStencil::compute_distance, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the distance of the stencil.
@@ -141,7 +144,7 @@ void define_collision_stencil(py::module_& m)
             py::arg("positions"))
         .def(
             "compute_distance_gradient",
-            py::overload_cast<const VectorMax12d&>(
+            py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
                 &CollisionStencil::compute_distance_gradient, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the distance gradient of the stencil w.r.t. the stencil's vertex positions.
@@ -158,7 +161,7 @@ void define_collision_stencil(py::module_& m)
             py::arg("positions"))
         .def(
             "compute_distance_hessian",
-            py::overload_cast<const VectorMax12d&>(
+            py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
                 &CollisionStencil::compute_distance_hessian, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the distance Hessian of the stencil w.r.t. the stencil's vertex positions.
@@ -175,9 +178,11 @@ void define_collision_stencil(py::module_& m)
             py::arg("positions"))
         .def(
             "ccd",
-            [](const CollisionStencil& self, const VectorMax12d& vertices_t0,
-               const VectorMax12d& vertices_t1, const double min_distance,
-               const double tmax, const NarrowPhaseCCD& narrow_phase_ccd) {
+            [](const CollisionStencil& self,
+               Eigen::ConstRef<VectorMax12d> vertices_t0,
+               Eigen::ConstRef<VectorMax12d> vertices_t1,
+               const double min_distance, const double tmax,
+               const NarrowPhaseCCD& narrow_phase_ccd) {
                 double toi;
                 bool r = self.ccd(
                     vertices_t0, vertices_t1, toi, min_distance, tmax,
@@ -204,8 +209,9 @@ void define_collision_stencil(py::module_& m)
             py::arg("narrow_phase_ccd") = DEFAULT_NARROW_PHASE_CCD)
         .def(
             "print_ccd_query",
-            [](const CollisionStencil& self, const VectorMax12d& vertices_t0,
-               const VectorMax12d& vertices_t1) -> void {
+            [](const CollisionStencil& self,
+               Eigen::ConstRef<VectorMax12d> vertices_t0,
+               Eigen::ConstRef<VectorMax12d> vertices_t1) -> void {
                 self.write_ccd_query(std::cout, vertices_t0, vertices_t1);
             },
             R"ipc_Qu8mg5v7(

--- a/python/src/ccd/inexact_point_edge.cpp
+++ b/python/src/ccd/inexact_point_edge.cpp
@@ -9,9 +9,12 @@ void define_inexact_point_edge(py::module_& m)
 {
     m.def(
         "inexact_point_edge_ccd_2D",
-        [](const Eigen::Vector2d& p_t0, const Eigen::Vector2d& e0_t0,
-           const Eigen::Vector2d& e1_t0, const Eigen::Vector2d& p_t1,
-           const Eigen::Vector2d& e0_t1, const Eigen::Vector2d& e1_t1,
+        [](Eigen::ConstRef<Eigen::Vector2d> p_t0,
+           Eigen::ConstRef<Eigen::Vector2d> e0_t0,
+           Eigen::ConstRef<Eigen::Vector2d> e1_t0,
+           Eigen::ConstRef<Eigen::Vector2d> p_t1,
+           Eigen::ConstRef<Eigen::Vector2d> e0_t1,
+           Eigen::ConstRef<Eigen::Vector2d> e1_t1,
            const double conservative_rescaling) {
             double toi;
             bool r = inexact_point_edge_ccd_2D(

--- a/python/src/ccd/narrow_phase_ccd.cpp
+++ b/python/src/ccd/narrow_phase_ccd.cpp
@@ -9,10 +9,10 @@ class PyNarrowPhaseCCD : public NarrowPhaseCCD {
 public:
     using NarrowPhaseCCD::NarrowPhaseCCD; // Inherit constructors
     bool point_point_ccd(
-        const VectorMax3d& p0_t0,
-        const VectorMax3d& p1_t0,
-        const VectorMax3d& p0_t1,
-        const VectorMax3d& p1_t1,
+        Eigen::ConstRef<VectorMax3d> p0_t0,
+        Eigen::ConstRef<VectorMax3d> p1_t0,
+        Eigen::ConstRef<VectorMax3d> p0_t1,
+        Eigen::ConstRef<VectorMax3d> p1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override
@@ -28,12 +28,12 @@ public:
         throw std::runtime_error("pure virtual function called");
     }
     bool point_edge_ccd(
-        const VectorMax3d& p_t0,
-        const VectorMax3d& e0_t0,
-        const VectorMax3d& e1_t0,
-        const VectorMax3d& p_t1,
-        const VectorMax3d& e0_t1,
-        const VectorMax3d& e1_t1,
+        Eigen::ConstRef<VectorMax3d> p_t0,
+        Eigen::ConstRef<VectorMax3d> e0_t0,
+        Eigen::ConstRef<VectorMax3d> e1_t0,
+        Eigen::ConstRef<VectorMax3d> p_t1,
+        Eigen::ConstRef<VectorMax3d> e0_t1,
+        Eigen::ConstRef<VectorMax3d> e1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override
@@ -49,14 +49,14 @@ public:
         throw std::runtime_error("pure virtual function called");
     }
     bool point_triangle_ccd(
-        const Eigen::Vector3d& p_t0,
-        const Eigen::Vector3d& t0_t0,
-        const Eigen::Vector3d& t1_t0,
-        const Eigen::Vector3d& t2_t0,
-        const Eigen::Vector3d& p_t1,
-        const Eigen::Vector3d& t0_t1,
-        const Eigen::Vector3d& t1_t1,
-        const Eigen::Vector3d& t2_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override
@@ -73,14 +73,14 @@ public:
         throw std::runtime_error("pure virtual function called");
     }
     bool edge_edge_ccd(
-        const Eigen::Vector3d& ea0_t0,
-        const Eigen::Vector3d& ea1_t0,
-        const Eigen::Vector3d& eb0_t0,
-        const Eigen::Vector3d& eb1_t0,
-        const Eigen::Vector3d& ea0_t1,
-        const Eigen::Vector3d& ea1_t1,
-        const Eigen::Vector3d& eb0_t1,
-        const Eigen::Vector3d& eb1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override
@@ -104,10 +104,11 @@ void define_narrow_phase_ccd(py::module_& m)
         .def(py::init<>())
         .def(
             "point_point_ccd",
-            [](const NarrowPhaseCCD& self, const VectorMax3d& p0_t0,
-               const VectorMax3d& p1_t0, const VectorMax3d& p0_t1,
-               const VectorMax3d& p1_t1, const double min_distance = 0.0,
-               const double tmax = 1.0) {
+            [](const NarrowPhaseCCD& self, Eigen::ConstRef<VectorMax3d> p0_t0,
+               Eigen::ConstRef<VectorMax3d> p1_t0,
+               Eigen::ConstRef<VectorMax3d> p0_t1,
+               Eigen::ConstRef<VectorMax3d> p1_t1,
+               const double min_distance = 0.0, const double tmax = 1.0) {
                 double toi;
                 bool r = self.point_point_ccd(
                     p0_t0, p1_t0, p0_t1, p1_t1, toi, min_distance, tmax);
@@ -118,11 +119,13 @@ void define_narrow_phase_ccd(py::module_& m)
             py::arg("tmax") = 1.0)
         .def(
             "point_edge_ccd",
-            [](const NarrowPhaseCCD& self, const VectorMax3d& p_t0,
-               const VectorMax3d& e0_t0, const VectorMax3d& e1_t0,
-               const VectorMax3d& p_t1, const VectorMax3d& e0_t1,
-               const VectorMax3d& e1_t1, const double min_distance = 0.0,
-               const double tmax = 1.0) {
+            [](const NarrowPhaseCCD& self, Eigen::ConstRef<VectorMax3d> p_t0,
+               Eigen::ConstRef<VectorMax3d> e0_t0,
+               Eigen::ConstRef<VectorMax3d> e1_t0,
+               Eigen::ConstRef<VectorMax3d> p_t1,
+               Eigen::ConstRef<VectorMax3d> e0_t1,
+               Eigen::ConstRef<VectorMax3d> e1_t1,
+               const double min_distance = 0.0, const double tmax = 1.0) {
                 double toi;
                 bool r = self.point_edge_ccd(
                     p_t0, e0_t0, e1_t0, p_t1, e0_t1, e1_t1, toi, min_distance,
@@ -134,12 +137,16 @@ void define_narrow_phase_ccd(py::module_& m)
             py::arg("min_distance") = 0.0, py::arg("tmax") = 1.0)
         .def(
             "point_triangle_ccd",
-            [](const NarrowPhaseCCD& self, const Eigen::Vector3d& p_t0,
-               const Eigen::Vector3d& t0_t0, const Eigen::Vector3d& t1_t0,
-               const Eigen::Vector3d& t2_t0, const Eigen::Vector3d& p_t1,
-               const Eigen::Vector3d& t0_t1, const Eigen::Vector3d& t1_t1,
-               const Eigen::Vector3d& t2_t1, const double min_distance = 0.0,
-               const double tmax = 1.0) {
+            [](const NarrowPhaseCCD& self,
+               Eigen::ConstRef<Eigen::Vector3d> p_t0,
+               Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+               Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+               Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+               Eigen::ConstRef<Eigen::Vector3d> p_t1,
+               Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+               Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+               Eigen::ConstRef<Eigen::Vector3d> t2_t1,
+               const double min_distance = 0.0, const double tmax = 1.0) {
                 double toi;
                 bool r = self.point_triangle_ccd(
                     p_t0, t0_t0, t1_t0, t2_t0, p_t1, t0_t1, t1_t1, t2_t1, toi,
@@ -152,12 +159,16 @@ void define_narrow_phase_ccd(py::module_& m)
             py::arg("tmax") = 1.0)
         .def(
             "edge_edge_ccd",
-            [](const NarrowPhaseCCD& self, const Eigen::Vector3d& ea0_t0,
-               const Eigen::Vector3d& ea1_t0, const Eigen::Vector3d& eb0_t0,
-               const Eigen::Vector3d& eb1_t0, const Eigen::Vector3d& ea0_t1,
-               const Eigen::Vector3d& ea1_t1, const Eigen::Vector3d& eb0_t1,
-               const Eigen::Vector3d& eb1_t1, const double min_distance = 0.0,
-               const double tmax = 1.0) {
+            [](const NarrowPhaseCCD& self,
+               Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+               Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+               Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+               Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+               Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+               Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+               Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+               Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
+               const double min_distance = 0.0, const double tmax = 1.0) {
                 double toi;
                 bool r = self.edge_edge_ccd(
                     ea0_t0, ea1_t0, eb0_t0, eb1_t0, ea0_t1, ea1_t1, eb0_t1,

--- a/python/src/ccd/point_static_plane.cpp
+++ b/python/src/ccd/point_static_plane.cpp
@@ -9,8 +9,9 @@ void define_point_static_plane(py::module_& m)
 {
     m.def(
         "point_static_plane_ccd",
-        [](const VectorMax3d& p_t0, const VectorMax3d& p_t1,
-           const VectorMax3d& plane_origin, const VectorMax3d& plane_normal,
+        [](Eigen::ConstRef<VectorMax3d> p_t0, Eigen::ConstRef<VectorMax3d> p_t1,
+           Eigen::ConstRef<VectorMax3d> plane_origin,
+           Eigen::ConstRef<VectorMax3d> plane_normal,
            const double conservative_rescaling) {
             double toi;
             bool r = point_static_plane_ccd(

--- a/python/src/collision_mesh.cpp
+++ b/python/src/collision_mesh.cpp
@@ -57,7 +57,7 @@ class VertexPatchesCanCollide {
 public:
     /// @brief Construct a new Vertex Patches Can Collide object.
     /// @param vertex_patches Vector of patches labels for each vertex.
-    VertexPatchesCanCollide(const Eigen::VectorXi& vertex_patches)
+    VertexPatchesCanCollide(Eigen::ConstRef<Eigen::VectorXi> vertex_patches)
         : m_vertex_patches(vertex_patches)
     {
     }
@@ -111,7 +111,8 @@ void define_collision_mesh(py::module_& m)
         m, "VertexPatchesCanCollide",
         "A functor which returns true if the vertices are in different patches.")
         .def(
-            py::init<const Eigen::VectorXi&>(), py::arg("vertex_patches"),
+            py::init<Eigen::ConstRef<Eigen::VectorXi>>(),
+            py::arg("vertex_patches"),
             R"ipc_Qu8mg5v7(
             Construct a new Vertex Patches Can Collide object.
 
@@ -134,8 +135,10 @@ void define_collision_mesh(py::module_& m)
     py::class_<CollisionMesh>(m, "CollisionMesh")
         .def(
             py::init<
-                const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                const Eigen::MatrixXi&, const Eigen::SparseMatrix<double>&>(),
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                const Eigen::SparseMatrix<double>&>(),
             R"ipc_Qu8mg5v7(
             Construct a new Collision Mesh object directly from the collision mesh vertices.
 
@@ -150,8 +153,9 @@ void define_collision_mesh(py::module_& m)
             py::arg("displacement_map") = Eigen::SparseMatrix<double>())
         .def(
             py::init<
-                const std::vector<bool>&, const Eigen::MatrixXd&,
-                const Eigen::MatrixXi&, const Eigen::MatrixXi&,
+                const std::vector<bool>&, Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
+                Eigen::ConstRef<Eigen::MatrixXi>,
                 const Eigen::SparseMatrix<double>&>(),
             R"ipc_Qu8mg5v7(
             Construct a new Collision Mesh object from a full mesh vertices.
@@ -282,7 +286,7 @@ void define_collision_mesh(py::module_& m)
             py::arg("id"))
         .def(
             "to_full_dof",
-            py::overload_cast<const Eigen::VectorXd&>(
+            py::overload_cast<Eigen::ConstRef<Eigen::VectorXd>>(
                 &CollisionMesh::to_full_dof, py::const_),
             R"ipc_Qu8mg5v7(
             Map a vector quantity on the collision mesh to the full mesh.

--- a/python/src/collisions/normal/normal_collision.cpp
+++ b/python/src/collisions/normal/normal_collision.cpp
@@ -25,7 +25,7 @@ void define_normal_collision(py::module_& m)
             py::arg("rest_positions"))
         .def(
             "mollifier",
-            py::overload_cast<const VectorMax12d&>(
+            py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
                 &NormalCollision::mollifier, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the mollifier for the distance.
@@ -39,7 +39,7 @@ void define_normal_collision(py::module_& m)
             py::arg("positions"))
         .def(
             "mollifier",
-            py::overload_cast<const VectorMax12d&, double>(
+            py::overload_cast<Eigen::ConstRef<VectorMax12d>, double>(
                 &NormalCollision::mollifier, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the mollifier for the distance.
@@ -54,7 +54,7 @@ void define_normal_collision(py::module_& m)
             py::arg("positions"), py::arg("eps_x"))
         .def(
             "mollifier_gradient",
-            py::overload_cast<const VectorMax12d&>(
+            py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
                 &NormalCollision::mollifier_gradient, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the gradient of the mollifier for the distance wrt the positions.
@@ -68,7 +68,7 @@ void define_normal_collision(py::module_& m)
             py::arg("positions"))
         .def(
             "mollifier_gradient",
-            py::overload_cast<const VectorMax12d&, double>(
+            py::overload_cast<Eigen::ConstRef<VectorMax12d>, double>(
                 &NormalCollision::mollifier_gradient, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the gradient of the mollifier for the distance wrt the positions.
@@ -83,7 +83,7 @@ void define_normal_collision(py::module_& m)
             py::arg("positions"), py::arg("eps_x"))
         .def(
             "mollifier_hessian",
-            py::overload_cast<const VectorMax12d&>(
+            py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
                 &NormalCollision::mollifier_hessian, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the Hessian of the mollifier for the distance wrt the positions.
@@ -97,7 +97,7 @@ void define_normal_collision(py::module_& m)
             py::arg("positions"))
         .def(
             "mollifier_hessian",
-            py::overload_cast<const VectorMax12d&, double>(
+            py::overload_cast<Eigen::ConstRef<VectorMax12d>, double>(
                 &NormalCollision::mollifier_hessian, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the Hessian of the mollifier for the distance wrt the positions.

--- a/python/src/collisions/normal/normal_collisions.cpp
+++ b/python/src/collisions/normal/normal_collisions.cpp
@@ -12,8 +12,8 @@ void define_normal_collisions(py::module_& m)
         .def(
             "build",
             py::overload_cast<
-                const CollisionMesh&, const Eigen::MatrixXd&, const double,
-                const double, std::shared_ptr<BroadPhase>>(
+                const CollisionMesh&, Eigen::ConstRef<Eigen::MatrixXd>,
+                const double, const double, std::shared_ptr<BroadPhase>>(
                 &NormalCollisions::build),
             R"ipc_Qu8mg5v7(
             Initialize the set of collisions used to compute the barrier potential.
@@ -31,8 +31,9 @@ void define_normal_collisions(py::module_& m)
         .def(
             "build",
             py::overload_cast<
-                const Candidates&, const CollisionMesh&, const Eigen::MatrixXd&,
-                const double, const double>(&NormalCollisions::build),
+                const Candidates&, const CollisionMesh&,
+                Eigen::ConstRef<Eigen::MatrixXd>, const double, const double>(
+                &NormalCollisions::build),
             R"ipc_Qu8mg5v7(
             Initialize the set of collisions used to compute the barrier potential.
 

--- a/python/src/collisions/normal/plane_vertex.cpp
+++ b/python/src/collisions/normal/plane_vertex.cpp
@@ -10,7 +10,9 @@ void define_plane_vertex_normal_collision(py::module_& m)
     py::class_<PlaneVertexNormalCollision, NormalCollision>(
         m, "PlaneVertexNormalCollision")
         .def(
-            py::init<const VectorMax3d&, const VectorMax3d&, const long>(),
+            py::init<
+                Eigen::ConstRef<VectorMax3d>, Eigen::ConstRef<VectorMax3d>,
+                const long>(),
             py::arg("plane_origin"), py::arg("plane_normal"),
             py::arg("vertex_id"))
         .def_readwrite(

--- a/python/src/collisions/tangential/edge_edge.cpp
+++ b/python/src/collisions/tangential/edge_edge.cpp
@@ -13,7 +13,7 @@ void define_edge_edge_tangential_collision(py::module_& m)
         .def(py::init<const EdgeEdgeNormalCollision&>(), py::arg("collision"))
         .def(
             py::init<
-                const EdgeEdgeNormalCollision&, const VectorMax12d&,
+                const EdgeEdgeNormalCollision&, Eigen::ConstRef<VectorMax12d>,
                 const NormalPotential&, const double>(),
             py::arg("collision"), py::arg("positions"),
             py::arg("normal_potential"), py::arg("normal_stiffness"));

--- a/python/src/collisions/tangential/edge_vertex.cpp
+++ b/python/src/collisions/tangential/edge_vertex.cpp
@@ -13,7 +13,7 @@ void define_edge_vertex_tangential_collision(py::module_& m)
         .def(py::init<const EdgeVertexNormalCollision&>(), py::arg("collision"))
         .def(
             py::init<
-                const EdgeVertexNormalCollision&, const VectorMax12d&,
+                const EdgeVertexNormalCollision&, Eigen::ConstRef<VectorMax12d>,
                 const NormalPotential&, const double>(),
             py::arg("collision"), py::arg("positions"),
             py::arg("normal_potential"), py::arg("normal_stiffness"));

--- a/python/src/collisions/tangential/face_vertex.cpp
+++ b/python/src/collisions/tangential/face_vertex.cpp
@@ -13,7 +13,7 @@ void define_face_vertex_tangential_collision(py::module_& m)
         .def(py::init<const FaceVertexNormalCollision&>(), py::arg("collision"))
         .def(
             py::init<
-                const FaceVertexNormalCollision&, const VectorMax12d&,
+                const FaceVertexNormalCollision&, Eigen::ConstRef<VectorMax12d>,
                 const NormalPotential&, const double>(),
             py::arg("collision"), py::arg("positions"),
             py::arg("normal_potential"), py::arg("normal_stiffness"));

--- a/python/src/collisions/tangential/tangential_collision.cpp
+++ b/python/src/collisions/tangential/tangential_collision.cpp
@@ -93,7 +93,7 @@ void define_tangential_collision(py::module_& m)
             )ipc_Qu8mg5v7")
         .def(
             "relative_velocity_matrix",
-            py::overload_cast<const VectorMax2d&>(
+            py::overload_cast<Eigen::ConstRef<VectorMax2d>>(
                 &TangentialCollision::relative_velocity_matrix, py::const_),
             R"ipc_Qu8mg5v7(
             Construct the premultiplier matrix for the relative velocity.

--- a/python/src/collisions/tangential/tangential_collisions.cpp
+++ b/python/src/collisions/tangential/tangential_collisions.cpp
@@ -12,7 +12,7 @@ void define_tangential_collisions(py::module_& m)
         .def(
             "build",
             py::overload_cast<
-                const CollisionMesh&, const Eigen::MatrixXd&,
+                const CollisionMesh&, Eigen::ConstRef<Eigen::MatrixXd>,
                 const NormalCollisions&, const NormalPotential&, double,
                 double>(&TangentialCollisions::build),
             py::arg("mesh"), py::arg("vertices"), py::arg("collisions"),
@@ -21,10 +21,11 @@ void define_tangential_collisions(py::module_& m)
         .def(
             "build",
             [](TangentialCollisions& self, const CollisionMesh& mesh,
-               const Eigen::MatrixXd& vertices,
+               Eigen::ConstRef<Eigen::MatrixXd> vertices,
                const NormalCollisions& collisions,
                const NormalPotential& normal_potential,
-               const double normal_stiffness, const Eigen::VectorXd& mus) {
+               const double normal_stiffness,
+               Eigen::ConstRef<Eigen::VectorXd> mus) {
                 self.build(
                     mesh, vertices, collisions, normal_potential,
                     normal_stiffness, mus);
@@ -35,9 +36,9 @@ void define_tangential_collisions(py::module_& m)
         .def(
             "build",
             py::overload_cast<
-                const CollisionMesh&, const Eigen::MatrixXd&,
+                const CollisionMesh&, Eigen::ConstRef<Eigen::MatrixXd>,
                 const NormalCollisions&, const NormalPotential&, const double,
-                const Eigen::VectorXd&,
+                Eigen::ConstRef<Eigen::VectorXd>,
                 const std::function<double(double, double)>&>(
                 &TangentialCollisions::build),
             py::arg("mesh"), py::arg("vertices"), py::arg("collisions"),

--- a/python/src/collisions/tangential/vertex_vertex.cpp
+++ b/python/src/collisions/tangential/vertex_vertex.cpp
@@ -15,8 +15,9 @@ void define_vertex_vertex_tangential_collision(py::module_& m)
             py::arg("collision"))
         .def(
             py::init<
-                const VertexVertexNormalCollision&, const VectorMax12d&,
-                const NormalPotential&, const double>(),
+                const VertexVertexNormalCollision&,
+                Eigen::ConstRef<VectorMax12d>, const NormalPotential&,
+                const double>(),
             py::arg("collision"), py::arg("positions"),
             py::arg("normal_potential"), py::arg("normal_stiffness"));
 }

--- a/python/src/distance/edge_edge_mollifier.cpp
+++ b/python/src/distance/edge_edge_mollifier.cpp
@@ -26,10 +26,10 @@ void define_edge_edge_mollifier(py::module_& m)
     m.def(
         "edge_edge_cross_squarednorm_gradient",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&>(
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>>(
             &edge_edge_cross_squarednorm_gradient),
         R"ipc_Qu8mg5v7(
         Compute the gradient of the squared norm of the edge cross product.
@@ -48,10 +48,10 @@ void define_edge_edge_mollifier(py::module_& m)
     m.def(
         "edge_edge_cross_squarednorm_hessian",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&>(
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>>(
             &edge_edge_cross_squarednorm_hessian),
         R"ipc_Qu8mg5v7(
         Compute the hessian of the squared norm of the edge cross product.
@@ -147,10 +147,10 @@ void define_edge_edge_mollifier(py::module_& m)
     m.def(
         "edge_edge_mollifier",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&, const double>(
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>, const double>(
             &edge_edge_mollifier),
         R"ipc_Qu8mg5v7(
         Compute a mollifier for the edge-edge distance.
@@ -173,10 +173,10 @@ void define_edge_edge_mollifier(py::module_& m)
     m.def(
         "edge_edge_mollifier_gradient",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&, const double>(
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>, const double>(
             &edge_edge_mollifier_gradient),
         R"ipc_Qu8mg5v7(
         Compute the gradient of the mollifier for the edge-edge distance.
@@ -197,10 +197,10 @@ void define_edge_edge_mollifier(py::module_& m)
     m.def(
         "edge_edge_mollifier_hessian",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&, const double>(
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>, const double>(
             &edge_edge_mollifier_hessian),
         R"ipc_Qu8mg5v7(
         Compute the hessian of the mollifier for the edge-edge distance.

--- a/python/src/distance/point_plane.cpp
+++ b/python/src/distance/point_plane.cpp
@@ -10,9 +10,9 @@ void define_point_plane_distance(py::module_& m)
     m.def(
         "point_plane_distance",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&>(&point_plane_distance),
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>>(&point_plane_distance),
         R"ipc_Qu8mg5v7(
         Compute the distance between a point and a plane.
 
@@ -32,10 +32,10 @@ void define_point_plane_distance(py::module_& m)
     m.def(
         "point_plane_distance",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&>(&point_plane_distance),
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>>(&point_plane_distance),
         R"ipc_Qu8mg5v7(
         Compute the distance between a point and a plane.
 
@@ -56,9 +56,9 @@ void define_point_plane_distance(py::module_& m)
     m.def(
         "point_plane_distance_gradient",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&>(
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>>(
             &point_plane_distance_gradient),
         R"ipc_Qu8mg5v7(
         Compute the gradient of the distance between a point and a plane.
@@ -79,10 +79,10 @@ void define_point_plane_distance(py::module_& m)
     m.def(
         "point_plane_distance_gradient",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&>(
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>>(
             &point_plane_distance_gradient),
         R"ipc_Qu8mg5v7(
         Compute the gradient of the distance between a point and a plane.
@@ -104,9 +104,9 @@ void define_point_plane_distance(py::module_& m)
     m.def(
         "point_plane_distance_hessian",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&>(
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>>(
             &point_plane_distance_hessian),
         R"ipc_Qu8mg5v7(
         Compute the hessian of the distance between a point and a plane.
@@ -127,10 +127,10 @@ void define_point_plane_distance(py::module_& m)
     m.def(
         "point_plane_distance_hessian",
         py::overload_cast<
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&,
-            const Eigen::Ref<const Eigen::Vector3d>&>(
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>,
+            Eigen::ConstRef<const Eigen::Vector3d>>(
             &point_plane_distance_hessian),
         R"ipc_Qu8mg5v7(
         Compute the hessian of the distance between a point and a plane.

--- a/python/src/implicits/plane.cpp
+++ b/python/src/implicits/plane.cpp
@@ -9,8 +9,9 @@ void define_plane_implicit(py::module_& m)
 {
     m.def(
         "construct_point_plane_collisions",
-        [](const Eigen::MatrixXd& points, const Eigen::MatrixXd& plane_origins,
-           const Eigen::MatrixXd& plane_normals, const double dhat,
+        [](Eigen::ConstRef<Eigen::MatrixXd> points,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_normals, const double dhat,
            const double dmin = 0) {
             std::vector<PlaneVertexNormalCollision> pv_collisions;
             construct_point_plane_collisions(
@@ -41,8 +42,9 @@ void define_plane_implicit(py::module_& m)
 
     m.def(
         "construct_point_plane_collisions",
-        [](const Eigen::MatrixXd& points, const Eigen::MatrixXd& plane_origins,
-           const Eigen::MatrixXd& plane_normals, const double dhat,
+        [](Eigen::ConstRef<Eigen::MatrixXd> points,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_normals, const double dhat,
            const double dmin,
            const std::function<bool(size_t, size_t)>& can_collide) {
             std::vector<PlaneVertexNormalCollision> pv_collisions;
@@ -75,9 +77,10 @@ void define_plane_implicit(py::module_& m)
 
     m.def(
         "is_step_point_plane_collision_free",
-        [](const Eigen::MatrixXd& points_t0, const Eigen::MatrixXd& points_t1,
-           const Eigen::MatrixXd& plane_origins,
-           const Eigen::MatrixXd& plane_normals) {
+        [](Eigen::ConstRef<Eigen::MatrixXd> points_t0,
+           Eigen::ConstRef<Eigen::MatrixXd> points_t1,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_normals) {
             return is_step_point_plane_collision_free(
                 points_t0, points_t1, plane_origins, plane_normals);
         },
@@ -101,9 +104,10 @@ void define_plane_implicit(py::module_& m)
 
     m.def(
         "is_step_point_plane_collision_free",
-        [](const Eigen::MatrixXd& points_t0, const Eigen::MatrixXd& points_t1,
-           const Eigen::MatrixXd& plane_origins,
-           const Eigen::MatrixXd& plane_normals,
+        [](Eigen::ConstRef<Eigen::MatrixXd> points_t0,
+           Eigen::ConstRef<Eigen::MatrixXd> points_t1,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_normals,
            const std::function<bool(size_t, size_t)>& can_collide) {
             return is_step_point_plane_collision_free(
                 points_t0, points_t1, plane_origins, plane_normals,
@@ -130,9 +134,10 @@ void define_plane_implicit(py::module_& m)
 
     m.def(
         "compute_point_plane_collision_free_stepsize",
-        [](const Eigen::MatrixXd& points_t0, const Eigen::MatrixXd& points_t1,
-           const Eigen::MatrixXd& plane_origins,
-           const Eigen::MatrixXd& plane_normals) {
+        [](Eigen::ConstRef<Eigen::MatrixXd> points_t0,
+           Eigen::ConstRef<Eigen::MatrixXd> points_t1,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_normals) {
             return compute_point_plane_collision_free_stepsize(
                 points_t0, points_t1, plane_origins, plane_normals);
         },
@@ -159,9 +164,10 @@ void define_plane_implicit(py::module_& m)
 
     m.def(
         "compute_point_plane_collision_free_stepsize",
-        [](const Eigen::MatrixXd& points_t0, const Eigen::MatrixXd& points_t1,
-           const Eigen::MatrixXd& plane_origins,
-           const Eigen::MatrixXd& plane_normals,
+        [](Eigen::ConstRef<Eigen::MatrixXd> points_t0,
+           Eigen::ConstRef<Eigen::MatrixXd> points_t1,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+           Eigen::ConstRef<Eigen::MatrixXd> plane_normals,
            const std::function<bool(size_t, size_t)>& can_collide) {
             return compute_point_plane_collision_free_stepsize(
                 points_t0, points_t1, plane_origins, plane_normals,

--- a/python/src/ipc.cpp
+++ b/python/src/ipc.cpp
@@ -78,7 +78,7 @@ void define_ipc(py::module_& m)
 
     m.def(
         "edges",
-        [](const Eigen::MatrixXi& F) {
+        [](Eigen::ConstRef<Eigen::MatrixXi> F) {
             Eigen::MatrixXi E;
             igl::edges(F, E);
             return E;

--- a/python/src/potentials/normal_potential.cpp
+++ b/python/src/potentials/normal_potential.cpp
@@ -17,7 +17,7 @@ void define_normal_potential(py::module_& m)
             "shape_derivative",
             py::overload_cast<
                 const NormalCollisions&, const CollisionMesh&,
-                const Eigen::MatrixXd&>(
+                Eigen::ConstRef<Eigen::MatrixXd>>(
                 &NormalPotential::shape_derivative, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the shape derivative of the potential.
@@ -37,8 +37,8 @@ void define_normal_potential(py::module_& m)
             "shape_derivative",
             [](const NormalPotential& self, const NormalCollision& collision,
                const std::array<long, 4>& vertex_ids,
-               const VectorMax12d& rest_positions,
-               const VectorMax12d& positions) {
+               Eigen::ConstRef<VectorMax12d> rest_positions,
+               Eigen::ConstRef<VectorMax12d> positions) {
                 std::vector<Eigen::Triplet<double>> out;
                 self.shape_derivative(
                     collision, vertex_ids, rest_positions, positions, out);

--- a/python/src/potentials/potential.hpp
+++ b/python/src/potentials/potential.hpp
@@ -19,7 +19,7 @@ void define_potential_methods(PyClass& potential)
             "__call__",
             py::overload_cast<
                 const TCollisions&, const CollisionMesh&,
-                const Eigen::MatrixXd&>(
+                Eigen::ConstRef<Eigen::MatrixXd>>(
                 &Potential<TCollisions>::operator(), py::const_),
             R"ipc_Qu8mg5v7(
             Compute the potential for a set of collisions.
@@ -37,7 +37,7 @@ void define_potential_methods(PyClass& potential)
             "gradient",
             py::overload_cast<
                 const TCollisions&, const CollisionMesh&,
-                const Eigen::MatrixXd&>(
+                Eigen::ConstRef<Eigen::MatrixXd>>(
                 &Potential<TCollisions>::gradient, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the gradient of the potential.
@@ -55,7 +55,7 @@ void define_potential_methods(PyClass& potential)
             "hessian",
             py::overload_cast<
                 const TCollisions&, const CollisionMesh&,
-                const Eigen::MatrixXd&, const PSDProjectionMethod>(
+                Eigen::ConstRef<Eigen::MatrixXd>, const PSDProjectionMethod>(
                 &Potential<TCollisions>::hessian, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the hessian of the potential.
@@ -73,7 +73,7 @@ void define_potential_methods(PyClass& potential)
             py::arg("project_hessian_to_psd") = PSDProjectionMethod::NONE)
         .def(
             "__call__",
-            py::overload_cast<const TCollision&, const VectorMax12d&>(
+            py::overload_cast<const TCollision&, Eigen::ConstRef<VectorMax12d>>(
                 &Potential<TCollisions>::operator(), py::const_),
             R"ipc_Qu8mg5v7(
             Compute the potential for a single collision.
@@ -88,7 +88,7 @@ void define_potential_methods(PyClass& potential)
             py::arg("collision"), py::arg("x"))
         .def(
             "gradient",
-            py::overload_cast<const TCollision&, const VectorMax12d&>(
+            py::overload_cast<const TCollision&, Eigen::ConstRef<VectorMax12d>>(
                 &Potential<TCollisions>::gradient, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the gradient of the potential for a single collision.
@@ -104,7 +104,7 @@ void define_potential_methods(PyClass& potential)
         .def(
             "hessian",
             py::overload_cast<
-                const TCollision&, const VectorMax12d&,
+                const TCollision&, Eigen::ConstRef<VectorMax12d>,
                 const PSDProjectionMethod>(
                 &Potential<TCollisions>::hessian, py::const_),
             R"ipc_Qu8mg5v7(

--- a/python/src/potentials/tangential_potential.cpp
+++ b/python/src/potentials/tangential_potential.cpp
@@ -31,9 +31,10 @@ void define_tangential_potential(py::module_& m)
             "force",
             py::overload_cast<
                 const TangentialCollisions&, const CollisionMesh&,
-                const Eigen::MatrixXd&, const Eigen::MatrixXd&,
-                const Eigen::MatrixXd&, const NormalPotential&, const double,
-                const double, const bool>(
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXd>, const NormalPotential&,
+                const double, const double, const bool>(
                 &TangentialPotential::force, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the friction force from the given velocities.
@@ -60,9 +61,10 @@ void define_tangential_potential(py::module_& m)
             "force_jacobian",
             py::overload_cast<
                 const TangentialCollisions&, const CollisionMesh&,
-                const Eigen::MatrixXd&, const Eigen::MatrixXd&,
-                const Eigen::MatrixXd&, const NormalPotential&, const double,
-                const TangentialPotential::DiffWRT, const double>(
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXd>,
+                Eigen::ConstRef<Eigen::MatrixXd>, const NormalPotential&,
+                const double, const TangentialPotential::DiffWRT, const double>(
                 &TangentialPotential::force_jacobian, py::const_),
             R"ipc_Qu8mg5v7(
             Compute the Jacobian of the friction force wrt the velocities.
@@ -88,8 +90,8 @@ void define_tangential_potential(py::module_& m)
         .def(
             "force",
             py::overload_cast<
-                const TangentialCollision&, const VectorMax12d&,
-                const VectorMax12d&, const VectorMax12d&,
+                const TangentialCollision&, Eigen::ConstRef<VectorMax12d>,
+                Eigen::ConstRef<VectorMax12d>, Eigen::ConstRef<VectorMax12d>,
                 const NormalPotential&, const double, const double, const bool>(
                 &TangentialPotential::force, py::const_),
             R"ipc_Qu8mg5v7(
@@ -115,8 +117,8 @@ void define_tangential_potential(py::module_& m)
         .def(
             "force_jacobian",
             py::overload_cast<
-                const TangentialCollision&, const VectorMax12d&,
-                const VectorMax12d&, const VectorMax12d&,
+                const TangentialCollision&, Eigen::ConstRef<VectorMax12d>,
+                Eigen::ConstRef<VectorMax12d>, Eigen::ConstRef<VectorMax12d>,
                 const NormalPotential&, const double,
                 const TangentialPotential::DiffWRT, const double>(
                 &TangentialPotential::force_jacobian, py::const_),

--- a/python/src/tangent/closest_point.cpp
+++ b/python/src/tangent/closest_point.cpp
@@ -9,7 +9,8 @@ void define_closest_point(py::module_& m)
 {
     m.def(
         "point_edge_closest_point",
-        [](const VectorMax3d& p, const VectorMax3d& e0, const VectorMax3d& e1) {
+        [](Eigen::ConstRef<VectorMax3d> p, Eigen::ConstRef<VectorMax3d> e0,
+           Eigen::ConstRef<VectorMax3d> e1) {
             assert_2D_or_3D_vector(p, "p");
             assert_2D_or_3D_vector(e0, "e0");
             assert_2D_or_3D_vector(e1, "e1");
@@ -30,7 +31,8 @@ void define_closest_point(py::module_& m)
 
     m.def(
         "point_edge_closest_point_jacobian",
-        [](const VectorMax3d& p, const VectorMax3d& e0, const VectorMax3d& e1) {
+        [](Eigen::ConstRef<VectorMax3d> p, Eigen::ConstRef<VectorMax3d> e0,
+           Eigen::ConstRef<VectorMax3d> e1) {
             assert_2D_or_3D_vector(p, "p");
             assert_2D_or_3D_vector(e0, "e0");
             assert_2D_or_3D_vector(e1, "e1");
@@ -51,8 +53,10 @@ void define_closest_point(py::module_& m)
 
     m.def(
         "edge_edge_closest_point",
-        [](const Eigen::Vector3d& ea0, const Eigen::Vector3d& ea1,
-           const Eigen::Vector3d& eb0, const Eigen::Vector3d& eb1) {
+        [](Eigen::ConstRef<Eigen::Vector3d> ea0,
+           Eigen::ConstRef<Eigen::Vector3d> ea1,
+           Eigen::ConstRef<Eigen::Vector3d> eb0,
+           Eigen::ConstRef<Eigen::Vector3d> eb1) {
             return edge_edge_closest_point(ea0, ea1, eb0, eb1);
         },
         R"ipc_Qu8mg5v7(
@@ -71,8 +75,10 @@ void define_closest_point(py::module_& m)
 
     m.def(
         "edge_edge_closest_point_jacobian",
-        [](const Eigen::Vector3d& ea0, const Eigen::Vector3d& ea1,
-           const Eigen::Vector3d& eb0, const Eigen::Vector3d& eb1) {
+        [](Eigen::ConstRef<Eigen::Vector3d> ea0,
+           Eigen::ConstRef<Eigen::Vector3d> ea1,
+           Eigen::ConstRef<Eigen::Vector3d> eb0,
+           Eigen::ConstRef<Eigen::Vector3d> eb1) {
             return edge_edge_closest_point_jacobian(ea0, ea1, eb0, eb1);
         },
         R"ipc_Qu8mg5v7(
@@ -91,8 +97,10 @@ void define_closest_point(py::module_& m)
 
     m.def(
         "point_triangle_closest_point",
-        [](const Eigen::Vector3d& p, const Eigen::Vector3d& t0,
-           const Eigen::Vector3d& t1, const Eigen::Vector3d& t2) {
+        [](Eigen::ConstRef<Eigen::Vector3d> p,
+           Eigen::ConstRef<Eigen::Vector3d> t0,
+           Eigen::ConstRef<Eigen::Vector3d> t1,
+           Eigen::ConstRef<Eigen::Vector3d> t2) {
             return point_triangle_closest_point(p, t0, t1, t2);
         },
         R"ipc_Qu8mg5v7(
@@ -111,8 +119,10 @@ void define_closest_point(py::module_& m)
 
     m.def(
         "point_triangle_closest_point_jacobian",
-        [](const Eigen::Vector3d& p, const Eigen::Vector3d& t0,
-           const Eigen::Vector3d& t1, const Eigen::Vector3d& t2) {
+        [](Eigen::ConstRef<Eigen::Vector3d> p,
+           Eigen::ConstRef<Eigen::Vector3d> t0,
+           Eigen::ConstRef<Eigen::Vector3d> t1,
+           Eigen::ConstRef<Eigen::Vector3d> t2) {
             return point_triangle_closest_point_jacobian(p, t0, t1, t2);
         },
         R"ipc_Qu8mg5v7(

--- a/python/src/tangent/tangent_basis.cpp
+++ b/python/src/tangent/tangent_basis.cpp
@@ -9,7 +9,7 @@ void define_tangent_basis(py::module_& m)
 {
     m.def(
         "point_point_tangent_basis",
-        [](const VectorMax3d& p0, const VectorMax3d& p1) {
+        [](Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1) {
             assert_2D_or_3D_vector(p0, "p0");
             assert_2D_or_3D_vector(p1, "p1");
             return point_point_tangent_basis(p0, p1);
@@ -28,7 +28,7 @@ void define_tangent_basis(py::module_& m)
 
     m.def(
         "point_point_tangent_basis_jacobian",
-        [](const VectorMax3d& p0, const VectorMax3d& p1) {
+        [](Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1) {
             assert_2D_or_3D_vector(p0, "p0");
             assert_2D_or_3D_vector(p1, "p1");
             return point_point_tangent_basis_jacobian(p0, p1);
@@ -47,7 +47,8 @@ void define_tangent_basis(py::module_& m)
 
     m.def(
         "point_edge_tangent_basis",
-        [](const VectorMax3d& p, const VectorMax3d& e0, const VectorMax3d& e1) {
+        [](Eigen::ConstRef<VectorMax3d> p, Eigen::ConstRef<VectorMax3d> e0,
+           Eigen::ConstRef<VectorMax3d> e1) {
             assert_2D_or_3D_vector(p, "p");
             assert_2D_or_3D_vector(e0, "e0");
             assert_2D_or_3D_vector(e1, "e1");
@@ -68,7 +69,8 @@ void define_tangent_basis(py::module_& m)
 
     m.def(
         "point_edge_tangent_basis_jacobian",
-        [](const VectorMax3d& p, const VectorMax3d& e0, const VectorMax3d& e1) {
+        [](Eigen::ConstRef<VectorMax3d> p, Eigen::ConstRef<VectorMax3d> e0,
+           Eigen::ConstRef<VectorMax3d> e1) {
             assert_2D_or_3D_vector(p, "p");
             assert_2D_or_3D_vector(e0, "e0");
             assert_2D_or_3D_vector(e1, "e1");
@@ -89,8 +91,10 @@ void define_tangent_basis(py::module_& m)
 
     m.def(
         "edge_edge_tangent_basis",
-        [](const Eigen::Vector3d& ea0, const Eigen::Vector3d& ea1,
-           const Eigen::Vector3d& eb0, const Eigen::Vector3d& eb1) {
+        [](Eigen::ConstRef<Eigen::Vector3d> ea0,
+           Eigen::ConstRef<Eigen::Vector3d> ea1,
+           Eigen::ConstRef<Eigen::Vector3d> eb0,
+           Eigen::ConstRef<Eigen::Vector3d> eb1) {
             return edge_edge_tangent_basis(ea0, ea1, eb0, eb1);
         },
         R"ipc_Qu8mg5v7(
@@ -109,8 +113,10 @@ void define_tangent_basis(py::module_& m)
 
     m.def(
         "edge_edge_tangent_basis_jacobian",
-        [](const Eigen::Vector3d& ea0, const Eigen::Vector3d& ea1,
-           const Eigen::Vector3d& eb0, const Eigen::Vector3d& eb1) {
+        [](Eigen::ConstRef<Eigen::Vector3d> ea0,
+           Eigen::ConstRef<Eigen::Vector3d> ea1,
+           Eigen::ConstRef<Eigen::Vector3d> eb0,
+           Eigen::ConstRef<Eigen::Vector3d> eb1) {
             return edge_edge_tangent_basis_jacobian(ea0, ea1, eb0, eb1);
         },
         R"ipc_Qu8mg5v7(
@@ -129,8 +135,10 @@ void define_tangent_basis(py::module_& m)
 
     m.def(
         "point_triangle_tangent_basis",
-        [](const Eigen::Vector3d& p, const Eigen::Vector3d& t0,
-           const Eigen::Vector3d& t1, const Eigen::Vector3d& t2) {
+        [](Eigen::ConstRef<Eigen::Vector3d> p,
+           Eigen::ConstRef<Eigen::Vector3d> t0,
+           Eigen::ConstRef<Eigen::Vector3d> t1,
+           Eigen::ConstRef<Eigen::Vector3d> t2) {
             return point_triangle_tangent_basis(p, t0, t1, t2);
         },
         R"ipc_Qu8mg5v7(
@@ -156,8 +164,10 @@ void define_tangent_basis(py::module_& m)
 
     m.def(
         "point_triangle_tangent_basis_jacobian",
-        [](const Eigen::Vector3d& p, const Eigen::Vector3d& t0,
-           const Eigen::Vector3d& t1, const Eigen::Vector3d& t2) {
+        [](Eigen::ConstRef<Eigen::Vector3d> p,
+           Eigen::ConstRef<Eigen::Vector3d> t0,
+           Eigen::ConstRef<Eigen::Vector3d> t1,
+           Eigen::ConstRef<Eigen::Vector3d> t2) {
             return point_triangle_tangent_basis_jacobian(p, t0, t1, t2);
         },
         R"ipc_Qu8mg5v7(

--- a/python/src/utils/intersection.cpp
+++ b/python/src/utils/intersection.cpp
@@ -16,8 +16,10 @@ void define_intersection(py::module_& m)
 
     m.def(
         "segment_segment_intersect",
-        [](const Eigen::Vector2d& A, const Eigen::Vector2d& B,
-           const Eigen::Vector2d& C, const Eigen::Vector2d& D) -> bool {
+        [](Eigen::ConstRef<Eigen::Vector2d> A,
+           Eigen::ConstRef<Eigen::Vector2d> B,
+           Eigen::ConstRef<Eigen::Vector2d> C,
+           Eigen::ConstRef<Eigen::Vector2d> D) -> bool {
             igl::predicates::exactinit();
             return igl::predicates::segment_segment_intersect(A, B, C, D);
         },

--- a/src/ipc/barrier/adaptive_stiffness.cpp
+++ b/src/ipc/barrier/adaptive_stiffness.cpp
@@ -16,8 +16,8 @@ double initial_barrier_stiffness(
     const Barrier& barrier,
     const double dhat,
     const double average_mass,
-    const Eigen::VectorXd& grad_energy,
-    const Eigen::VectorXd& grad_barrier,
+    Eigen::ConstRef<Eigen::VectorXd> grad_energy,
+    Eigen::ConstRef<Eigen::VectorXd> grad_barrier,
     double& max_barrier_stiffness,
     const double min_barrier_stiffness_scale,
     const double dmin)
@@ -88,9 +88,9 @@ double update_barrier_stiffness(
 double semi_implicit_stiffness(
     const CollisionStencil& stencil,
     const std::array<long, 4>& vertex_ids,
-    const VectorMax12d& vertices,
-    const VectorMax4d& mass,
-    const MatrixMax12d& local_hess,
+    Eigen::ConstRef<VectorMax12d> vertices,
+    Eigen::ConstRef<VectorMax4d> mass,
+    Eigen::ConstRef<MatrixMax12d> local_hess,
     const double dmin)
 {
     const unsigned N = stencil.num_vertices();
@@ -125,9 +125,9 @@ double semi_implicit_stiffness(
 template <typename StencilsT>
 Eigen::VectorXd semi_implicit_stiffness(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const StencilsT& collisions,
-    const Eigen::VectorXd& vertex_masses,
+    Eigen::ConstRef<Eigen::VectorXd> vertex_masses,
     const Eigen::SparseMatrix<double>& hess,
     const double dmin)
 {
@@ -183,17 +183,17 @@ Eigen::VectorXd semi_implicit_stiffness(
 
 template Eigen::VectorXd semi_implicit_stiffness<NormalCollisions>(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const NormalCollisions& collisions,
-    const Eigen::VectorXd& vertex_masses,
+    Eigen::ConstRef<Eigen::VectorXd> vertex_masses,
     const Eigen::SparseMatrix<double>& hess,
     const double dmin);
 
 template Eigen::VectorXd semi_implicit_stiffness<Candidates>(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const Candidates& collisions,
-    const Eigen::VectorXd& vertex_masses,
+    Eigen::ConstRef<Eigen::VectorXd> vertex_masses,
     const Eigen::SparseMatrix<double>& hess,
     const double dmin);
 

--- a/src/ipc/barrier/adaptive_stiffness.hpp
+++ b/src/ipc/barrier/adaptive_stiffness.hpp
@@ -26,8 +26,8 @@ double initial_barrier_stiffness(
     const Barrier& barrier,
     const double dhat,
     const double average_mass,
-    const Eigen::VectorXd& grad_energy,
-    const Eigen::VectorXd& grad_barrier,
+    Eigen::ConstRef<Eigen::VectorXd> grad_energy,
+    Eigen::ConstRef<Eigen::VectorXd> grad_barrier,
     double& max_barrier_stiffness,
     const double min_barrier_stiffness_scale = 1e11,
     const double dmin = 0);
@@ -62,9 +62,9 @@ double update_barrier_stiffness(
 double semi_implicit_stiffness(
     const CollisionStencil& stencil,
     const std::array<long, 4>& vertex_ids,
-    const VectorMax12d& vertices,
-    const VectorMax4d& mass,
-    const MatrixMax12d& local_hess,
+    Eigen::ConstRef<VectorMax12d> vertices,
+    Eigen::ConstRef<VectorMax4d> mass,
+    Eigen::ConstRef<MatrixMax12d> local_hess,
     const double dmin);
 
 /// @brief Compute the semi-implicit stiffness's for all collisions.
@@ -79,9 +79,9 @@ double semi_implicit_stiffness(
 template <typename StencilsT>
 Eigen::VectorXd semi_implicit_stiffness(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const StencilsT& collisions,
-    const Eigen::VectorXd& vertex_masses,
+    Eigen::ConstRef<Eigen::VectorXd> vertex_masses,
     const Eigen::SparseMatrix<double>& hess,
     const double dmin);
 

--- a/src/ipc/barrier/barrier_force_magnitude.cpp
+++ b/src/ipc/barrier/barrier_force_magnitude.cpp
@@ -16,7 +16,7 @@ double barrier_force_magnitude(
 
 VectorMax12d barrier_force_magnitude_gradient(
     const double distance_squared,
-    const VectorMax12d& distance_squared_gradient,
+    Eigen::ConstRef<VectorMax12d> distance_squared_gradient,
     const Barrier& barrier,
     const double dhat,
     const double barrier_stiffness,

--- a/src/ipc/barrier/barrier_force_magnitude.hpp
+++ b/src/ipc/barrier/barrier_force_magnitude.hpp
@@ -29,7 +29,7 @@ double barrier_force_magnitude(
 /// @return The gradient of the force.
 VectorMax12d barrier_force_magnitude_gradient(
     const double distance_squared,
-    const VectorMax12d& distance_squared_gradient,
+    Eigen::ConstRef<VectorMax12d> distance_squared_gradient,
     const Barrier& barrier,
     const double dhat,
     const double barrier_stiffness,

--- a/src/ipc/broad_phase/aabb.cpp
+++ b/src/ipc/broad_phase/aabb.cpp
@@ -7,7 +7,7 @@
 
 namespace ipc {
 
-AABB::AABB(const ArrayMax3d& _min, const ArrayMax3d& _max)
+AABB::AABB(Eigen::ConstRef<ArrayMax3d> _min, Eigen::ConstRef<ArrayMax3d> _max)
     : min(_min)
     , max(_max)
 {
@@ -17,7 +17,8 @@ AABB::AABB(const ArrayMax3d& _min, const ArrayMax3d& _max)
     // center = min() + half_extent();
 }
 
-AABB AABB::from_point(const VectorMax3d& p, const double inflation_radius)
+AABB AABB::from_point(
+    Eigen::ConstRef<VectorMax3d> p, const double inflation_radius)
 {
     ArrayMax3d min = p.array(), max = p.array();
     conservative_inflation(min, max, inflation_radius);
@@ -44,7 +45,9 @@ bool AABB::intersects(const AABB& other) const
 }
 
 void AABB::conservative_inflation(
-    ArrayMax3d& min, ArrayMax3d& max, const double inflation_radius)
+    Eigen::Ref<ArrayMax3d> min,
+    Eigen::Ref<ArrayMax3d> max,
+    const double inflation_radius)
 {
 #pragma STDC FENV_ACCESS ON
     const int current_round = std::fegetround();
@@ -59,7 +62,7 @@ void AABB::conservative_inflation(
 }
 
 void build_vertex_boxes(
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     std::vector<AABB>& vertex_boxes,
     const double inflation_radius)
 {
@@ -77,8 +80,8 @@ void build_vertex_boxes(
 }
 
 void build_vertex_boxes(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     std::vector<AABB>& vertex_boxes,
     const double inflation_radius)
 {
@@ -97,7 +100,7 @@ void build_vertex_boxes(
 
 void build_edge_boxes(
     const std::vector<AABB>& vertex_boxes,
-    const Eigen::MatrixXi& edges,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
     std::vector<AABB>& edge_boxes)
 {
     edge_boxes.resize(edges.rows());
@@ -115,7 +118,7 @@ void build_edge_boxes(
 
 void build_face_boxes(
     const std::vector<AABB>& vertex_boxes,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     std::vector<AABB>& face_boxes)
 {
     face_boxes.resize(faces.rows());

--- a/src/ipc/broad_phase/aabb.hpp
+++ b/src/ipc/broad_phase/aabb.hpp
@@ -11,7 +11,7 @@ class AABB {
 public:
     AABB() = default;
 
-    AABB(const ArrayMax3d& min, const ArrayMax3d& max);
+    AABB(Eigen::ConstRef<ArrayMax3d> min, Eigen::ConstRef<ArrayMax3d> max);
 
     AABB(const AABB& aabb1, const AABB& aabb2)
         : AABB(aabb1.min.min(aabb2.min), aabb1.max.max(aabb2.max))
@@ -29,8 +29,8 @@ public:
     /// @param p The point's position.
     /// @param inflation_radius Radius of a sphere around the point which the AABB encloses.
     /// @return The constructed AABB.
-    static AABB
-    from_point(const VectorMax3d& p, const double inflation_radius = 0);
+    static AABB from_point(
+        Eigen::ConstRef<VectorMax3d> p, const double inflation_radius = 0);
 
     /// @brief Construct an AABB for a moving point (i.e. temporal edge).
     /// @param p_t0 The point's position at time t=0.
@@ -38,8 +38,8 @@ public:
     /// @param inflation_radius Radius of a capsule around the temporal edge which the AABB encloses.
     /// @return The constructed AABB.
     static AABB from_point(
-        const VectorMax3d& p_t0,
-        const VectorMax3d& p_t1,
+        Eigen::ConstRef<VectorMax3d> p_t0,
+        Eigen::ConstRef<VectorMax3d> p_t1,
         const double inflation_radius = 0)
     {
         return AABB(
@@ -54,7 +54,9 @@ public:
 
     /// @brief Compute a conservative inflation of the AABB.
     static void conservative_inflation(
-        ArrayMax3d& min, ArrayMax3d& max, const double inflation_radius);
+        Eigen::Ref<ArrayMax3d> min,
+        Eigen::Ref<ArrayMax3d> max,
+        const double inflation_radius);
 
 public:
     /// @brief Minimum corner of the AABB.
@@ -70,7 +72,7 @@ public:
 /// @param[out] vertex_boxes Vertex AABBs.
 /// @param[in] inflation_radius Radius of a sphere around the points which the AABBs enclose.
 void build_vertex_boxes(
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     std::vector<AABB>& vertex_boxes,
     const double inflation_radius = 0);
 
@@ -80,8 +82,8 @@ void build_vertex_boxes(
 /// @param vertex_boxes Vertex AABBs.
 /// @param inflation_radius Radius of a capsule around the temporal edges which the AABBs enclose.
 void build_vertex_boxes(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     std::vector<AABB>& vertex_boxes,
     const double inflation_radius = 0);
 
@@ -91,7 +93,7 @@ void build_vertex_boxes(
 /// @param edge_boxes Edge AABBs.
 void build_edge_boxes(
     const std::vector<AABB>& vertex_boxes,
-    const Eigen::MatrixXi& edges,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
     std::vector<AABB>& edge_boxes);
 
 /// @brief Build one AABB per face.
@@ -100,7 +102,7 @@ void build_edge_boxes(
 /// @param face_boxes Face AABBs.
 void build_face_boxes(
     const std::vector<AABB>& vertex_boxes,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     std::vector<AABB>& face_boxes);
 
 } // namespace ipc

--- a/src/ipc/broad_phase/broad_phase.cpp
+++ b/src/ipc/broad_phase/broad_phase.cpp
@@ -12,9 +12,9 @@
 namespace ipc {
 
 void BroadPhase::build(
-    const Eigen::MatrixXd& vertices,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     assert(edges.size() == 0 || edges.cols() == 2);
@@ -26,10 +26,10 @@ void BroadPhase::build(
 }
 
 void BroadPhase::build(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     assert(edges.size() == 0 || edges.cols() == 2);

--- a/src/ipc/broad_phase/broad_phase.hpp
+++ b/src/ipc/broad_phase/broad_phase.hpp
@@ -29,9 +29,9 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     virtual void build(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         const double inflation_radius = 0);
 
     /// @brief Build the broad phase for continuous collision detection.
@@ -41,10 +41,10 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     virtual void build(
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         const double inflation_radius = 0);
 
     /// @brief Clear any built data.

--- a/src/ipc/broad_phase/bvh.cpp
+++ b/src/ipc/broad_phase/bvh.cpp
@@ -11,9 +11,9 @@ using namespace std::placeholders;
 namespace ipc {
 
 void BVH::build(
-    const Eigen::MatrixXd& vertices,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     BroadPhase::build(vertices, edges, faces, inflation_radius);
@@ -23,10 +23,10 @@ void BVH::build(
 }
 
 void BVH::build(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     BroadPhase::build(vertices_t0, vertices_t1, edges, faces, inflation_radius);

--- a/src/ipc/broad_phase/bvh.hpp
+++ b/src/ipc/broad_phase/bvh.hpp
@@ -20,9 +20,9 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     void build(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         const double inflation_radius = 0) override;
 
     /// @brief Build the broad phase for continuous collision detection.
@@ -32,10 +32,10 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     void build(
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         const double inflation_radius = 0) override;
 
     /// @brief Clear any built data.

--- a/src/ipc/broad_phase/hash_grid.cpp
+++ b/src/ipc/broad_phase/hash_grid.cpp
@@ -18,9 +18,9 @@ using namespace std::placeholders;
 namespace ipc {
 
 void HashGrid::build(
-    const Eigen::MatrixXd& vertices,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     BroadPhase::build(vertices, edges, faces, inflation_radius);
@@ -38,10 +38,10 @@ void HashGrid::build(
 }
 
 void HashGrid::build(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     BroadPhase::build(vertices_t0, vertices_t1, edges, faces, inflation_radius);
@@ -64,8 +64,8 @@ void HashGrid::build(
 }
 
 void HashGrid::resize(
-    const ArrayMax3d& domain_min,
-    const ArrayMax3d& domain_max,
+    Eigen::ConstRef<ArrayMax3d> domain_min,
+    Eigen::ConstRef<ArrayMax3d> domain_max,
     double cell_size)
 {
     assert(cell_size != 0.0);

--- a/src/ipc/broad_phase/hash_grid.hpp
+++ b/src/ipc/broad_phase/hash_grid.hpp
@@ -38,9 +38,9 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     void build(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0) override;
 
     /// @brief Build the broad phase for continuous collision detection.
@@ -50,10 +50,10 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     void build(
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0) override;
 
     /// @brief Clear the hash grid.
@@ -101,8 +101,8 @@ public:
 
 protected:
     void resize(
-        const ArrayMax3d& domain_min,
-        const ArrayMax3d& domain_max,
+        Eigen::ConstRef<ArrayMax3d> domain_min,
+        Eigen::ConstRef<ArrayMax3d> domain_max,
         double cell_size);
 
     void insert_boxes();

--- a/src/ipc/broad_phase/spatial_hash.cpp
+++ b/src/ipc/broad_phase/spatial_hash.cpp
@@ -31,9 +31,9 @@ namespace {
     }
 
     void fill_primitive_to_voxels(
-        const Eigen::Array3i& min_voxel,
-        const Eigen::Array3i& max_voxel,
-        const ArrayMax3i& voxel_count,
+        Eigen::ConstRef<Eigen::Array3i> min_voxel,
+        Eigen::ConstRef<Eigen::Array3i> max_voxel,
+        Eigen::ConstRef<ArrayMax3i> voxel_count,
         const int voxel_count_0x1,
         std::vector<int>& primitive_to_voxels)
     {
@@ -70,9 +70,9 @@ namespace {
 } // namespace
 
 void SpatialHash::build(
-    const Eigen::MatrixXd& vertices,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     double inflation_radius,
     double voxel_size)
 {
@@ -80,10 +80,10 @@ void SpatialHash::build(
 }
 
 void SpatialHash::build(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     double inflation_radius,
     double voxel_size)
 {
@@ -405,12 +405,13 @@ void SpatialHash::detect_face_face_candidates(
 
 // ============================================================================
 
-int SpatialHash::locate_voxel_index(const VectorMax3d& p) const
+int SpatialHash::locate_voxel_index(Eigen::ConstRef<VectorMax3d> p) const
 {
     return voxel_axis_index_to_voxel_index(locate_voxel_axis_index(p));
 }
 
-ArrayMax3i SpatialHash::locate_voxel_axis_index(const VectorMax3d& p) const
+ArrayMax3i
+SpatialHash::locate_voxel_axis_index(Eigen::ConstRef<VectorMax3d> p) const
 {
     return ((p.array() - left_bottom_corner) * one_div_voxelSize)
         .floor()
@@ -418,10 +419,10 @@ ArrayMax3i SpatialHash::locate_voxel_axis_index(const VectorMax3d& p) const
 }
 
 void SpatialHash::locate_box_voxel_axis_index(
-    ArrayMax3d min_corner, // input but will be modified
-    ArrayMax3d max_corner, // input but will be modified
-    ArrayMax3i& min_index, // output
-    ArrayMax3i& max_index, // output
+    ArrayMax3d min_corner,            // input but will be modified
+    ArrayMax3d max_corner,            // input but will be modified
+    Eigen::Ref<ArrayMax3i> min_index, // output
+    Eigen::Ref<ArrayMax3i> max_index, // output
     const double inflation_radius) const
 {
     AABB::conservative_inflation(min_corner, max_corner, inflation_radius);
@@ -430,7 +431,7 @@ void SpatialHash::locate_box_voxel_axis_index(
 }
 
 int SpatialHash::voxel_axis_index_to_voxel_index(
-    const ArrayMax3i& voxel_axis_index) const
+    Eigen::ConstRef<ArrayMax3i> voxel_axis_index) const
 {
     return voxel_axis_index_to_voxel_index(
         voxel_axis_index[0], voxel_axis_index[1],

--- a/src/ipc/broad_phase/spatial_hash.hpp
+++ b/src/ipc/broad_phase/spatial_hash.hpp
@@ -52,9 +52,9 @@ public: // constructor
     SpatialHash() = default;
 
     SpatialHash(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0,
         double voxel_size = -1)
     {
@@ -62,10 +62,10 @@ public: // constructor
     }
 
     SpatialHash(
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0,
         double voxel_size = -1)
     {
@@ -80,19 +80,19 @@ public: // constructor
 
 public: // API
     void build(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0) override
     {
         build(vertices, edges, faces, inflation_radius, /*voxel_size=*/-1);
     }
 
     void build(
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0) override
     {
         build(
@@ -101,17 +101,17 @@ public: // API
     }
 
     void build(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius,
         double voxel_size);
 
     void build(
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius,
         double voxel_size);
 
@@ -197,19 +197,19 @@ protected: // helper functions
     void
     query_triangle_for_triangles(int ti, unordered_set<int>& tri_inds) const;
 
-    int locate_voxel_index(const VectorMax3d& p) const;
+    int locate_voxel_index(Eigen::ConstRef<VectorMax3d> p) const;
 
-    ArrayMax3i locate_voxel_axis_index(const VectorMax3d& p) const;
+    ArrayMax3i locate_voxel_axis_index(Eigen::ConstRef<VectorMax3d> p) const;
 
     void locate_box_voxel_axis_index(
         ArrayMax3d min_corner,
         ArrayMax3d max_corner,
-        ArrayMax3i& min_index,
-        ArrayMax3i& max_index,
+        Eigen::Ref<ArrayMax3i> min_index,
+        Eigen::Ref<ArrayMax3i> max_index,
         const double inflation_radius = 0) const;
 
-    int
-    voxel_axis_index_to_voxel_index(const ArrayMax3i& voxel_axis_index) const;
+    int voxel_axis_index_to_voxel_index(
+        Eigen::ConstRef<ArrayMax3i> voxel_axis_index) const;
 
     int voxel_axis_index_to_voxel_index(int ix, int iy, int iz) const;
 

--- a/src/ipc/broad_phase/sweep_and_prune.cpp
+++ b/src/ipc/broad_phase/sweep_and_prune.cpp
@@ -5,9 +5,9 @@
 namespace ipc {
 
 void SweepAndPrune::build(
-    const Eigen::MatrixXd& vertices,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     assert(edges.size() == 0 || edges.cols() == 2);
@@ -21,10 +21,10 @@ void SweepAndPrune::build(
 }
 
 void SweepAndPrune::build(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     assert(edges.size() == 0 || edges.cols() == 2);

--- a/src/ipc/broad_phase/sweep_and_prune.hpp
+++ b/src/ipc/broad_phase/sweep_and_prune.hpp
@@ -20,9 +20,9 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     void build(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0) override;
 
     /// @brief Build the broad phase for continuous collision detection.
@@ -32,10 +32,10 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     void build(
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0) override;
 
     /// @brief Clear any built data.

--- a/src/ipc/broad_phase/sweep_and_tiniest_queue.cpp
+++ b/src/ipc/broad_phase/sweep_and_tiniest_queue.cpp
@@ -7,9 +7,9 @@
 namespace ipc {
 
 void SweepAndTiniestQueue::build(
-    const Eigen::MatrixXd& _vertices,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> _vertices,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     assert(edges.size() == 0 || edges.cols() == 2);
@@ -34,10 +34,10 @@ void SweepAndTiniestQueue::build(
 }
 
 void SweepAndTiniestQueue::build(
-    const Eigen::MatrixXd& _vertices_t0,
-    const Eigen::MatrixXd& _vertices_t1,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> _vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> _vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const double inflation_radius)
 {
     assert(_vertices_t0.rows() == _vertices_t1.rows());

--- a/src/ipc/broad_phase/sweep_and_tiniest_queue.hpp
+++ b/src/ipc/broad_phase/sweep_and_tiniest_queue.hpp
@@ -24,9 +24,9 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     void build(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0) override;
 
     /// @brief Build the broad phase for continuous collision detection.
@@ -36,10 +36,10 @@ public:
     /// @param faces Collision mesh faces
     /// @param inflation_radius Radius of inflation around all elements.
     void build(
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
         double inflation_radius = 0) override;
 
     /// @brief Clear any built data.

--- a/src/ipc/broad_phase/voxel_size_heuristic.cpp
+++ b/src/ipc/broad_phase/voxel_size_heuristic.cpp
@@ -15,8 +15,8 @@ namespace {
 } // namespace
 
 double suggest_good_voxel_size(
-    const Eigen::MatrixXd& vertices,
-    const Eigen::MatrixXi& edges,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
     const double inflation_radius)
 {
     // double edge_len_std_deviation;
@@ -41,9 +41,9 @@ double suggest_good_voxel_size(
 }
 
 double suggest_good_voxel_size(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
     const double inflation_radius)
 {
     // double edge_len_std_deviation;
@@ -78,9 +78,9 @@ double suggest_good_voxel_size(
 }
 
 double mean_edge_length(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
     double& std_deviation)
 {
     if (edges.rows() == 0) {
@@ -110,7 +110,7 @@ double mean_edge_length(
 }
 
 double mean_displacement_length(
-    const Eigen::MatrixXd& displacements, double& std_deviation)
+    Eigen::ConstRef<Eigen::MatrixXd> displacements, double& std_deviation)
 {
     const double mean = displacements.rowwise().norm().mean();
     std_deviation = sqrt(
@@ -120,9 +120,9 @@ double mean_displacement_length(
 }
 
 double median_edge_length(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges)
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges)
 {
     if (edges.rows() == 0) {
         return 0;
@@ -142,7 +142,8 @@ double median_edge_length(
     return median;
 }
 
-double median_displacement_length(const Eigen::MatrixXd& displacements)
+double
+median_displacement_length(Eigen::ConstRef<Eigen::MatrixXd> displacements)
 {
     double median = -1;
     check_success(igl::median(displacements.rowwise().norm(), median));
@@ -150,9 +151,9 @@ double median_displacement_length(const Eigen::MatrixXd& displacements)
 }
 
 double max_edge_length(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges)
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges)
 {
     double max_edge = -std::numeric_limits<double>::infinity();
     for (int i = 0; i < edges.rows(); i++) {
@@ -166,7 +167,7 @@ double max_edge_length(
     return max_edge;
 }
 
-double max_displacement_length(const Eigen::MatrixXd& displacements)
+double max_displacement_length(Eigen::ConstRef<Eigen::MatrixXd> displacements)
 {
     return displacements.rowwise().norm().maxCoeff();
 }

--- a/src/ipc/broad_phase/voxel_size_heuristic.hpp
+++ b/src/ipc/broad_phase/voxel_size_heuristic.hpp
@@ -1,47 +1,48 @@
 #pragma once
 
-#include <Eigen/Core>
+#include <ipc/utils/eigen_ext.hpp>
 
 namespace ipc {
 
 double suggest_good_voxel_size(
-    const Eigen::MatrixXd& vertices,
-    const Eigen::MatrixXi& edges,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
     const double inflation_radius = 0);
 
 double suggest_good_voxel_size(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
     const double inflation_radius = 0);
 
 /// @brief Compute the average edge length of a mesh.
 double mean_edge_length(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
     double& std_deviation);
 
 /// @brief Compute the average displacement length.
 double mean_displacement_length(
-    const Eigen::MatrixXd& displacements, double& std_deviation);
+    Eigen::ConstRef<Eigen::MatrixXd> displacements, double& std_deviation);
 
 /// @brief Compute the median edge length of a mesh.
 double median_edge_length(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges);
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges);
 
 /// @brief Compute the median displacement length.
-double median_displacement_length(const Eigen::MatrixXd& displacements);
+double
+median_displacement_length(Eigen::ConstRef<Eigen::MatrixXd> displacements);
 
 /// @brief Compute the maximum edge length of a mesh.
 double max_edge_length(
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
-    const Eigen::MatrixXi& edges);
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXi> edges);
 
 /// @brief Compute the maximum displacement length.
-double max_displacement_length(const Eigen::MatrixXd& displacements);
+double max_displacement_length(Eigen::ConstRef<Eigen::MatrixXd> displacements);
 
 } // namespace ipc

--- a/src/ipc/candidates/candidates.cpp
+++ b/src/ipc/candidates/candidates.cpp
@@ -17,7 +17,7 @@ namespace ipc {
 
 namespace {
     // Pad codim_edges because remove_unreferenced requires a N×3 matrix.
-    Eigen::MatrixXi pad_edges(const Eigen::MatrixXi& E)
+    Eigen::MatrixXi pad_edges(Eigen::ConstRef<Eigen::MatrixXi> E)
     {
         assert(E.cols() == 2);
         Eigen::MatrixXi E_padded(E.rows(), 3);
@@ -26,7 +26,7 @@ namespace {
         return E_padded;
     }
 
-    Eigen::MatrixXi unpad_edges(const Eigen::MatrixXi& E_padded)
+    Eigen::MatrixXi unpad_edges(Eigen::ConstRef<Eigen::MatrixXi> E_padded)
     {
         return E_padded.leftCols(2);
     }
@@ -34,7 +34,7 @@ namespace {
 
 void Candidates::build(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const double inflation_radius,
     const std::shared_ptr<BroadPhase> broad_phase)
 {
@@ -105,8 +105,8 @@ void Candidates::build(
 
 void Candidates::build(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     const double inflation_radius,
     const std::shared_ptr<BroadPhase> broad_phase)
 {
@@ -185,8 +185,8 @@ void Candidates::build(
 
 bool Candidates::is_step_collision_free(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     const double min_distance,
     const NarrowPhaseCCD& narrow_phase_ccd) const
 {
@@ -213,8 +213,8 @@ bool Candidates::is_step_collision_free(
 
 double Candidates::compute_collision_free_stepsize(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     const double min_distance,
     const NarrowPhaseCCD& narrow_phase_ccd) const
 {
@@ -263,7 +263,7 @@ double Candidates::compute_collision_free_stepsize(
 
 double Candidates::compute_noncandidate_conservative_stepsize(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& displacements,
+    Eigen::ConstRef<Eigen::MatrixXd> displacements,
     const double dhat) const
 {
     assert(displacements.rows() == mesh.num_vertices());
@@ -272,8 +272,8 @@ double Candidates::compute_noncandidate_conservative_stepsize(
         return 1; // No possible collisions, so can take full step.
     }
 
-    const auto& E = mesh.edges();
-    const auto& F = mesh.faces();
+    const Eigen::MatrixXi& E = mesh.edges();
+    const Eigen::MatrixXi& F = mesh.faces();
 
     std::vector<bool> is_vertex_a_candidates(mesh.num_vertices(), false);
     for (size_t i = 0; i < size(); i++) {
@@ -299,8 +299,8 @@ double Candidates::compute_noncandidate_conservative_stepsize(
 
 double Candidates::compute_cfl_stepsize(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     const double dhat,
     const double min_distance,
     const std::shared_ptr<BroadPhase> broad_phase,
@@ -386,9 +386,9 @@ const CollisionStencil& Candidates::operator[](size_t i) const
 
 bool Candidates::save_obj(
     const std::string& filename,
-    const Eigen::MatrixXd& vertices,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces) const
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces) const
 {
     std::ofstream obj(filename, std::ios::out);
     if (!obj.is_open()) {

--- a/src/ipc/candidates/candidates.hpp
+++ b/src/ipc/candidates/candidates.hpp
@@ -23,7 +23,7 @@ public:
     /// @param broad_phase_method Broad phase method to use.
     void build(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const double inflation_radius = 0,
         const std::shared_ptr<BroadPhase> broad_phase =
             make_default_broad_phase());
@@ -37,8 +37,8 @@ public:
     /// @param broad_phase_method Broad phase method to use.
     void build(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
         const double inflation_radius = 0,
         const std::shared_ptr<BroadPhase> broad_phase =
             make_default_broad_phase());
@@ -62,8 +62,8 @@ public:
     /// @returns True if <b>any</b> collisions occur.
     bool is_step_collision_free(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
         const double min_distance = 0.0,
         const NarrowPhaseCCD& narrow_phase_ccd =
             DEFAULT_NARROW_PHASE_CCD) const;
@@ -78,8 +78,8 @@ public:
     /// @returns A step-size \f$\in [0, 1]\f$ that is collision free. A value of 1.0 if a full step and 0.0 is no step.
     double compute_collision_free_stepsize(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
         const double min_distance = 0.0,
         const NarrowPhaseCCD& narrow_phase_ccd =
             DEFAULT_NARROW_PHASE_CCD) const;
@@ -90,7 +90,7 @@ public:
     /// @param dhat Barrier activation distance.
     double compute_noncandidate_conservative_stepsize(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& displacements,
+        Eigen::ConstRef<Eigen::MatrixXd> displacements,
         const double dhat) const;
 
     /// @brief Computes a CFL-inspired CCD maximum step step size.
@@ -102,8 +102,8 @@ public:
     /// @param narrow_phase_ccd The narrow phase CCD algorithm to use.
     double compute_cfl_stepsize(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices_t0,
-        const Eigen::MatrixXd& vertices_t1,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
         const double dhat,
         const double min_distance = 0.0,
         const std::shared_ptr<BroadPhase> broad_phase =
@@ -113,9 +113,9 @@ public:
 
     bool save_obj(
         const std::string& filename,
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const;
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const;
 
 public:
     std::vector<VertexVertexCandidate> vv_candidates;

--- a/src/ipc/candidates/collision_stencil.cpp
+++ b/src/ipc/candidates/collision_stencil.cpp
@@ -4,8 +4,8 @@ namespace ipc {
 
 std::ostream& CollisionStencil::write_ccd_query(
     std::ostream& out,
-    const VectorMax12d& vertices_t0,
-    const VectorMax12d& vertices_t1) const
+    Eigen::ConstRef<VectorMax12d> vertices_t0,
+    Eigen::ConstRef<VectorMax12d> vertices_t1) const
 {
     assert(vertices_t0.size() == vertices_t1.size());
 

--- a/src/ipc/candidates/collision_stencil.hpp
+++ b/src/ipc/candidates/collision_stencil.hpp
@@ -31,7 +31,8 @@ public:
     /// @param faces Collision mesh faces
     /// @return The vertex IDs of the collision stencil. Size is always 4, but elements i > num_vertices() are -1.
     virtual std::array<long, 4> vertex_ids(
-        const Eigen::MatrixXi& edges, const Eigen::MatrixXi& faces) const = 0;
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const = 0;
 
     /// @brief Get the vertex attributes of the collision stencil.
     /// @tparam T Type of the attributes
@@ -39,22 +40,21 @@ public:
     /// @param edges Collision mesh edges
     /// @param faces Collision mesh faces
     /// @return The vertex positions of the collision stencil. Size is always 4, but elements i > num_vertices() are NaN.
-    template <typename T>
-    std::array<VectorMax3<T>, 4> vertices(
-        const Eigen::MatrixX<T>& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const
+    std::array<VectorMax3d, 4> vertices(
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const
     {
         constexpr double NaN = std::numeric_limits<double>::signaling_NaN();
 
         const std::array<long, 4> vertex_ids = this->vertex_ids(edges, faces);
 
-        std::array<VectorMax3<T>, 4> stencil_vertices;
+        std::array<VectorMax3d, 4> stencil_vertices;
         for (int i = 0; i < 4; i++) {
             if (vertex_ids[i] >= 0) {
                 stencil_vertices[i] = vertices.row(vertex_ids[i]);
             } else {
-                stencil_vertices[i].setConstant(vertices.cols(), T(NaN));
+                stencil_vertices[i].setConstant(vertices.cols(), NaN);
             }
         }
 
@@ -67,14 +67,13 @@ public:
     /// @param edges Collision mesh edges
     /// @param faces Collision mesh faces
     /// @return This stencil's DOF.
-    template <typename T>
-    VectorMax12<T>
-    dof(const Eigen::MatrixX<T>& X,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const
+    VectorMax12d
+    dof(Eigen::ConstRef<Eigen::MatrixXd> X,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const
     {
         const int dim = X.cols();
-        VectorMax12<T> x(num_vertices() * dim);
+        VectorMax12d x(num_vertices() * dim);
         const std::array<long, 4> idx = vertex_ids(edges, faces);
         for (int i = 0; i < num_vertices(); i++) {
             x.segment(i * dim, dim) = X.row(idx[i]);
@@ -88,9 +87,9 @@ public:
     /// @param faces Collision mesh faces
     /// @return Distance of the stencil.
     double compute_distance(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const
     {
         return compute_distance(dof(vertices, edges, faces));
     }
@@ -101,9 +100,9 @@ public:
     /// @param faces Collision mesh faces
     /// @return Distance gradient of the stencil w.r.t. the stencil's vertex positions.
     VectorMax12d compute_distance_gradient(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const
     {
         return compute_distance_gradient(dof(vertices, edges, faces));
     }
@@ -114,9 +113,9 @@ public:
     /// @param faces Collision mesh faces
     /// @return Distance Hessian of the stencil w.r.t. the stencil's vertex positions.
     MatrixMax12d compute_distance_hessian(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const
     {
         return compute_distance_hessian(dof(vertices, edges, faces));
     }
@@ -127,9 +126,9 @@ public:
     /// @param faces Collision mesh faces
     /// @return Coefficients of the stencil.
     VectorMax4d compute_coefficients(
-        const Eigen::MatrixXd& vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const
     {
         return compute_coefficients(dof(vertices, edges, faces));
     }
@@ -142,27 +141,28 @@ public:
     /// @param positions Stencil's vertex positions.
     /// @note positions can be computed as stencil.dof(vertices, edges, faces)
     /// @return Distance of the stencil.
-    virtual double compute_distance(const VectorMax12d& positions) const = 0;
+    virtual double
+    compute_distance(Eigen::ConstRef<VectorMax12d> positions) const = 0;
 
     /// @brief Compute the distance gradient of the stencil w.r.t. the stencil's vertex positions.
     /// @param positions Stencil's vertex positions.
     /// @note positions can be computed as stencil.dof(vertices, edges, faces)
     /// @return Distance gradient of the stencil w.r.t. the stencil's vertex positions.
-    virtual VectorMax12d
-    compute_distance_gradient(const VectorMax12d& positions) const = 0;
+    virtual VectorMax12d compute_distance_gradient(
+        Eigen::ConstRef<VectorMax12d> positions) const = 0;
 
     /// @brief Compute the distance Hessian of the stencil w.r.t. the stencil's vertex positions.
     /// @param positions Stencil's vertex positions.
     /// @note positions can be computed as stencil.dof(vertices, edges, faces)
     /// @return Distance Hessian of the stencil w.r.t. the stencil's vertex positions.
     virtual MatrixMax12d
-    compute_distance_hessian(const VectorMax12d& positions) const = 0;
+    compute_distance_hessian(Eigen::ConstRef<VectorMax12d> positions) const = 0;
 
     /// @brief Compute the coefficients of the stencil s.t. d(x) = ‖∑ cᵢ xᵢ‖².
     /// @param positions Stencil's vertex positions.
     /// @return Coefficients of the stencil.
     virtual VectorMax4d
-    compute_coefficients(const VectorMax12d& positions) const = 0;
+    compute_coefficients(Eigen::ConstRef<VectorMax12d> positions) const = 0;
 
     /// @brief Perform narrow-phase CCD on the candidate.
     /// @param[in] vertices_t0 Stencil vertices at the start of the time step.
@@ -173,8 +173,8 @@ public:
     /// @param[in] narrow_phase_ccd The narrow phase CCD algorithm to use.
     /// @return If the candidate had a collision over the time interval.
     virtual bool
-    ccd(const VectorMax12d& vertices_t0,
-        const VectorMax12d& vertices_t1,
+    ccd(Eigen::ConstRef<VectorMax12d> vertices_t0,
+        Eigen::ConstRef<VectorMax12d> vertices_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0,
@@ -188,8 +188,8 @@ public:
     /// @return The stream.
     std::ostream& write_ccd_query(
         std::ostream& out,
-        const VectorMax12d& vertices_t0,
-        const VectorMax12d& vertices_t1) const;
+        Eigen::ConstRef<VectorMax12d> vertices_t0,
+        Eigen::ConstRef<VectorMax12d> vertices_t1) const;
 };
 
 } // namespace ipc

--- a/src/ipc/candidates/edge_edge.cpp
+++ b/src/ipc/candidates/edge_edge.cpp
@@ -11,7 +11,8 @@ EdgeEdgeCandidate::EdgeEdgeCandidate(long _edge0_id, long _edge1_id)
 {
 }
 
-double EdgeEdgeCandidate::compute_distance(const VectorMax12d& positions) const
+double EdgeEdgeCandidate::compute_distance(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 12);
     return edge_edge_distance(
@@ -20,7 +21,7 @@ double EdgeEdgeCandidate::compute_distance(const VectorMax12d& positions) const
 }
 
 VectorMax12d EdgeEdgeCandidate::compute_distance_gradient(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 12);
     return edge_edge_distance_gradient(
@@ -28,8 +29,8 @@ VectorMax12d EdgeEdgeCandidate::compute_distance_gradient(
         positions.tail<3>(), known_dtype());
 }
 
-MatrixMax12d
-EdgeEdgeCandidate::compute_distance_hessian(const VectorMax12d& positions) const
+MatrixMax12d EdgeEdgeCandidate::compute_distance_hessian(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 12);
     return edge_edge_distance_hessian(
@@ -37,14 +38,14 @@ EdgeEdgeCandidate::compute_distance_hessian(const VectorMax12d& positions) const
         positions.tail<3>(), known_dtype());
 }
 
-VectorMax4d
-EdgeEdgeCandidate::compute_coefficients(const VectorMax12d& positions) const
+VectorMax4d EdgeEdgeCandidate::compute_coefficients(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 12);
-    const Eigen::Ref<const Eigen::Vector3d> ea0 = positions.head<3>();
-    const Eigen::Ref<const Eigen::Vector3d> ea1 = positions.segment<3>(3);
-    const Eigen::Ref<const Eigen::Vector3d> eb0 = positions.segment<3>(6);
-    const Eigen::Ref<const Eigen::Vector3d> eb1 = positions.tail<3>();
+    Eigen::ConstRef<Eigen::Vector3d> ea0 = positions.head<3>();
+    Eigen::ConstRef<Eigen::Vector3d> ea1 = positions.segment<3>(3);
+    Eigen::ConstRef<Eigen::Vector3d> eb0 = positions.segment<3>(6);
+    Eigen::ConstRef<Eigen::Vector3d> eb1 = positions.tail<3>();
 
     // Project the point inside the triangle
     auto dtype = known_dtype();
@@ -95,8 +96,8 @@ EdgeEdgeCandidate::compute_coefficients(const VectorMax12d& positions) const
 }
 
 bool EdgeEdgeCandidate::ccd(
-    const VectorMax12d& vertices_t0,
-    const VectorMax12d& vertices_t1,
+    Eigen::ConstRef<VectorMax12d> vertices_t0,
+    Eigen::ConstRef<VectorMax12d> vertices_t1,
     double& toi,
     const double min_distance,
     const double tmax,

--- a/src/ipc/candidates/edge_edge.hpp
+++ b/src/ipc/candidates/edge_edge.hpp
@@ -19,8 +19,8 @@ public:
     int num_vertices() const override { return 4; };
 
     std::array<long, 4> vertex_ids(
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const override
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
         return { { edges(edge0_id, 0), edges(edge0_id, 1), //
                    edges(edge1_id, 0), edges(edge1_id, 1) } };
@@ -31,22 +31,23 @@ public:
     using CollisionStencil::compute_distance_gradient;
     using CollisionStencil::compute_distance_hessian;
 
-    double compute_distance(const VectorMax12d& positions) const override;
+    double
+    compute_distance(Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax12d
-    compute_distance_gradient(const VectorMax12d& positions) const override;
+    VectorMax12d compute_distance_gradient(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    MatrixMax12d
-    compute_distance_hessian(const VectorMax12d& positions) const override;
+    MatrixMax12d compute_distance_hessian(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax4d
-    compute_coefficients(const VectorMax12d& positions) const override;
+    VectorMax4d compute_coefficients(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     // ------------------------------------------------------------------------
 
     bool
-    ccd(const VectorMax12d& vertices_t0,
-        const VectorMax12d& vertices_t1,
+    ccd(Eigen::ConstRef<VectorMax12d> vertices_t0,
+        Eigen::ConstRef<VectorMax12d> vertices_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0,

--- a/src/ipc/candidates/edge_vertex.cpp
+++ b/src/ipc/candidates/edge_vertex.cpp
@@ -13,8 +13,8 @@ EdgeVertexCandidate::EdgeVertexCandidate(long _edge_id, long _vertex_id)
 {
 }
 
-double
-EdgeVertexCandidate::compute_distance(const VectorMax12d& positions) const
+double EdgeVertexCandidate::compute_distance(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 6 || positions.size() == 9);
     const int dim = this->dim(positions.size());
@@ -24,7 +24,7 @@ EdgeVertexCandidate::compute_distance(const VectorMax12d& positions) const
 }
 
 VectorMax12d EdgeVertexCandidate::compute_distance_gradient(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 6 || positions.size() == 9);
     const int dim = this->dim(positions.size());
@@ -34,7 +34,7 @@ VectorMax12d EdgeVertexCandidate::compute_distance_gradient(
 }
 
 MatrixMax12d EdgeVertexCandidate::compute_distance_hessian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 6 || positions.size() == 9);
     const int dim = this->dim(positions.size());
@@ -43,14 +43,14 @@ MatrixMax12d EdgeVertexCandidate::compute_distance_hessian(
         known_dtype());
 }
 
-VectorMax4d
-EdgeVertexCandidate::compute_coefficients(const VectorMax12d& positions) const
+VectorMax4d EdgeVertexCandidate::compute_coefficients(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 6 || positions.size() == 9);
     const int dim = this->dim(positions.size());
-    const Eigen::Ref<const VectorMax3d> p = positions.head(dim);
-    const Eigen::Ref<const VectorMax3d> t0 = positions.segment(dim, dim);
-    const Eigen::Ref<const VectorMax3d> t1 = positions.tail(dim);
+    Eigen::ConstRef<VectorMax3d> p = positions.head(dim);
+    Eigen::ConstRef<VectorMax3d> t0 = positions.segment(dim, dim);
+    Eigen::ConstRef<VectorMax3d> t1 = positions.tail(dim);
 
     auto dtype = known_dtype();
     if (dtype == PointEdgeDistanceType::AUTO) {
@@ -78,8 +78,8 @@ EdgeVertexCandidate::compute_coefficients(const VectorMax12d& positions) const
 }
 
 bool EdgeVertexCandidate::ccd(
-    const VectorMax12d& vertices_t0,
-    const VectorMax12d& vertices_t1,
+    Eigen::ConstRef<VectorMax12d> vertices_t0,
+    Eigen::ConstRef<VectorMax12d> vertices_t1,
     double& toi,
     const double min_distance,
     const double tmax,

--- a/src/ipc/candidates/edge_vertex.hpp
+++ b/src/ipc/candidates/edge_vertex.hpp
@@ -19,8 +19,8 @@ public:
     int num_vertices() const override { return 3; };
 
     std::array<long, 4> vertex_ids(
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const override
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
         return { { vertex_id, edges(edge_id, 0), edges(edge_id, 1), -1 } };
     }
@@ -30,22 +30,23 @@ public:
     using CollisionStencil::compute_distance_gradient;
     using CollisionStencil::compute_distance_hessian;
 
-    double compute_distance(const VectorMax12d& positions) const override;
+    double
+    compute_distance(Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax12d
-    compute_distance_gradient(const VectorMax12d& positions) const override;
+    VectorMax12d compute_distance_gradient(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    MatrixMax12d
-    compute_distance_hessian(const VectorMax12d& positions) const override;
+    MatrixMax12d compute_distance_hessian(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax4d
-    compute_coefficients(const VectorMax12d& positions) const override;
+    VectorMax4d compute_coefficients(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     // ------------------------------------------------------------------------
 
     bool
-    ccd(const VectorMax12d& vertices_t0,
-        const VectorMax12d& vertices_t1,
+    ccd(Eigen::ConstRef<VectorMax12d> vertices_t0,
+        Eigen::ConstRef<VectorMax12d> vertices_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0,

--- a/src/ipc/candidates/face_vertex.cpp
+++ b/src/ipc/candidates/face_vertex.cpp
@@ -13,8 +13,8 @@ FaceVertexCandidate::FaceVertexCandidate(long _face_id, long _vertex_id)
 {
 }
 
-double
-FaceVertexCandidate::compute_distance(const VectorMax12d& positions) const
+double FaceVertexCandidate::compute_distance(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 12);
     return point_triangle_distance(
@@ -23,7 +23,7 @@ FaceVertexCandidate::compute_distance(const VectorMax12d& positions) const
 }
 
 VectorMax12d FaceVertexCandidate::compute_distance_gradient(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 12);
     return point_triangle_distance_gradient(
@@ -32,7 +32,7 @@ VectorMax12d FaceVertexCandidate::compute_distance_gradient(
 }
 
 MatrixMax12d FaceVertexCandidate::compute_distance_hessian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 12);
     return point_triangle_distance_hessian(
@@ -40,14 +40,14 @@ MatrixMax12d FaceVertexCandidate::compute_distance_hessian(
         positions.tail<3>(), known_dtype());
 }
 
-VectorMax4d
-FaceVertexCandidate::compute_coefficients(const VectorMax12d& positions) const
+VectorMax4d FaceVertexCandidate::compute_coefficients(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 12);
-    const Eigen::Ref<const Eigen::Vector3d> p = positions.head<3>();
-    const Eigen::Ref<const Eigen::Vector3d> t0 = positions.segment<3>(3);
-    const Eigen::Ref<const Eigen::Vector3d> t1 = positions.segment<3>(6);
-    const Eigen::Ref<const Eigen::Vector3d> t2 = positions.tail<3>();
+    Eigen::ConstRef<Eigen::Vector3d> p = positions.head<3>();
+    Eigen::ConstRef<Eigen::Vector3d> t0 = positions.segment<3>(3);
+    Eigen::ConstRef<Eigen::Vector3d> t1 = positions.segment<3>(6);
+    Eigen::ConstRef<Eigen::Vector3d> t2 = positions.tail<3>();
 
     // Project the point inside the triangle
     auto dtype = known_dtype();
@@ -91,8 +91,8 @@ FaceVertexCandidate::compute_coefficients(const VectorMax12d& positions) const
 }
 
 bool FaceVertexCandidate::ccd(
-    const VectorMax12d& vertices_t0,
-    const VectorMax12d& vertices_t1,
+    Eigen::ConstRef<VectorMax12d> vertices_t0,
+    Eigen::ConstRef<VectorMax12d> vertices_t1,
     double& toi,
     const double min_distance,
     const double tmax,

--- a/src/ipc/candidates/face_vertex.hpp
+++ b/src/ipc/candidates/face_vertex.hpp
@@ -19,8 +19,8 @@ public:
     int num_vertices() const override { return 4; };
 
     std::array<long, 4> vertex_ids(
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const override
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
         return { { vertex_id, faces(face_id, 0), faces(face_id, 1),
                    faces(face_id, 2) } };
@@ -31,22 +31,23 @@ public:
     using CollisionStencil::compute_distance_gradient;
     using CollisionStencil::compute_distance_hessian;
 
-    double compute_distance(const VectorMax12d& positions) const override;
+    double
+    compute_distance(Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax12d
-    compute_distance_gradient(const VectorMax12d& positions) const override;
+    VectorMax12d compute_distance_gradient(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    MatrixMax12d
-    compute_distance_hessian(const VectorMax12d& positions) const override;
+    MatrixMax12d compute_distance_hessian(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax4d
-    compute_coefficients(const VectorMax12d& positions) const override;
+    VectorMax4d compute_coefficients(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     // ------------------------------------------------------------------------
 
     bool
-    ccd(const VectorMax12d& vertices_t0,
-        const VectorMax12d& vertices_t1,
+    ccd(Eigen::ConstRef<VectorMax12d> vertices_t0,
+        Eigen::ConstRef<VectorMax12d> vertices_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0,

--- a/src/ipc/candidates/vertex_vertex.cpp
+++ b/src/ipc/candidates/vertex_vertex.cpp
@@ -12,8 +12,8 @@ VertexVertexCandidate::VertexVertexCandidate(long _vertex0_id, long _vertex1_id)
 {
 }
 
-double
-VertexVertexCandidate::compute_distance(const VectorMax12d& positions) const
+double VertexVertexCandidate::compute_distance(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 4 || positions.size() == 6);
     const int dim = this->dim(positions.size());
@@ -21,7 +21,7 @@ VertexVertexCandidate::compute_distance(const VectorMax12d& positions) const
 }
 
 VectorMax12d VertexVertexCandidate::compute_distance_gradient(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 4 || positions.size() == 6);
     const int dim = this->dim(positions.size());
@@ -30,7 +30,7 @@ VectorMax12d VertexVertexCandidate::compute_distance_gradient(
 }
 
 MatrixMax12d VertexVertexCandidate::compute_distance_hessian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == 4 || positions.size() == 6);
     const int dim = this->dim(positions.size());
@@ -38,8 +38,8 @@ MatrixMax12d VertexVertexCandidate::compute_distance_hessian(
         positions.head(dim), positions.tail(dim));
 }
 
-VectorMax4d
-VertexVertexCandidate::compute_coefficients(const VectorMax12d& positions) const
+VectorMax4d VertexVertexCandidate::compute_coefficients(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     VectorMax4d coeffs(2);
     coeffs << 1.0, -1.0;
@@ -47,8 +47,8 @@ VertexVertexCandidate::compute_coefficients(const VectorMax12d& positions) const
 }
 
 bool VertexVertexCandidate::ccd(
-    const VectorMax12d& vertices_t0,
-    const VectorMax12d& vertices_t1,
+    Eigen::ConstRef<VectorMax12d> vertices_t0,
+    Eigen::ConstRef<VectorMax12d> vertices_t1,
     double& toi,
     const double min_distance,
     const double tmax,

--- a/src/ipc/candidates/vertex_vertex.hpp
+++ b/src/ipc/candidates/vertex_vertex.hpp
@@ -23,8 +23,8 @@ public:
     /// @param faces face matrix of mesh
     /// @return List of vertex indices
     std::array<long, 4> vertex_ids(
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const override
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
         return { { vertex0_id, vertex1_id, -1, -1 } };
     }
@@ -34,22 +34,23 @@ public:
     using CollisionStencil::compute_distance_gradient;
     using CollisionStencil::compute_distance_hessian;
 
-    double compute_distance(const VectorMax12d& positions) const override;
+    double
+    compute_distance(Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax12d
-    compute_distance_gradient(const VectorMax12d& positions) const override;
+    VectorMax12d compute_distance_gradient(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    MatrixMax12d
-    compute_distance_hessian(const VectorMax12d& positions) const override;
+    MatrixMax12d compute_distance_hessian(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax4d
-    compute_coefficients(const VectorMax12d& positions) const override;
+    VectorMax4d compute_coefficients(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     // ------------------------------------------------------------------------
 
     bool
-    ccd(const VectorMax12d& vertices_t0,
-        const VectorMax12d& vertices_t1,
+    ccd(Eigen::ConstRef<VectorMax12d> vertices_t0,
+        Eigen::ConstRef<VectorMax12d> vertices_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0,

--- a/src/ipc/ccd/aabb.cpp
+++ b/src/ipc/ccd/aabb.cpp
@@ -5,9 +5,9 @@ namespace ipc {
 // Discrete collision detection
 
 bool point_edge_aabb_cd(
-    const VectorMax3d& p,
-    const VectorMax3d& e0,
-    const VectorMax3d& e1,
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1,
     double dist)
 {
     const ArrayMax3d max_e = e0.array().max(e1.array());
@@ -17,10 +17,10 @@ bool point_edge_aabb_cd(
 }
 
 bool edge_edge_aabb_cd(
-    const VectorMax3d& ea0,
-    const VectorMax3d& ea1,
-    const VectorMax3d& eb0,
-    const VectorMax3d& eb1,
+    Eigen::ConstRef<VectorMax3d> ea0,
+    Eigen::ConstRef<VectorMax3d> ea1,
+    Eigen::ConstRef<VectorMax3d> eb0,
+    Eigen::ConstRef<VectorMax3d> eb1,
     double dist)
 {
     const ArrayMax3d max_a = ea0.array().max(ea1.array());
@@ -31,10 +31,10 @@ bool edge_edge_aabb_cd(
 }
 
 bool point_triangle_aabb_cd(
-    const Eigen::Vector3d& p,
-    const Eigen::Vector3d& t0,
-    const Eigen::Vector3d& t1,
-    const Eigen::Vector3d& t2,
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     double dist)
 {
     const Eigen::Array3d max_tri = t0.array().max(t1.array()).max(t2.array());
@@ -44,11 +44,11 @@ bool point_triangle_aabb_cd(
 }
 
 bool edge_triangle_aabb_cd(
-    const Eigen::Vector3d& e0,
-    const Eigen::Vector3d& e1,
-    const Eigen::Vector3d& t0,
-    const Eigen::Vector3d& t1,
-    const Eigen::Vector3d& t2,
+    Eigen::ConstRef<Eigen::Vector3d> e0,
+    Eigen::ConstRef<Eigen::Vector3d> e1,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     double dist)
 {
     const Eigen::Array3d max_e = e0.array().max(e1.array());
@@ -61,12 +61,12 @@ bool edge_triangle_aabb_cd(
 // Continous collision detection
 
 bool point_edge_aabb_ccd(
-    const VectorMax3d& p_t0,
-    const VectorMax3d& e0_t0,
-    const VectorMax3d& e1_t0,
-    const VectorMax3d& p_t1,
-    const VectorMax3d& e0_t1,
-    const VectorMax3d& e1_t1,
+    Eigen::ConstRef<VectorMax3d> p_t0,
+    Eigen::ConstRef<VectorMax3d> e0_t0,
+    Eigen::ConstRef<VectorMax3d> e1_t0,
+    Eigen::ConstRef<VectorMax3d> p_t1,
+    Eigen::ConstRef<VectorMax3d> e0_t1,
+    Eigen::ConstRef<VectorMax3d> e1_t1,
     double dist)
 {
     const ArrayMax3d max_p = p_t0.array().max(p_t1.array());
@@ -79,14 +79,14 @@ bool point_edge_aabb_ccd(
 }
 
 bool point_triangle_aabb_ccd(
-    const Eigen::Vector3d& p_t0,
-    const Eigen::Vector3d& t0_t0,
-    const Eigen::Vector3d& t1_t0,
-    const Eigen::Vector3d& t2_t0,
-    const Eigen::Vector3d& p_t1,
-    const Eigen::Vector3d& t0_t1,
-    const Eigen::Vector3d& t1_t1,
-    const Eigen::Vector3d& t2_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t1,
     double dist)
 {
     const Eigen::Array3d max_p = p_t0.array().max((p_t1).array());
@@ -107,14 +107,14 @@ bool point_triangle_aabb_ccd(
 }
 
 bool edge_edge_aabb_ccd(
-    const Eigen::Vector3d& ea0_t0,
-    const Eigen::Vector3d& ea1_t0,
-    const Eigen::Vector3d& eb0_t0,
-    const Eigen::Vector3d& eb1_t0,
-    const Eigen::Vector3d& ea0_t1,
-    const Eigen::Vector3d& ea1_t1,
-    const Eigen::Vector3d& eb0_t1,
-    const Eigen::Vector3d& eb1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
     double dist)
 {
     const Eigen::Array3d max_a = ea0_t0.array()

--- a/src/ipc/ccd/aabb.hpp
+++ b/src/ipc/ccd/aabb.hpp
@@ -7,64 +7,64 @@ namespace ipc {
 // Discrete collision detection
 
 bool point_edge_aabb_cd(
-    const VectorMax3d& p,
-    const VectorMax3d& e0,
-    const VectorMax3d& e1,
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1,
     double dist);
 
 bool edge_edge_aabb_cd(
-    const VectorMax3d& ea0,
-    const VectorMax3d& ea1,
-    const VectorMax3d& eb0,
-    const VectorMax3d& eb1,
+    Eigen::ConstRef<VectorMax3d> ea0,
+    Eigen::ConstRef<VectorMax3d> ea1,
+    Eigen::ConstRef<VectorMax3d> eb0,
+    Eigen::ConstRef<VectorMax3d> eb1,
     double dist);
 
 bool point_triangle_aabb_cd(
-    const Eigen::Vector3d& p,
-    const Eigen::Vector3d& t0,
-    const Eigen::Vector3d& t1,
-    const Eigen::Vector3d& t2,
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     double dist);
 
 bool edge_triangle_aabb_cd(
-    const Eigen::Vector3d& e0,
-    const Eigen::Vector3d& e1,
-    const Eigen::Vector3d& t0,
-    const Eigen::Vector3d& t1,
-    const Eigen::Vector3d& t2,
+    Eigen::ConstRef<Eigen::Vector3d> e0,
+    Eigen::ConstRef<Eigen::Vector3d> e1,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     double dist);
 
 // Continous collision detection
 
 bool point_edge_aabb_ccd(
-    const VectorMax3d& p_t0,
-    const VectorMax3d& e0_t0,
-    const VectorMax3d& e1_t0,
-    const VectorMax3d& p_t1,
-    const VectorMax3d& e0_t1,
-    const VectorMax3d& e1_t1,
+    Eigen::ConstRef<VectorMax3d> p_t0,
+    Eigen::ConstRef<VectorMax3d> e0_t0,
+    Eigen::ConstRef<VectorMax3d> e1_t0,
+    Eigen::ConstRef<VectorMax3d> p_t1,
+    Eigen::ConstRef<VectorMax3d> e0_t1,
+    Eigen::ConstRef<VectorMax3d> e1_t1,
     double dist);
 
 bool edge_edge_aabb_ccd(
-    const Eigen::Vector3d& ea0_t0,
-    const Eigen::Vector3d& ea1_t0,
-    const Eigen::Vector3d& eb0_t0,
-    const Eigen::Vector3d& eb1_t0,
-    const Eigen::Vector3d& ea0_t1,
-    const Eigen::Vector3d& ea1_t1,
-    const Eigen::Vector3d& eb0_t1,
-    const Eigen::Vector3d& eb1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
     double dist);
 
 bool point_triangle_aabb_ccd(
-    const Eigen::Vector3d& p_t0,
-    const Eigen::Vector3d& t0_t0,
-    const Eigen::Vector3d& t1_t0,
-    const Eigen::Vector3d& t2_t0,
-    const Eigen::Vector3d& p_t1,
-    const Eigen::Vector3d& t0_t1,
-    const Eigen::Vector3d& t1_t1,
-    const Eigen::Vector3d& t2_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t1,
     double dist);
 
 } // namespace ipc

--- a/src/ipc/ccd/additive_ccd.cpp
+++ b/src/ipc/ccd/additive_ccd.cpp
@@ -49,10 +49,10 @@ namespace {
         }
     }
 
-    VectorMax12d stack(const VectorMax3d& x) { return x; }
+    VectorMax12d stack(Eigen::ConstRef<VectorMax3d> x) { return x; }
 
     template <typename... Args>
-    VectorMax12d stack(const VectorMax3d& x0, const Args&... args)
+    VectorMax12d stack(Eigen::ConstRef<VectorMax3d> x0, const Args&... args)
     {
         VectorMax12d x(x0.size() * (1 + sizeof...(args)));
         x.head(x0.size()) = x0;
@@ -69,9 +69,9 @@ AdditiveCCD::AdditiveCCD(
 }
 
 bool AdditiveCCD::additive_ccd(
-    VectorMax12d x,
-    const VectorMax12d& dx,
-    const std::function<double(const VectorMax12d&)>& distance_squared,
+    VectorMax12d x, // mutable copy
+    Eigen::ConstRef<VectorMax12d> dx,
+    const std::function<double(Eigen::ConstRef<VectorMax12d>)> distance_squared,
     const double max_disp_mag,
     double& toi,
     const double min_distance,
@@ -127,10 +127,10 @@ bool AdditiveCCD::additive_ccd(
 }
 
 bool AdditiveCCD::point_point_ccd(
-    const VectorMax3d& p0_t0,
-    const VectorMax3d& p1_t0,
-    const VectorMax3d& p0_t1,
-    const VectorMax3d& p1_t1,
+    Eigen::ConstRef<VectorMax3d> p0_t0,
+    Eigen::ConstRef<VectorMax3d> p1_t0,
+    Eigen::ConstRef<VectorMax3d> p0_t1,
+    Eigen::ConstRef<VectorMax3d> p1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -156,7 +156,7 @@ bool AdditiveCCD::point_point_ccd(
         return false;
     }
 
-    auto distance_squared = [dim](const VectorMax12d& x) {
+    auto distance_squared = [dim](Eigen::ConstRef<VectorMax12d> x) {
         return point_point_distance(x.head(dim), x.tail(dim));
     };
 
@@ -168,12 +168,12 @@ bool AdditiveCCD::point_point_ccd(
 }
 
 bool AdditiveCCD::point_edge_ccd(
-    const VectorMax3d& p_t0,
-    const VectorMax3d& e0_t0,
-    const VectorMax3d& e1_t0,
-    const VectorMax3d& p_t1,
-    const VectorMax3d& e0_t1,
-    const VectorMax3d& e1_t1,
+    Eigen::ConstRef<VectorMax3d> p_t0,
+    Eigen::ConstRef<VectorMax3d> e0_t0,
+    Eigen::ConstRef<VectorMax3d> e1_t0,
+    Eigen::ConstRef<VectorMax3d> p_t1,
+    Eigen::ConstRef<VectorMax3d> e0_t1,
+    Eigen::ConstRef<VectorMax3d> e1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -202,7 +202,7 @@ bool AdditiveCCD::point_edge_ccd(
         return false;
     }
 
-    auto distance_squared = [dim](const VectorMax12d& x) {
+    auto distance_squared = [dim](Eigen::ConstRef<VectorMax12d> x) {
         return point_edge_distance(
             x.head(dim), x.segment(dim, dim), x.tail(dim));
     };
@@ -215,14 +215,14 @@ bool AdditiveCCD::point_edge_ccd(
 }
 
 bool AdditiveCCD::point_triangle_ccd(
-    const Eigen::Vector3d& p_t0,
-    const Eigen::Vector3d& t0_t0,
-    const Eigen::Vector3d& t1_t0,
-    const Eigen::Vector3d& t2_t0,
-    const Eigen::Vector3d& p_t1,
-    const Eigen::Vector3d& t0_t1,
-    const Eigen::Vector3d& t1_t1,
-    const Eigen::Vector3d& t2_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -250,7 +250,7 @@ bool AdditiveCCD::point_triangle_ccd(
         return false;
     }
 
-    auto distance_squared = [](const VectorMax12d& x) {
+    auto distance_squared = [](Eigen::ConstRef<VectorMax12d> x) {
         return point_triangle_distance(
             x.head<3>(), x.segment<3>(3), x.segment<3>(6), x.tail<3>());
     };
@@ -263,14 +263,14 @@ bool AdditiveCCD::point_triangle_ccd(
 }
 
 bool AdditiveCCD::edge_edge_ccd(
-    const Eigen::Vector3d& ea0_t0,
-    const Eigen::Vector3d& ea1_t0,
-    const Eigen::Vector3d& eb0_t0,
-    const Eigen::Vector3d& eb1_t0,
-    const Eigen::Vector3d& ea0_t1,
-    const Eigen::Vector3d& ea1_t1,
-    const Eigen::Vector3d& eb0_t1,
-    const Eigen::Vector3d& eb1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -299,7 +299,7 @@ bool AdditiveCCD::edge_edge_ccd(
     }
 
     const double min_distance_sq = min_distance * min_distance;
-    auto distance_squared = [min_distance_sq](const VectorMax12d& x) {
+    auto distance_squared = [min_distance_sq](Eigen::ConstRef<VectorMax12d> x) {
         const auto& ea0 = x.head<3>();
         const auto& ea1 = x.segment<3>(3);
         const auto& eb0 = x.segment<3>(6);

--- a/src/ipc/ccd/additive_ccd.hpp
+++ b/src/ipc/ccd/additive_ccd.hpp
@@ -42,10 +42,10 @@ public:
     /// @param conservative_rescaling The conservative rescaling of the time of impact.
     /// @return True if a collision was detected, false otherwise.
     bool point_point_ccd(
-        const VectorMax3d& p0_t0,
-        const VectorMax3d& p1_t0,
-        const VectorMax3d& p0_t1,
-        const VectorMax3d& p1_t1,
+        Eigen::ConstRef<VectorMax3d> p0_t0,
+        Eigen::ConstRef<VectorMax3d> p1_t0,
+        Eigen::ConstRef<VectorMax3d> p0_t1,
+        Eigen::ConstRef<VectorMax3d> p1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -63,12 +63,12 @@ public:
     /// @param conservative_rescaling The conservative rescaling of the time of impact.
     /// @return True if a collision was detected, false otherwise.
     bool point_edge_ccd(
-        const VectorMax3d& p_t0,
-        const VectorMax3d& e0_t0,
-        const VectorMax3d& e1_t0,
-        const VectorMax3d& p_t1,
-        const VectorMax3d& e0_t1,
-        const VectorMax3d& e1_t1,
+        Eigen::ConstRef<VectorMax3d> p_t0,
+        Eigen::ConstRef<VectorMax3d> e0_t0,
+        Eigen::ConstRef<VectorMax3d> e1_t0,
+        Eigen::ConstRef<VectorMax3d> p_t1,
+        Eigen::ConstRef<VectorMax3d> e0_t1,
+        Eigen::ConstRef<VectorMax3d> e1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -88,14 +88,14 @@ public:
     /// @param conservative_rescaling The conservative rescaling of the time of impact.
     /// @return True if a collision was detected, false otherwise.
     bool point_triangle_ccd(
-        const Eigen::Vector3d& p_t0,
-        const Eigen::Vector3d& t0_t0,
-        const Eigen::Vector3d& t1_t0,
-        const Eigen::Vector3d& t2_t0,
-        const Eigen::Vector3d& p_t1,
-        const Eigen::Vector3d& t0_t1,
-        const Eigen::Vector3d& t1_t1,
-        const Eigen::Vector3d& t2_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -115,14 +115,14 @@ public:
     /// @param conservative_rescaling The conservative rescaling of the time of impact.
     /// @return True if a collision was detected, false otherwise.
     bool edge_edge_ccd(
-        const Eigen::Vector3d& ea0_t0,
-        const Eigen::Vector3d& ea1_t0,
-        const Eigen::Vector3d& eb0_t0,
-        const Eigen::Vector3d& eb1_t0,
-        const Eigen::Vector3d& ea0_t1,
-        const Eigen::Vector3d& ea1_t1,
-        const Eigen::Vector3d& eb0_t1,
-        const Eigen::Vector3d& eb1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -142,9 +142,10 @@ private:
     /// @param conservative_rescaling The amount to rescale the objects by to ensure conservative advancement.
     /// @return True if a collision was detected, false otherwise.
     bool additive_ccd(
-        VectorMax12d x,
-        const VectorMax12d& dx,
-        const std::function<double(const VectorMax12d&)>& distance_squared,
+        VectorMax12d x, // mutable copy
+        Eigen::ConstRef<VectorMax12d> dx,
+        const std::function<double(Eigen::ConstRef<VectorMax12d>)>
+            distance_squared,
         const double max_disp_mag,
         double& toi,
         const double min_distance = 0.0,

--- a/src/ipc/ccd/inexact_ccd.cpp
+++ b/src/ipc/ccd/inexact_ccd.cpp
@@ -51,10 +51,10 @@ bool InexactCCD::ccd_strategy(
 }
 
 bool InexactCCD::point_point_ccd_3D(
-    const Eigen::Vector3d& p0_t0,
-    const Eigen::Vector3d& p1_t0,
-    const Eigen::Vector3d& p0_t1,
-    const Eigen::Vector3d& p1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -77,10 +77,10 @@ bool InexactCCD::point_point_ccd_3D(
 }
 
 bool InexactCCD::point_point_ccd(
-    const VectorMax3d& p0_t0,
-    const VectorMax3d& p1_t0,
-    const VectorMax3d& p0_t1,
-    const VectorMax3d& p1_t1,
+    Eigen::ConstRef<VectorMax3d> p0_t0,
+    Eigen::ConstRef<VectorMax3d> p1_t0,
+    Eigen::ConstRef<VectorMax3d> p0_t1,
+    Eigen::ConstRef<VectorMax3d> p1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -94,12 +94,12 @@ bool InexactCCD::point_point_ccd(
 }
 
 bool InexactCCD::point_edge_ccd_3D(
-    const Eigen::Vector3d& p_t0,
-    const Eigen::Vector3d& e0_t0,
-    const Eigen::Vector3d& e1_t0,
-    const Eigen::Vector3d& p_t1,
-    const Eigen::Vector3d& e0_t1,
-    const Eigen::Vector3d& e1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p_t0,
+    Eigen::ConstRef<Eigen::Vector3d> e0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> e1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p_t1,
+    Eigen::ConstRef<Eigen::Vector3d> e0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> e1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -123,12 +123,12 @@ bool InexactCCD::point_edge_ccd_3D(
 }
 
 bool InexactCCD::point_edge_ccd(
-    const VectorMax3d& p_t0,
-    const VectorMax3d& e0_t0,
-    const VectorMax3d& e1_t0,
-    const VectorMax3d& p_t1,
-    const VectorMax3d& e0_t1,
-    const VectorMax3d& e1_t1,
+    Eigen::ConstRef<VectorMax3d> p_t0,
+    Eigen::ConstRef<VectorMax3d> e0_t0,
+    Eigen::ConstRef<VectorMax3d> e1_t0,
+    Eigen::ConstRef<VectorMax3d> p_t1,
+    Eigen::ConstRef<VectorMax3d> e0_t1,
+    Eigen::ConstRef<VectorMax3d> e1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -142,14 +142,14 @@ bool InexactCCD::point_edge_ccd(
 }
 
 bool InexactCCD::edge_edge_ccd(
-    const Eigen::Vector3d& ea0_t0,
-    const Eigen::Vector3d& ea1_t0,
-    const Eigen::Vector3d& eb0_t0,
-    const Eigen::Vector3d& eb1_t0,
-    const Eigen::Vector3d& ea0_t1,
-    const Eigen::Vector3d& ea1_t1,
-    const Eigen::Vector3d& eb0_t1,
-    const Eigen::Vector3d& eb1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -175,14 +175,14 @@ bool InexactCCD::edge_edge_ccd(
 }
 
 bool InexactCCD::point_triangle_ccd(
-    const Eigen::Vector3d& p_t0,
-    const Eigen::Vector3d& t0_t0,
-    const Eigen::Vector3d& t1_t0,
-    const Eigen::Vector3d& t2_t0,
-    const Eigen::Vector3d& p_t1,
-    const Eigen::Vector3d& t0_t1,
-    const Eigen::Vector3d& t1_t1,
-    const Eigen::Vector3d& t2_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t1,
     double& toi,
     const double min_distance,
     const double tmax) const

--- a/src/ipc/ccd/inexact_ccd.hpp
+++ b/src/ipc/ccd/inexact_ccd.hpp
@@ -32,10 +32,10 @@ public:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_point_ccd(
-        const VectorMax3d& p0_t0,
-        const VectorMax3d& p1_t0,
-        const VectorMax3d& p0_t1,
-        const VectorMax3d& p1_t1,
+        Eigen::ConstRef<VectorMax3d> p0_t0,
+        Eigen::ConstRef<VectorMax3d> p1_t0,
+        Eigen::ConstRef<VectorMax3d> p0_t1,
+        Eigen::ConstRef<VectorMax3d> p1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -52,12 +52,12 @@ public:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_edge_ccd(
-        const VectorMax3d& p_t0,
-        const VectorMax3d& e0_t0,
-        const VectorMax3d& e1_t0,
-        const VectorMax3d& p_t1,
-        const VectorMax3d& e0_t1,
-        const VectorMax3d& e1_t1,
+        Eigen::ConstRef<VectorMax3d> p_t0,
+        Eigen::ConstRef<VectorMax3d> e0_t0,
+        Eigen::ConstRef<VectorMax3d> e1_t0,
+        Eigen::ConstRef<VectorMax3d> p_t1,
+        Eigen::ConstRef<VectorMax3d> e0_t1,
+        Eigen::ConstRef<VectorMax3d> e1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -76,14 +76,14 @@ public:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool edge_edge_ccd(
-        const Eigen::Vector3d& ea0_t0,
-        const Eigen::Vector3d& ea1_t0,
-        const Eigen::Vector3d& eb0_t0,
-        const Eigen::Vector3d& eb1_t0,
-        const Eigen::Vector3d& ea0_t1,
-        const Eigen::Vector3d& ea1_t1,
-        const Eigen::Vector3d& eb0_t1,
-        const Eigen::Vector3d& eb1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -102,14 +102,14 @@ public:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_triangle_ccd(
-        const Eigen::Vector3d& p_t0,
-        const Eigen::Vector3d& t0_t0,
-        const Eigen::Vector3d& t1_t0,
-        const Eigen::Vector3d& t2_t0,
-        const Eigen::Vector3d& p_t1,
-        const Eigen::Vector3d& t0_t1,
-        const Eigen::Vector3d& t1_t1,
-        const Eigen::Vector3d& t2_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -128,10 +128,10 @@ private:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_point_ccd_3D(
-        const Eigen::Vector3d& p0_t0,
-        const Eigen::Vector3d& p1_t0,
-        const Eigen::Vector3d& p0_t1,
-        const Eigen::Vector3d& p1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const;
@@ -148,12 +148,12 @@ private:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_edge_ccd_3D(
-        const Eigen::Vector3d& p_t0,
-        const Eigen::Vector3d& e0_t0,
-        const Eigen::Vector3d& e1_t0,
-        const Eigen::Vector3d& p_t1,
-        const Eigen::Vector3d& e0_t1,
-        const Eigen::Vector3d& e1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p_t0,
+        Eigen::ConstRef<Eigen::Vector3d> e0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> e1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p_t1,
+        Eigen::ConstRef<Eigen::Vector3d> e0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> e1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const;

--- a/src/ipc/ccd/inexact_point_edge.cpp
+++ b/src/ipc/ccd/inexact_point_edge.cpp
@@ -12,12 +12,12 @@
 namespace ipc {
 
 bool inexact_point_edge_ccd_2D(
-    const Eigen::Vector2d& p_t0,
-    const Eigen::Vector2d& e0_t0,
-    const Eigen::Vector2d& e1_t0,
-    const Eigen::Vector2d& p_t1,
-    const Eigen::Vector2d& e0_t1,
-    const Eigen::Vector2d& e1_t1,
+    Eigen::ConstRef<Eigen::Vector2d> p_t0,
+    Eigen::ConstRef<Eigen::Vector2d> e0_t0,
+    Eigen::ConstRef<Eigen::Vector2d> e1_t0,
+    Eigen::ConstRef<Eigen::Vector2d> p_t1,
+    Eigen::ConstRef<Eigen::Vector2d> e0_t1,
+    Eigen::ConstRef<Eigen::Vector2d> e1_t1,
     double& toi,
     const double conservative_rescaling)
 {

--- a/src/ipc/ccd/inexact_point_edge.hpp
+++ b/src/ipc/ccd/inexact_point_edge.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <Eigen/Core>
+#include <ipc/utils/eigen_ext.hpp>
 
 namespace ipc {
 
@@ -22,12 +22,12 @@ namespace ipc {
 /// @param[in] conservative_rescaling The conservative rescaling of the time of impact.
 /// @return True if a collision was detected, false otherwise.
 bool inexact_point_edge_ccd_2D(
-    const Eigen::Vector2d& p_t0,
-    const Eigen::Vector2d& e0_t0,
-    const Eigen::Vector2d& e1_t0,
-    const Eigen::Vector2d& p_t1,
-    const Eigen::Vector2d& e0_t1,
-    const Eigen::Vector2d& e1_t1,
+    Eigen::ConstRef<Eigen::Vector2d> p_t0,
+    Eigen::ConstRef<Eigen::Vector2d> e0_t0,
+    Eigen::ConstRef<Eigen::Vector2d> e1_t0,
+    Eigen::ConstRef<Eigen::Vector2d> p_t1,
+    Eigen::ConstRef<Eigen::Vector2d> e0_t1,
+    Eigen::ConstRef<Eigen::Vector2d> e1_t1,
     double& toi,
     const double conservative_rescaling);
 

--- a/src/ipc/ccd/narrow_phase_ccd.hpp
+++ b/src/ipc/ccd/narrow_phase_ccd.hpp
@@ -11,47 +11,47 @@ public:
     virtual ~NarrowPhaseCCD() = default;
 
     virtual bool point_point_ccd(
-        const VectorMax3d& p0_t0,
-        const VectorMax3d& p1_t0,
-        const VectorMax3d& p0_t1,
-        const VectorMax3d& p1_t1,
+        Eigen::ConstRef<VectorMax3d> p0_t0,
+        Eigen::ConstRef<VectorMax3d> p1_t0,
+        Eigen::ConstRef<VectorMax3d> p0_t1,
+        Eigen::ConstRef<VectorMax3d> p1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const = 0;
 
     virtual bool point_edge_ccd(
-        const VectorMax3d& p_t0,
-        const VectorMax3d& e0_t0,
-        const VectorMax3d& e1_t0,
-        const VectorMax3d& p_t1,
-        const VectorMax3d& e0_t1,
-        const VectorMax3d& e1_t1,
+        Eigen::ConstRef<VectorMax3d> p_t0,
+        Eigen::ConstRef<VectorMax3d> e0_t0,
+        Eigen::ConstRef<VectorMax3d> e1_t0,
+        Eigen::ConstRef<VectorMax3d> p_t1,
+        Eigen::ConstRef<VectorMax3d> e0_t1,
+        Eigen::ConstRef<VectorMax3d> e1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const = 0;
 
     virtual bool point_triangle_ccd(
-        const Eigen::Vector3d& p_t0,
-        const Eigen::Vector3d& t0_t0,
-        const Eigen::Vector3d& t1_t0,
-        const Eigen::Vector3d& t2_t0,
-        const Eigen::Vector3d& p_t1,
-        const Eigen::Vector3d& t0_t1,
-        const Eigen::Vector3d& t1_t1,
-        const Eigen::Vector3d& t2_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const = 0;
 
     virtual bool edge_edge_ccd(
-        const Eigen::Vector3d& ea0_t0,
-        const Eigen::Vector3d& ea1_t0,
-        const Eigen::Vector3d& eb0_t0,
-        const Eigen::Vector3d& eb1_t0,
-        const Eigen::Vector3d& ea0_t1,
-        const Eigen::Vector3d& ea1_t1,
-        const Eigen::Vector3d& eb0_t1,
-        const Eigen::Vector3d& eb1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const = 0;

--- a/src/ipc/ccd/point_static_plane.cpp
+++ b/src/ipc/ccd/point_static_plane.cpp
@@ -9,10 +9,10 @@ namespace ipc {
 inline bool is_in_01(double x) { return 0 <= x && x <= 1; };
 
 bool point_static_plane_ccd(
-    const VectorMax3d& p_t0,
-    const VectorMax3d& p_t1,
-    const VectorMax3d& plane_origin,
-    const VectorMax3d& plane_normal,
+    Eigen::ConstRef<VectorMax3d> p_t0,
+    Eigen::ConstRef<VectorMax3d> p_t1,
+    Eigen::ConstRef<VectorMax3d> plane_origin,
+    Eigen::ConstRef<VectorMax3d> plane_normal,
     double& toi,
     double conservative_rescaling)
 {

--- a/src/ipc/ccd/point_static_plane.hpp
+++ b/src/ipc/ccd/point_static_plane.hpp
@@ -13,10 +13,10 @@ namespace ipc {
 /// @param[in] conservative_rescaling Conservative rescaling of the time of impact.
 /// @return True if a collision was detected, false otherwise.
 bool point_static_plane_ccd(
-    const VectorMax3d& p_t0,
-    const VectorMax3d& p_t1,
-    const VectorMax3d& plane_origin,
-    const VectorMax3d& plane_normal,
+    Eigen::ConstRef<VectorMax3d> p_t0,
+    Eigen::ConstRef<VectorMax3d> p_t1,
+    Eigen::ConstRef<VectorMax3d> plane_origin,
+    Eigen::ConstRef<VectorMax3d> plane_normal,
     double& toi,
     const double conservative_rescaling =
         TightInclusionCCD::DEFAULT_CONSERVATIVE_RESCALING);

--- a/src/ipc/ccd/tight_inclusion_ccd.cpp
+++ b/src/ipc/ccd/tight_inclusion_ccd.cpp
@@ -75,10 +75,10 @@ bool TightInclusionCCD::ccd_strategy(
 }
 
 bool TightInclusionCCD::point_point_ccd_3D(
-    const Eigen::Vector3d& p0_t0,
-    const Eigen::Vector3d& p1_t0,
-    const Eigen::Vector3d& p0_t1,
-    const Eigen::Vector3d& p1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -128,10 +128,10 @@ bool TightInclusionCCD::point_point_ccd_3D(
 }
 
 bool TightInclusionCCD::point_point_ccd(
-    const VectorMax3d& p0_t0,
-    const VectorMax3d& p1_t0,
-    const VectorMax3d& p0_t1,
-    const VectorMax3d& p1_t1,
+    Eigen::ConstRef<VectorMax3d> p0_t0,
+    Eigen::ConstRef<VectorMax3d> p1_t0,
+    Eigen::ConstRef<VectorMax3d> p0_t1,
+    Eigen::ConstRef<VectorMax3d> p1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -145,12 +145,12 @@ bool TightInclusionCCD::point_point_ccd(
 }
 
 bool TightInclusionCCD::point_edge_ccd_3D(
-    const Eigen::Vector3d& p_t0,
-    const Eigen::Vector3d& e0_t0,
-    const Eigen::Vector3d& e1_t0,
-    const Eigen::Vector3d& p_t1,
-    const Eigen::Vector3d& e0_t1,
-    const Eigen::Vector3d& e1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p_t0,
+    Eigen::ConstRef<Eigen::Vector3d> e0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> e1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p_t1,
+    Eigen::ConstRef<Eigen::Vector3d> e0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> e1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -201,12 +201,12 @@ bool TightInclusionCCD::point_edge_ccd_3D(
 }
 
 bool TightInclusionCCD::point_edge_ccd(
-    const VectorMax3d& p_t0,
-    const VectorMax3d& e0_t0,
-    const VectorMax3d& e1_t0,
-    const VectorMax3d& p_t1,
-    const VectorMax3d& e0_t1,
-    const VectorMax3d& e1_t1,
+    Eigen::ConstRef<VectorMax3d> p_t0,
+    Eigen::ConstRef<VectorMax3d> e0_t0,
+    Eigen::ConstRef<VectorMax3d> e1_t0,
+    Eigen::ConstRef<VectorMax3d> p_t1,
+    Eigen::ConstRef<VectorMax3d> e0_t1,
+    Eigen::ConstRef<VectorMax3d> e1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -220,14 +220,14 @@ bool TightInclusionCCD::point_edge_ccd(
 }
 
 bool TightInclusionCCD::edge_edge_ccd(
-    const Eigen::Vector3d& ea0_t0,
-    const Eigen::Vector3d& ea1_t0,
-    const Eigen::Vector3d& eb0_t0,
-    const Eigen::Vector3d& eb1_t0,
-    const Eigen::Vector3d& ea0_t1,
-    const Eigen::Vector3d& ea1_t1,
-    const Eigen::Vector3d& eb0_t1,
-    const Eigen::Vector3d& eb1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
     double& toi,
     const double min_distance,
     const double tmax) const
@@ -278,14 +278,14 @@ bool TightInclusionCCD::edge_edge_ccd(
 }
 
 bool TightInclusionCCD::point_triangle_ccd(
-    const Eigen::Vector3d& p_t0,
-    const Eigen::Vector3d& t0_t0,
-    const Eigen::Vector3d& t1_t0,
-    const Eigen::Vector3d& t2_t0,
-    const Eigen::Vector3d& p_t1,
-    const Eigen::Vector3d& t0_t1,
-    const Eigen::Vector3d& t1_t1,
-    const Eigen::Vector3d& t2_t1,
+    Eigen::ConstRef<Eigen::Vector3d> p_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+    Eigen::ConstRef<Eigen::Vector3d> p_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2_t1,
     double& toi,
     const double min_distance,
     const double tmax) const

--- a/src/ipc/ccd/tight_inclusion_ccd.hpp
+++ b/src/ipc/ccd/tight_inclusion_ccd.hpp
@@ -34,10 +34,10 @@ public:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_point_ccd(
-        const VectorMax3d& p0_t0,
-        const VectorMax3d& p1_t0,
-        const VectorMax3d& p0_t1,
-        const VectorMax3d& p1_t1,
+        Eigen::ConstRef<VectorMax3d> p0_t0,
+        Eigen::ConstRef<VectorMax3d> p1_t0,
+        Eigen::ConstRef<VectorMax3d> p0_t1,
+        Eigen::ConstRef<VectorMax3d> p1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -54,12 +54,12 @@ public:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_edge_ccd(
-        const VectorMax3d& p_t0,
-        const VectorMax3d& e0_t0,
-        const VectorMax3d& e1_t0,
-        const VectorMax3d& p_t1,
-        const VectorMax3d& e0_t1,
-        const VectorMax3d& e1_t1,
+        Eigen::ConstRef<VectorMax3d> p_t0,
+        Eigen::ConstRef<VectorMax3d> e0_t0,
+        Eigen::ConstRef<VectorMax3d> e1_t0,
+        Eigen::ConstRef<VectorMax3d> p_t1,
+        Eigen::ConstRef<VectorMax3d> e0_t1,
+        Eigen::ConstRef<VectorMax3d> e1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -78,14 +78,14 @@ public:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool edge_edge_ccd(
-        const Eigen::Vector3d& ea0_t0,
-        const Eigen::Vector3d& ea1_t0,
-        const Eigen::Vector3d& eb0_t0,
-        const Eigen::Vector3d& eb1_t0,
-        const Eigen::Vector3d& ea0_t1,
-        const Eigen::Vector3d& ea1_t1,
-        const Eigen::Vector3d& eb0_t1,
-        const Eigen::Vector3d& eb1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> ea0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> ea1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> eb1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -104,14 +104,14 @@ public:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_triangle_ccd(
-        const Eigen::Vector3d& p_t0,
-        const Eigen::Vector3d& t0_t0,
-        const Eigen::Vector3d& t1_t0,
-        const Eigen::Vector3d& t2_t0,
-        const Eigen::Vector3d& p_t1,
-        const Eigen::Vector3d& t0_t1,
-        const Eigen::Vector3d& t1_t1,
-        const Eigen::Vector3d& t2_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> t2_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const override;
@@ -136,10 +136,10 @@ private:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_point_ccd_3D(
-        const Eigen::Vector3d& p0_t0,
-        const Eigen::Vector3d& p1_t0,
-        const Eigen::Vector3d& p0_t1,
-        const Eigen::Vector3d& p1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const;
@@ -156,12 +156,12 @@ private:
     /// @param[in] tmax The maximum time to check for collisions.
     /// @return True if a collision was detected, false otherwise.
     bool point_edge_ccd_3D(
-        const Eigen::Vector3d& p_t0,
-        const Eigen::Vector3d& e0_t0,
-        const Eigen::Vector3d& e1_t0,
-        const Eigen::Vector3d& p_t1,
-        const Eigen::Vector3d& e0_t1,
-        const Eigen::Vector3d& e1_t1,
+        Eigen::ConstRef<Eigen::Vector3d> p_t0,
+        Eigen::ConstRef<Eigen::Vector3d> e0_t0,
+        Eigen::ConstRef<Eigen::Vector3d> e1_t0,
+        Eigen::ConstRef<Eigen::Vector3d> p_t1,
+        Eigen::ConstRef<Eigen::Vector3d> e0_t1,
+        Eigen::ConstRef<Eigen::Vector3d> e1_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0) const;

--- a/src/ipc/collision_mesh.cpp
+++ b/src/ipc/collision_mesh.cpp
@@ -9,9 +9,9 @@
 namespace ipc {
 
 CollisionMesh::CollisionMesh(
-    const Eigen::MatrixXd& rest_positions,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> rest_positions,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const Eigen::SparseMatrix<double>& displacement_map)
     : CollisionMesh(
           std::vector<bool>(rest_positions.rows(), true),
@@ -24,9 +24,9 @@ CollisionMesh::CollisionMesh(
 
 CollisionMesh::CollisionMesh(
     const std::vector<bool>& include_vertex,
-    const Eigen::MatrixXd& full_rest_positions,
-    const Eigen::MatrixXi& edges,
-    const Eigen::MatrixXi& faces,
+    Eigen::ConstRef<Eigen::MatrixXd> full_rest_positions,
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
     const Eigen::SparseMatrix<double>& displacement_map)
     : m_full_rest_positions(full_rest_positions)
     , m_edges(edges)
@@ -376,7 +376,7 @@ void CollisionMesh::init_area_jacobians()
 // ============================================================================/
 
 Eigen::MatrixXd
-CollisionMesh::vertices(const Eigen::MatrixXd& full_positions) const
+CollisionMesh::vertices(Eigen::ConstRef<Eigen::MatrixXd> full_positions) const
 {
     // full_U = full_V - full_V_rest
     assert(full_positions.rows() == full_num_vertices());
@@ -385,14 +385,14 @@ CollisionMesh::vertices(const Eigen::MatrixXd& full_positions) const
 }
 
 Eigen::MatrixXd CollisionMesh::displace_vertices(
-    const Eigen::MatrixXd& full_displacements) const
+    Eigen::ConstRef<Eigen::MatrixXd> full_displacements) const
 {
     // V_rest + S * T * full_U; m_displacement_map = S * T
     return m_rest_positions + map_displacements(full_displacements);
 }
 
 Eigen::MatrixXd CollisionMesh::map_displacements(
-    const Eigen::MatrixXd& full_displacements) const
+    Eigen::ConstRef<Eigen::MatrixXd> full_displacements) const
 {
     assert(m_displacement_map.cols() == full_displacements.rows());
     assert(full_displacements.cols() == dim());
@@ -401,7 +401,8 @@ Eigen::MatrixXd CollisionMesh::map_displacements(
 
 // ============================================================================/
 
-Eigen::VectorXd CollisionMesh::to_full_dof(const Eigen::VectorXd& x) const
+Eigen::VectorXd
+CollisionMesh::to_full_dof(Eigen::ConstRef<Eigen::VectorXd> x) const
 {
     // ∇_{full} f(S * T * x_full) = Tᵀ * Sᵀ * ∇_{collision} f(S * T * x_full)
     // x = ∇_{collision} f(S * T * x_full); m_displacement_dof_map = S * T
@@ -421,8 +422,8 @@ CollisionMesh::to_full_dof(const Eigen::SparseMatrix<double>& X) const
 
 std::vector<bool> CollisionMesh::construct_is_on_surface(
     const long num_vertices,
-    const Eigen::MatrixXi& edges,
-    const Eigen::VectorXi& codim_vertices)
+    Eigen::ConstRef<Eigen::MatrixXi> edges,
+    Eigen::ConstRef<Eigen::VectorXi> codim_vertices)
 {
     std::vector<bool> is_on_surface(num_vertices, false);
     for (int i = 0; i < codim_vertices.size(); i++) {
@@ -442,7 +443,8 @@ std::vector<bool> CollisionMesh::construct_is_on_surface(
 // ============================================================================/
 
 Eigen::MatrixXi CollisionMesh::construct_faces_to_edges(
-    const Eigen::MatrixXi& faces, const Eigen::MatrixXi& edges)
+    Eigen::ConstRef<Eigen::MatrixXi> faces,
+    Eigen::ConstRef<Eigen::MatrixXi> edges)
 {
     if (faces.size() == 0) {
         return Eigen::MatrixXi(faces.rows(), faces.cols());

--- a/src/ipc/collision_mesh.hpp
+++ b/src/ipc/collision_mesh.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
+#include <ipc/utils/eigen_ext.hpp>
 #include <ipc/utils/unordered_map_and_set.hpp>
-
-#include <Eigen/Core>
-#include <Eigen/Sparse>
 
 namespace ipc {
 
@@ -20,9 +18,9 @@ public:
     /// @param faces The faces of the collision mesh (#F × 3).
     /// @param displacement_map The displacement mapping from displacements on the full mesh to the collision mesh.
     CollisionMesh(
-        const Eigen::MatrixXd& rest_positions,
-        const Eigen::MatrixXi& edges = Eigen::MatrixXi(),
-        const Eigen::MatrixXi& faces = Eigen::MatrixXi(),
+        Eigen::ConstRef<Eigen::MatrixXd> rest_positions,
+        Eigen::ConstRef<Eigen::MatrixXi> edges = Eigen::MatrixXi(),
+        Eigen::ConstRef<Eigen::MatrixXi> faces = Eigen::MatrixXi(),
         const Eigen::SparseMatrix<double>& displacement_map =
             Eigen::SparseMatrix<double>());
 
@@ -34,9 +32,9 @@ public:
     /// @param displacement_map The displacement mapping from displacements on the full mesh to the collision mesh.
     CollisionMesh(
         const std::vector<bool>& include_vertex,
-        const Eigen::MatrixXd& full_rest_positions,
-        const Eigen::MatrixXi& edges = Eigen::MatrixXi(),
-        const Eigen::MatrixXi& faces = Eigen::MatrixXi(),
+        Eigen::ConstRef<Eigen::MatrixXd> full_rest_positions,
+        Eigen::ConstRef<Eigen::MatrixXi> edges = Eigen::MatrixXi(),
+        Eigen::ConstRef<Eigen::MatrixXi> faces = Eigen::MatrixXi(),
         const Eigen::SparseMatrix<double>& displacement_map =
             Eigen::SparseMatrix<double>());
 
@@ -46,9 +44,9 @@ public:
     /// @param faces The face matrix of mesh (#F × 3).
     /// @return Constructed CollisionMesh.
     static CollisionMesh build_from_full_mesh(
-        const Eigen::MatrixXd& full_rest_positions,
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces = Eigen::MatrixXi())
+        Eigen::ConstRef<Eigen::MatrixXd> full_rest_positions,
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces = Eigen::MatrixXi())
     {
         return CollisionMesh(
             construct_is_on_surface(full_rest_positions.rows(), edges),
@@ -126,19 +124,20 @@ public:
     /// @brief Compute the vertex positions from the positions of the full mesh.
     /// @param full_positions The vertex positions of the full mesh (#FV × dim).
     /// @return The vertex positions of the collision mesh (#V × dim).
-    Eigen::MatrixXd vertices(const Eigen::MatrixXd& full_positions) const;
+    Eigen::MatrixXd
+    vertices(Eigen::ConstRef<Eigen::MatrixXd> full_positions) const;
 
     /// @brief Compute the vertex positions from vertex displacements on the full mesh.
     /// @param full_displacements The vertex displacements on the full mesh (#FV × dim).
     /// @return The vertex positions of the collision mesh (#V × dim).
-    Eigen::MatrixXd
-    displace_vertices(const Eigen::MatrixXd& full_displacements) const;
+    Eigen::MatrixXd displace_vertices(
+        Eigen::ConstRef<Eigen::MatrixXd> full_displacements) const;
 
     /// @brief Map vertex displacements on the full mesh to vertex displacements on the collision mesh.
     /// @param full_displacements The vertex displacements on the full mesh (#FV × dim).
     /// @return The vertex displacements on the collision mesh (#V × dim).
-    Eigen::MatrixXd
-    map_displacements(const Eigen::MatrixXd& full_displacements) const;
+    Eigen::MatrixXd map_displacements(
+        Eigen::ConstRef<Eigen::MatrixXd> full_displacements) const;
 
     /// @brief Map a vertex ID to the corresponding vertex ID in the full mesh.
     /// @param id Vertex ID in the collision mesh.
@@ -154,7 +153,7 @@ public:
     /// mesh (i.e., applies the chain-rule).
     /// @param x Vector quantity on the collision mesh with size equal to ndof().
     /// @return Vector quantity on the full mesh with size equal to full_ndof().
-    Eigen::VectorXd to_full_dof(const Eigen::VectorXd& x) const;
+    Eigen::VectorXd to_full_dof(Eigen::ConstRef<Eigen::VectorXd> x) const;
 
     /// @brief Map a matrix quantity on the collision mesh to the full mesh.
     /// This is useful for mapping Hessians from the collision mesh to the full
@@ -269,15 +268,16 @@ public:
     /// @return A vector of bools indicating whether each vertex is on the surface.
     static std::vector<bool> construct_is_on_surface(
         const long num_vertices,
-        const Eigen::MatrixXi& edges,
-        const Eigen::VectorXi& codim_vertices = Eigen::VectorXi());
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::VectorXi> codim_vertices = Eigen::VectorXi());
 
     /// @brief Construct a matrix that maps from the faces' edges to rows in the edges matrix.
     /// @param faces The face matrix of mesh (#F × 3).
     /// @param edges The edge matrix of mesh (#E × 2).
     /// @return Matrix that maps from the faces' edges to rows in the edges matrix.
     static Eigen::MatrixXi construct_faces_to_edges(
-        const Eigen::MatrixXi& faces, const Eigen::MatrixXi& edges);
+        Eigen::ConstRef<Eigen::MatrixXi> faces,
+        Eigen::ConstRef<Eigen::MatrixXi> edges);
 
     /// A function that takes two vertex IDs and returns true if the vertices
     /// (and faces or edges containing the vertices) can collide. By default all

--- a/src/ipc/collisions/normal/edge_edge.cpp
+++ b/src/ipc/collisions/normal/edge_edge.cpp
@@ -42,20 +42,21 @@ EdgeEdgeNormalCollision::EdgeEdgeNormalCollision(
 }
 
 double EdgeEdgeNormalCollision::mollifier_threshold(
-    const VectorMax12d& rest_positions) const
+    Eigen::ConstRef<VectorMax12d> rest_positions) const
 {
     return edge_edge_mollifier_threshold(
         rest_positions.segment<3>(0), rest_positions.segment<3>(3),
         rest_positions.segment<3>(6), rest_positions.segment<3>(9));
 }
 
-double EdgeEdgeNormalCollision::mollifier(const VectorMax12d& positions) const
+double EdgeEdgeNormalCollision::mollifier(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     return mollifier(positions, eps_x);
 }
 
 double EdgeEdgeNormalCollision::mollifier(
-    const VectorMax12d& positions, const double _eps_x) const
+    Eigen::ConstRef<VectorMax12d> positions, const double _eps_x) const
 {
     assert(positions.size() == 12);
     return edge_edge_mollifier(
@@ -63,14 +64,14 @@ double EdgeEdgeNormalCollision::mollifier(
         positions.segment<3>(6), positions.segment<3>(9), _eps_x);
 }
 
-VectorMax12d
-EdgeEdgeNormalCollision::mollifier_gradient(const VectorMax12d& positions) const
+VectorMax12d EdgeEdgeNormalCollision::mollifier_gradient(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     return mollifier_gradient(positions, eps_x);
 }
 
 VectorMax12d EdgeEdgeNormalCollision::mollifier_gradient(
-    const VectorMax12d& positions, const double _eps_x) const
+    Eigen::ConstRef<VectorMax12d> positions, const double _eps_x) const
 {
     assert(positions.size() == 12);
     return edge_edge_mollifier_gradient(
@@ -78,14 +79,14 @@ VectorMax12d EdgeEdgeNormalCollision::mollifier_gradient(
         positions.segment<3>(6), positions.segment<3>(9), _eps_x);
 }
 
-MatrixMax12d
-EdgeEdgeNormalCollision::mollifier_hessian(const VectorMax12d& positions) const
+MatrixMax12d EdgeEdgeNormalCollision::mollifier_hessian(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     return mollifier_hessian(positions, eps_x);
 }
 
 MatrixMax12d EdgeEdgeNormalCollision::mollifier_hessian(
-    const VectorMax12d& positions, const double _eps_x) const
+    Eigen::ConstRef<VectorMax12d> positions, const double _eps_x) const
 {
     assert(positions.size() == 12);
     return edge_edge_mollifier_hessian(
@@ -94,7 +95,8 @@ MatrixMax12d EdgeEdgeNormalCollision::mollifier_hessian(
 }
 
 Vector12d EdgeEdgeNormalCollision::mollifier_gradient_wrt_x(
-    const VectorMax12d& rest_positions, const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> rest_positions,
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(rest_positions.size() == 12);
     assert(positions.size() == 12);
@@ -106,7 +108,8 @@ Vector12d EdgeEdgeNormalCollision::mollifier_gradient_wrt_x(
 }
 
 Matrix12d EdgeEdgeNormalCollision::mollifier_gradient_jacobian_wrt_x(
-    const VectorMax12d& rest_positions, const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> rest_positions,
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(rest_positions.size() == 12);
     assert(positions.size() == 12);

--- a/src/ipc/collisions/normal/edge_edge.hpp
+++ b/src/ipc/collisions/normal/edge_edge.hpp
@@ -34,62 +34,62 @@ public:
     /// @brief Compute the mollifier threshold for the distance.
     /// @param rest_positions The stencil's rest vertex positions.
     /// @return The mollifier threshold.
-    double
-    mollifier_threshold(const VectorMax12d& rest_positions) const override;
+    double mollifier_threshold(
+        Eigen::ConstRef<VectorMax12d> rest_positions) const override;
 
     /// @brief Compute the mollifier for the distance.
     /// @param positions The stencil's vertex positions.
     /// @return The mollifier value.
-    double mollifier(const VectorMax12d& positions) const override;
+    double mollifier(Eigen::ConstRef<VectorMax12d> positions) const override;
 
     /// @brief Compute the mollifier for the distance.
     /// @param positions The stencil's vertex positions.
     /// @param eps_x The mollifier's tolerance.
     /// @return The mollifier value.
-    double
-    mollifier(const VectorMax12d& positions, double eps_x) const override;
+    double mollifier(
+        Eigen::ConstRef<VectorMax12d> positions, double eps_x) const override;
 
     /// @brief Compute the gradient of the mollifier for the distance w.r.t. positions.
     /// @param positions The stencil's vertex positions.
     /// @return The mollifier gradient.
     VectorMax12d
-    mollifier_gradient(const VectorMax12d& positions) const override;
+    mollifier_gradient(Eigen::ConstRef<VectorMax12d> positions) const override;
 
     /// @brief Compute the gradient of the mollifier for the distance wrt the positions.
     /// @param positions The stencil's vertex positions.
     /// @param eps_x The mollifier's tolerance.
     /// @return The mollifier gradient.
     VectorMax12d mollifier_gradient(
-        const VectorMax12d& positions, double eps_x) const override;
+        Eigen::ConstRef<VectorMax12d> positions, double eps_x) const override;
 
     /// @brief Compute the Hessian of the mollifier for the distance w.r.t. positions.
     /// @param positions The stencil's vertex positions.
     /// @return The mollifier Hessian.
     MatrixMax12d
-    mollifier_hessian(const VectorMax12d& positions) const override;
+    mollifier_hessian(Eigen::ConstRef<VectorMax12d> positions) const override;
 
     /// @brief Compute the Hessian of the mollifier for the distance wrt the positions.
     /// @param positions The stencil's vertex positions.
     /// @param eps_x The mollifier's tolerance.
     /// @return The mollifier Hessian.
     MatrixMax12d mollifier_hessian(
-        const VectorMax12d& positions, double eps_x) const override;
+        Eigen::ConstRef<VectorMax12d> positions, double eps_x) const override;
 
     /// @brief Compute the gradient of the mollifier for the distance w.r.t. rest positions.
     /// @param rest_positions The stencil's rest vertex positions.
     /// @param positions The stencil's vertex positions.
     /// @return The mollifier gradient w.r.t. rest positions.
     Vector12d mollifier_gradient_wrt_x(
-        const VectorMax12d& rest_positions,
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> rest_positions,
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     /// @brief Compute the jacobian of the distance mollifier's gradient w.r.t. rest positions.
     /// @param rest_positions The stencil's rest vertex positions.
     /// @param positions The stencil's vertex positions.
     /// @return The jacobian of the mollifier's gradient w.r.t. rest positions.
     Matrix12d mollifier_gradient_jacobian_wrt_x(
-        const VectorMax12d& rest_positions,
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> rest_positions,
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     // ------------------------------------------------------------------------
 

--- a/src/ipc/collisions/normal/normal_collision.cpp
+++ b/src/ipc/collisions/normal/normal_collision.cpp
@@ -9,49 +9,51 @@ NormalCollision::NormalCollision(
 {
 }
 
-double NormalCollision::mollifier(const VectorMax12d& positions) const
+double NormalCollision::mollifier(Eigen::ConstRef<VectorMax12d> positions) const
 {
     return 1.0;
 }
 
-double
-NormalCollision::mollifier(const VectorMax12d& positions, double eps_x) const
+double NormalCollision::mollifier(
+    Eigen::ConstRef<VectorMax12d> positions, double eps_x) const
 {
     return 1.0;
 }
 
-VectorMax12d
-NormalCollision::mollifier_gradient(const VectorMax12d& positions) const
+VectorMax12d NormalCollision::mollifier_gradient(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     return VectorMax12d::Zero(positions.size());
 }
 
 VectorMax12d NormalCollision::mollifier_gradient(
-    const VectorMax12d& positions, double eps_x) const
+    Eigen::ConstRef<VectorMax12d> positions, double eps_x) const
 {
     return VectorMax12d::Zero(positions.size());
 }
 
-MatrixMax12d
-NormalCollision::mollifier_hessian(const VectorMax12d& positions) const
+MatrixMax12d NormalCollision::mollifier_hessian(
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     return MatrixMax12d::Zero(positions.size(), positions.size());
 }
 
 MatrixMax12d NormalCollision::mollifier_hessian(
-    const VectorMax12d& positions, double eps_x) const
+    Eigen::ConstRef<VectorMax12d> positions, double eps_x) const
 {
     return MatrixMax12d::Zero(positions.size(), positions.size());
 }
 
 Vector12d NormalCollision::mollifier_gradient_wrt_x(
-    const VectorMax12d& rest_positions, const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> rest_positions,
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     return Vector12d::Zero(rest_positions.size());
 }
 
 Matrix12d NormalCollision::mollifier_gradient_jacobian_wrt_x(
-    const VectorMax12d& rest_positions, const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> rest_positions,
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     return Matrix12d::Zero(rest_positions.size(), positions.size());
 }

--- a/src/ipc/collisions/normal/normal_collision.hpp
+++ b/src/ipc/collisions/normal/normal_collision.hpp
@@ -27,7 +27,8 @@ public:
     /// @brief Compute the mollifier threshold for the distance.
     /// @param rest_positions The stencil's rest vertex positions.
     /// @return The mollifier threshold.
-    virtual double mollifier_threshold(const VectorMax12d& rest_positions) const
+    virtual double
+    mollifier_threshold(Eigen::ConstRef<VectorMax12d> rest_positions) const
     {
         return std::numeric_limits<double>::quiet_NaN(); // No mollifier
     }
@@ -35,54 +36,56 @@ public:
     /// @brief Compute the mollifier for the distance.
     /// @param positions The stencil's vertex positions.
     /// @return The mollifier value.
-    virtual double mollifier(const VectorMax12d& positions) const;
+    virtual double mollifier(Eigen::ConstRef<VectorMax12d> positions) const;
 
     /// @brief Compute the mollifier for the distance.
     /// @param positions The stencil's vertex positions.
     /// @param eps_x The mollifier's threshold.
     /// @return The mollifier value.
-    virtual double mollifier(const VectorMax12d& positions, double eps_x) const;
+    virtual double
+    mollifier(Eigen::ConstRef<VectorMax12d> positions, double eps_x) const;
 
     /// @brief Compute the gradient of the mollifier for the distance wrt the positions.
     /// @param positions The stencil's vertex positions.
     /// @return The mollifier gradient.
     virtual VectorMax12d
-    mollifier_gradient(const VectorMax12d& positions) const;
+    mollifier_gradient(Eigen::ConstRef<VectorMax12d> positions) const;
 
     /// @brief Compute the gradient of the mollifier for the distance wrt the positions.
     /// @param positions The stencil's vertex positions.
     /// @param eps_x The mollifier's threshold.
     /// @return The mollifier gradient.
-    virtual VectorMax12d
-    mollifier_gradient(const VectorMax12d& positions, double eps_x) const;
+    virtual VectorMax12d mollifier_gradient(
+        Eigen::ConstRef<VectorMax12d> positions, double eps_x) const;
 
     /// @brief Compute the Hessian of the mollifier for the distance wrt the positions.
     /// @param positions The stencil's vertex positions.
-    /// @return The mollifier Hessian.
-    virtual MatrixMax12d mollifier_hessian(const VectorMax12d& positions) const;
-
-    /// @brief Compute the Hessian of the mollifier for the distance wrt the positions.
-    /// @param positions The stencil's vertex positions.
-    /// @param eps_x The mollifier's threshold.
     /// @return The mollifier Hessian.
     virtual MatrixMax12d
-    mollifier_hessian(const VectorMax12d& positions, double eps_x) const;
+    mollifier_hessian(Eigen::ConstRef<VectorMax12d> positions) const;
+
+    /// @brief Compute the Hessian of the mollifier for the distance wrt the positions.
+    /// @param positions The stencil's vertex positions.
+    /// @param eps_x The mollifier's threshold.
+    /// @return The mollifier Hessian.
+    virtual MatrixMax12d mollifier_hessian(
+        Eigen::ConstRef<VectorMax12d> positions, double eps_x) const;
 
     /// @brief Compute the gradient of the mollifier for the distance w.r.t. rest positions.
     /// @param rest_positions The stencil's rest vertex positions.
     /// @param positions The stencil's vertex positions.
     /// @return The mollifier gradient w.r.t. rest positions.
     virtual Vector12d mollifier_gradient_wrt_x(
-        const VectorMax12d& rest_positions,
-        const VectorMax12d& positions) const;
+        Eigen::ConstRef<VectorMax12d> rest_positions,
+        Eigen::ConstRef<VectorMax12d> positions) const;
 
     /// @brief Compute the jacobian of the distance mollifier's gradient w.r.t. rest positions.
     /// @param rest_positions The stencil's rest vertex positions.
     /// @param positions The stencil's vertex positions.
     /// @return The jacobian of the mollifier's gradient w.r.t. rest positions.
     virtual Matrix12d mollifier_gradient_jacobian_wrt_x(
-        const VectorMax12d& rest_positions,
-        const VectorMax12d& positions) const;
+        Eigen::ConstRef<VectorMax12d> rest_positions,
+        Eigen::ConstRef<VectorMax12d> positions) const;
 
     // -------------------------------------------------------------------------
 

--- a/src/ipc/collisions/normal/normal_collisions.cpp
+++ b/src/ipc/collisions/normal/normal_collisions.cpp
@@ -28,8 +28,8 @@ namespace {
     template <typename Candidate>
     std::vector<VertexVertexCandidate>
     element_vertex_to_vertex_vertex_candidates(
-        const Eigen::MatrixXi& elements,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXi> elements,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<Candidate>& candidates,
         const std::function<bool(double)>& is_active)
     {
@@ -55,7 +55,7 @@ namespace {
 
     std::vector<VertexVertexCandidate> edge_vertex_to_vertex_vertex_candidates(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<EdgeVertexCandidate>& ev_candidates,
         const std::function<bool(double)>& is_active)
     {
@@ -65,7 +65,7 @@ namespace {
 
     std::vector<VertexVertexCandidate> face_vertex_to_vertex_vertex_candidates(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<FaceVertexCandidate>& fv_candidates,
         const std::function<bool(double)>& is_active)
     {
@@ -75,7 +75,7 @@ namespace {
 
     std::vector<EdgeVertexCandidate> face_vertex_to_edge_vertex_candidates(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<FaceVertexCandidate>& fv_candidates,
         const std::function<bool(double)>& is_active)
     {
@@ -104,7 +104,7 @@ namespace {
 
     std::vector<EdgeVertexCandidate> edge_edge_to_edge_vertex_candidates(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<EdgeEdgeCandidate>& ee_candidates,
         const std::function<bool(double)>& is_active)
     {
@@ -142,7 +142,7 @@ namespace {
 
 void NormalCollisions::build(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const double dhat,
     const double dmin,
     const std::shared_ptr<BroadPhase> broad_phase)
@@ -160,7 +160,7 @@ void NormalCollisions::build(
 void NormalCollisions::build(
     const Candidates& candidates,
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const double dhat,
     const double dmin)
 {
@@ -329,7 +329,7 @@ void NormalCollisions::set_enable_shape_derivatives(
 
 // NOTE: Actually distance squared
 double NormalCollisions::compute_minimum_distance(
-    const CollisionMesh& mesh, const Eigen::MatrixXd& vertices) const
+    const CollisionMesh& mesh, Eigen::ConstRef<Eigen::MatrixXd> vertices) const
 {
     assert(vertices.rows() == mesh.num_vertices());
 
@@ -465,7 +465,7 @@ bool NormalCollisions::is_plane_vertex(size_t i) const
 }
 
 std::string NormalCollisions::to_string(
-    const CollisionMesh& mesh, const Eigen::MatrixXd& vertices) const
+    const CollisionMesh& mesh, Eigen::ConstRef<Eigen::MatrixXd> vertices) const
 {
     std::stringstream ss;
     for (const auto& vv : vv_collisions) {

--- a/src/ipc/collisions/normal/normal_collisions.hpp
+++ b/src/ipc/collisions/normal/normal_collisions.hpp
@@ -31,7 +31,7 @@ public:
     /// @param broad_phase_method Broad-phase method to use.
     void build(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const double dhat,
         const double dmin = 0,
         const std::shared_ptr<BroadPhase> broad_phase =
@@ -46,7 +46,7 @@ public:
     void build(
         const Candidates& candidates,
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const double dhat,
         const double dmin = 0);
 
@@ -57,7 +57,8 @@ public:
     /// @param vertices Vertices of the collision mesh.
     /// @returns The minimum distance between any non-adjacent elements.
     double compute_minimum_distance(
-        const CollisionMesh& mesh, const Eigen::MatrixXd& vertices) const;
+        const CollisionMesh& mesh,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices) const;
 
     // ------------------------------------------------------------------------
 
@@ -139,8 +140,9 @@ public:
     /// @param enable_shape_derivatives If the collision set should enable shape derivative computation.
     void set_enable_shape_derivatives(const bool enable_shape_derivatives);
 
-    std::string
-    to_string(const CollisionMesh& mesh, const Eigen::MatrixXd& vertices) const;
+    std::string to_string(
+        const CollisionMesh& mesh,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices) const;
 
 public:
     /// @brief Vertex-vertex normal collisions.

--- a/src/ipc/collisions/normal/normal_collisions_builder.cpp
+++ b/src/ipc/collisions/normal/normal_collisions_builder.cpp
@@ -20,7 +20,7 @@ NormalCollisionsBuilder::NormalCollisionsBuilder(
 
 void NormalCollisionsBuilder::add_vertex_vertex_collisions(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::vector<VertexVertexCandidate>& candidates,
     const std::function<bool(double)>& is_active,
     const size_t start_i,
@@ -59,7 +59,7 @@ void NormalCollisionsBuilder::add_vertex_vertex_collisions(
 
 void NormalCollisionsBuilder::add_edge_vertex_collisions(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::vector<EdgeVertexCandidate>& candidates,
     const std::function<bool(double)>& is_active,
     const size_t start_i,
@@ -124,7 +124,7 @@ void NormalCollisionsBuilder::add_edge_vertex_collision(
 
 void NormalCollisionsBuilder::add_edge_edge_collisions(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::vector<EdgeEdgeCandidate>& candidates,
     const std::function<bool(double)>& is_active,
     const size_t start_i,
@@ -225,7 +225,7 @@ void NormalCollisionsBuilder::add_edge_edge_collisions(
 
 void NormalCollisionsBuilder::add_face_vertex_collisions(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::vector<FaceVertexCandidate>& candidates,
     const std::function<bool(double)>& is_active,
     const size_t start_i,
@@ -303,7 +303,7 @@ void NormalCollisionsBuilder::add_face_vertex_collisions(
 
 void NormalCollisionsBuilder::add_edge_vertex_negative_vertex_vertex_collisions(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::vector<VertexVertexCandidate>& candidates,
     const size_t start_i,
     const size_t end_i)
@@ -348,7 +348,7 @@ void NormalCollisionsBuilder::add_edge_vertex_negative_vertex_vertex_collisions(
 
 void NormalCollisionsBuilder::add_face_vertex_positive_vertex_vertex_collisions(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::vector<VertexVertexCandidate>& candidates,
     const size_t start_i,
     const size_t end_i)
@@ -391,7 +391,7 @@ void NormalCollisionsBuilder::add_face_vertex_positive_vertex_vertex_collisions(
 
 void NormalCollisionsBuilder::add_face_vertex_negative_edge_vertex_collisions(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::vector<EdgeVertexCandidate>& candidates,
     const size_t start_i,
     const size_t end_i)
@@ -429,7 +429,7 @@ void NormalCollisionsBuilder::add_face_vertex_negative_edge_vertex_collisions(
 
 void NormalCollisionsBuilder::add_edge_edge_negative_edge_vertex_collisions(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::vector<EdgeVertexCandidate>& candidates,
     const size_t start_i,
     const size_t end_i)

--- a/src/ipc/collisions/normal/normal_collisions_builder.hpp
+++ b/src/ipc/collisions/normal/normal_collisions_builder.hpp
@@ -15,7 +15,7 @@ public:
 
     void add_vertex_vertex_collisions(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<VertexVertexCandidate>& candidates,
         const std::function<bool(double)>& is_active,
         const size_t start_i,
@@ -23,7 +23,7 @@ public:
 
     void add_edge_vertex_collisions(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<EdgeVertexCandidate>& candidates,
         const std::function<bool(double)>& is_active,
         const size_t start_i,
@@ -31,7 +31,7 @@ public:
 
     void add_edge_edge_collisions(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<EdgeEdgeCandidate>& candidates,
         const std::function<bool(double)>& is_active,
         const size_t start_i,
@@ -39,7 +39,7 @@ public:
 
     void add_face_vertex_collisions(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<FaceVertexCandidate>& candidates,
         const std::function<bool(double)>& is_active,
         const size_t start_i,
@@ -50,28 +50,28 @@ public:
 
     void add_edge_vertex_negative_vertex_vertex_collisions(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<VertexVertexCandidate>& candidates,
         const size_t start_i,
         const size_t end_i);
 
     void add_face_vertex_positive_vertex_vertex_collisions(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<VertexVertexCandidate>& candidates,
         const size_t start_i,
         const size_t end_i);
 
     void add_face_vertex_negative_edge_vertex_collisions(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<EdgeVertexCandidate>& candidates,
         const size_t start_i,
         const size_t end_i);
 
     void add_edge_edge_negative_edge_vertex_collisions(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const std::vector<EdgeVertexCandidate>& candidates,
         const size_t start_i,
         const size_t end_i);

--- a/src/ipc/collisions/normal/plane_vertex.cpp
+++ b/src/ipc/collisions/normal/plane_vertex.cpp
@@ -6,8 +6,8 @@
 namespace ipc {
 
 PlaneVertexNormalCollision::PlaneVertexNormalCollision(
-    const VectorMax3d& _plane_origin,
-    const VectorMax3d& _plane_normal,
+    Eigen::ConstRef<VectorMax3d> _plane_origin,
+    Eigen::ConstRef<VectorMax3d> _plane_normal,
     const long _vertex_id)
     : plane_origin(_plane_origin)
     , plane_normal(_plane_normal)
@@ -15,29 +15,29 @@ PlaneVertexNormalCollision::PlaneVertexNormalCollision(
 {
 }
 
-double
-PlaneVertexNormalCollision::compute_distance(const VectorMax12d& point) const
+double PlaneVertexNormalCollision::compute_distance(
+    Eigen::ConstRef<VectorMax12d> point) const
 {
     assert(point.size() == plane_origin.size());
     return point_plane_distance(point, plane_origin, plane_normal);
 }
 
 VectorMax12d PlaneVertexNormalCollision::compute_distance_gradient(
-    const VectorMax12d& point) const
+    Eigen::ConstRef<VectorMax12d> point) const
 {
     assert(point.size() == plane_origin.size());
     return point_plane_distance_gradient(point, plane_origin, plane_normal);
 }
 
 MatrixMax12d PlaneVertexNormalCollision::compute_distance_hessian(
-    const VectorMax12d& point) const
+    Eigen::ConstRef<VectorMax12d> point) const
 {
     assert(point.size() == plane_origin.size());
     return point_plane_distance_hessian(point, plane_origin, plane_normal);
 }
 
 VectorMax4d PlaneVertexNormalCollision::compute_coefficients(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     VectorMax4d coeffs(1);
     coeffs << 1.0;
@@ -45,8 +45,8 @@ VectorMax4d PlaneVertexNormalCollision::compute_coefficients(
 }
 
 bool PlaneVertexNormalCollision::ccd(
-    const VectorMax12d& vertices_t0,
-    const VectorMax12d& vertices_t1,
+    Eigen::ConstRef<VectorMax12d> vertices_t0,
+    Eigen::ConstRef<VectorMax12d> vertices_t1,
     double& toi,
     const double min_distance,
     const double tmax,

--- a/src/ipc/collisions/normal/plane_vertex.hpp
+++ b/src/ipc/collisions/normal/plane_vertex.hpp
@@ -8,15 +8,15 @@ namespace ipc {
 class PlaneVertexNormalCollision : public NormalCollision {
 public:
     PlaneVertexNormalCollision(
-        const VectorMax3d& plane_origin,
-        const VectorMax3d& plane_normal,
+        Eigen::ConstRef<VectorMax3d> plane_origin,
+        Eigen::ConstRef<VectorMax3d> plane_normal,
         const long vertex_id);
 
     int num_vertices() const override { return 1; };
 
     std::array<long, 4> vertex_ids(
-        const Eigen::MatrixXi& edges,
-        const Eigen::MatrixXi& faces) const override
+        Eigen::ConstRef<Eigen::MatrixXi> edges,
+        Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
         return { { vertex_id, -1, -1, -1 } };
     }
@@ -29,25 +29,25 @@ public:
     /// @brief Compute the distance between the point and plane.
     /// @param point Point's position.
     /// @return Distance of the stencil.
-    double compute_distance(const VectorMax12d& point) const override;
+    double compute_distance(Eigen::ConstRef<VectorMax12d> point) const override;
 
     /// @brief Compute the gradient of the distance w.r.t. the point's positions.
     /// @param point Point's position.
     /// @return Distance gradient w.r.t. the point's positions.
-    VectorMax12d
-    compute_distance_gradient(const VectorMax12d& point) const override;
+    VectorMax12d compute_distance_gradient(
+        Eigen::ConstRef<VectorMax12d> point) const override;
 
     /// @brief Compute the distance Hessian of the stencil w.r.t. the stencil's vertex positions.
     /// @param point Point's position.
     /// @return Distance Hessian w.r.t. the point's positions.
-    MatrixMax12d
-    compute_distance_hessian(const VectorMax12d& point) const override;
+    MatrixMax12d compute_distance_hessian(
+        Eigen::ConstRef<VectorMax12d> point) const override;
 
     /// @brief Compute the coefficients of the stencil.
     /// @param positions Vertex positions.
     /// @return Coefficients of the stencil.
-    VectorMax4d
-    compute_coefficients(const VectorMax12d& positions) const override;
+    VectorMax4d compute_coefficients(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     /// @brief Perform narrow-phase CCD on the candidate.
     /// @param[in] vertices_t0 Stencil vertices at the start of the time step.
@@ -58,8 +58,8 @@ public:
     /// @param[in] narrow_phase_ccd The narrow phase CCD algorithm to use.
     /// @return If the candidate had a collision over the time interval.
     bool
-    ccd(const VectorMax12d& vertices_t0,
-        const VectorMax12d& vertices_t1,
+    ccd(Eigen::ConstRef<VectorMax12d> vertices_t0,
+        Eigen::ConstRef<VectorMax12d> vertices_t1,
         double& toi,
         const double min_distance = 0.0,
         const double tmax = 1.0,

--- a/src/ipc/collisions/tangential/edge_edge.cpp
+++ b/src/ipc/collisions/tangential/edge_edge.cpp
@@ -17,7 +17,7 @@ EdgeEdgeTangentialCollision::EdgeEdgeTangentialCollision(
 
 EdgeEdgeTangentialCollision::EdgeEdgeTangentialCollision(
     const EdgeEdgeNormalCollision& collision,
-    const VectorMax12d& positions,
+    Eigen::ConstRef<VectorMax12d> positions,
     const NormalPotential& normal_potential,
     const double normal_stiffness)
     : EdgeEdgeTangentialCollision(collision)
@@ -29,7 +29,7 @@ EdgeEdgeTangentialCollision::EdgeEdgeTangentialCollision(
 // ============================================================================
 
 MatrixMax<double, 3, 2> EdgeEdgeTangentialCollision::compute_tangent_basis(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
 
     assert(positions.size() == ndof());
@@ -40,7 +40,7 @@ MatrixMax<double, 3, 2> EdgeEdgeTangentialCollision::compute_tangent_basis(
 
 MatrixMax<double, 36, 2>
 EdgeEdgeTangentialCollision::compute_tangent_basis_jacobian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return edge_edge_tangent_basis_jacobian(
@@ -51,7 +51,7 @@ EdgeEdgeTangentialCollision::compute_tangent_basis_jacobian(
 // ============================================================================
 
 VectorMax2d EdgeEdgeTangentialCollision::compute_closest_point(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return edge_edge_closest_point(
@@ -61,7 +61,7 @@ VectorMax2d EdgeEdgeTangentialCollision::compute_closest_point(
 
 MatrixMax<double, 2, 12>
 EdgeEdgeTangentialCollision::compute_closest_point_jacobian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return edge_edge_closest_point_jacobian(
@@ -72,7 +72,7 @@ EdgeEdgeTangentialCollision::compute_closest_point_jacobian(
 // ============================================================================
 
 VectorMax3d EdgeEdgeTangentialCollision::relative_velocity(
-    const VectorMax12d& velocities) const
+    Eigen::ConstRef<VectorMax12d> velocities) const
 {
     assert(velocities.size() == 12);
     return edge_edge_relative_velocity(
@@ -81,7 +81,7 @@ VectorMax3d EdgeEdgeTangentialCollision::relative_velocity(
 }
 
 MatrixMax<double, 3, 12> EdgeEdgeTangentialCollision::relative_velocity_matrix(
-    const VectorMax2d& _closest_point) const
+    Eigen::ConstRef<VectorMax2d> _closest_point) const
 {
     assert(_closest_point.size() == 2);
     return edge_edge_relative_velocity_matrix(dim(), _closest_point);
@@ -89,7 +89,7 @@ MatrixMax<double, 3, 12> EdgeEdgeTangentialCollision::relative_velocity_matrix(
 
 MatrixMax<double, 6, 12>
 EdgeEdgeTangentialCollision::relative_velocity_matrix_jacobian(
-    const VectorMax2d& _closest_point) const
+    Eigen::ConstRef<VectorMax2d> _closest_point) const
 {
     assert(_closest_point.size() == 2);
     return edge_edge_relative_velocity_matrix_jacobian(dim(), _closest_point);

--- a/src/ipc/collisions/tangential/edge_edge.hpp
+++ b/src/ipc/collisions/tangential/edge_edge.hpp
@@ -15,7 +15,7 @@ public:
 
     EdgeEdgeTangentialCollision(
         const EdgeEdgeNormalCollision& collision,
-        const VectorMax12d& positions,
+        Eigen::ConstRef<VectorMax12d> positions,
         const NormalPotential& normal_potential,
         const double normal_stiffness);
 
@@ -26,28 +26,28 @@ protected:
         return EdgeEdgeDistanceType::EA_EB;
     }
 
-    MatrixMax<double, 3, 2>
-    compute_tangent_basis(const VectorMax12d& positions) const override;
+    MatrixMax<double, 3, 2> compute_tangent_basis(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     MatrixMax<double, 36, 2> compute_tangent_basis_jacobian(
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax2d
-    compute_closest_point(const VectorMax12d& positions) const override;
+    VectorMax2d compute_closest_point(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     MatrixMax<double, 2, 12> compute_closest_point_jacobian(
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     VectorMax3d
-    relative_velocity(const VectorMax12d& velocities) const override;
+    relative_velocity(Eigen::ConstRef<VectorMax12d> velocities) const override;
 
     using TangentialCollision::relative_velocity_matrix;
 
-    MatrixMax<double, 3, 12>
-    relative_velocity_matrix(const VectorMax2d& closest_point) const override;
+    MatrixMax<double, 3, 12> relative_velocity_matrix(
+        Eigen::ConstRef<VectorMax2d> closest_point) const override;
 
     MatrixMax<double, 6, 12> relative_velocity_matrix_jacobian(
-        const VectorMax2d& closest_point) const override;
+        Eigen::ConstRef<VectorMax2d> closest_point) const override;
 };
 
 } // namespace ipc

--- a/src/ipc/collisions/tangential/edge_vertex.cpp
+++ b/src/ipc/collisions/tangential/edge_vertex.cpp
@@ -17,7 +17,7 @@ EdgeVertexTangentialCollision::EdgeVertexTangentialCollision(
 
 EdgeVertexTangentialCollision::EdgeVertexTangentialCollision(
     const EdgeVertexNormalCollision& collision,
-    const VectorMax12d& positions,
+    Eigen::ConstRef<VectorMax12d> positions,
     const NormalPotential& normal_potential,
     const double normal_stiffness)
     : EdgeVertexTangentialCollision(collision)
@@ -29,7 +29,7 @@ EdgeVertexTangentialCollision::EdgeVertexTangentialCollision(
 // ============================================================================
 
 MatrixMax<double, 3, 2> EdgeVertexTangentialCollision::compute_tangent_basis(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return point_edge_tangent_basis(
@@ -39,7 +39,7 @@ MatrixMax<double, 3, 2> EdgeVertexTangentialCollision::compute_tangent_basis(
 
 MatrixMax<double, 36, 2>
 EdgeVertexTangentialCollision::compute_tangent_basis_jacobian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return point_edge_tangent_basis_jacobian(
@@ -50,7 +50,7 @@ EdgeVertexTangentialCollision::compute_tangent_basis_jacobian(
 // ============================================================================
 
 VectorMax2d EdgeVertexTangentialCollision::compute_closest_point(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     VectorMax2d alpha(1);
@@ -62,7 +62,7 @@ VectorMax2d EdgeVertexTangentialCollision::compute_closest_point(
 
 MatrixMax<double, 2, 12>
 EdgeVertexTangentialCollision::compute_closest_point_jacobian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return point_edge_closest_point_jacobian(
@@ -74,7 +74,7 @@ EdgeVertexTangentialCollision::compute_closest_point_jacobian(
 // ============================================================================
 
 VectorMax3d EdgeVertexTangentialCollision::relative_velocity(
-    const VectorMax12d& velocities) const
+    Eigen::ConstRef<VectorMax12d> velocities) const
 {
     assert(velocities.size() == ndof());
     return point_edge_relative_velocity(
@@ -84,7 +84,7 @@ VectorMax3d EdgeVertexTangentialCollision::relative_velocity(
 
 MatrixMax<double, 3, 12>
 EdgeVertexTangentialCollision::relative_velocity_matrix(
-    const VectorMax2d& _closest_point) const
+    Eigen::ConstRef<VectorMax2d> _closest_point) const
 {
     assert(_closest_point.size() == 1);
     return point_edge_relative_velocity_matrix(dim(), _closest_point[0]);
@@ -92,7 +92,7 @@ EdgeVertexTangentialCollision::relative_velocity_matrix(
 
 MatrixMax<double, 6, 12>
 EdgeVertexTangentialCollision::relative_velocity_matrix_jacobian(
-    const VectorMax2d& _closest_point) const
+    Eigen::ConstRef<VectorMax2d> _closest_point) const
 {
     assert(_closest_point.size() == 1);
     return point_edge_relative_velocity_matrix_jacobian(

--- a/src/ipc/collisions/tangential/edge_vertex.hpp
+++ b/src/ipc/collisions/tangential/edge_vertex.hpp
@@ -15,33 +15,33 @@ public:
 
     EdgeVertexTangentialCollision(
         const EdgeVertexNormalCollision& collision,
-        const VectorMax12d& positions,
+        Eigen::ConstRef<VectorMax12d> positions,
         const NormalPotential& normal_potential,
         const double normal_stiffness);
 
 protected:
-    MatrixMax<double, 3, 2>
-    compute_tangent_basis(const VectorMax12d& positions) const override;
+    MatrixMax<double, 3, 2> compute_tangent_basis(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     MatrixMax<double, 36, 2> compute_tangent_basis_jacobian(
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax2d
-    compute_closest_point(const VectorMax12d& positions) const override;
+    VectorMax2d compute_closest_point(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     MatrixMax<double, 2, 12> compute_closest_point_jacobian(
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     VectorMax3d
-    relative_velocity(const VectorMax12d& velocities) const override;
+    relative_velocity(Eigen::ConstRef<VectorMax12d> velocities) const override;
 
     using TangentialCollision::relative_velocity_matrix;
 
-    MatrixMax<double, 3, 12>
-    relative_velocity_matrix(const VectorMax2d& closest_point) const override;
+    MatrixMax<double, 3, 12> relative_velocity_matrix(
+        Eigen::ConstRef<VectorMax2d> closest_point) const override;
 
     MatrixMax<double, 6, 12> relative_velocity_matrix_jacobian(
-        const VectorMax2d& closest_point) const override;
+        Eigen::ConstRef<VectorMax2d> closest_point) const override;
 };
 
 } // namespace ipc

--- a/src/ipc/collisions/tangential/face_vertex.cpp
+++ b/src/ipc/collisions/tangential/face_vertex.cpp
@@ -17,7 +17,7 @@ FaceVertexTangentialCollision::FaceVertexTangentialCollision(
 
 FaceVertexTangentialCollision::FaceVertexTangentialCollision(
     const FaceVertexNormalCollision& collision,
-    const VectorMax12d& positions,
+    Eigen::ConstRef<VectorMax12d> positions,
     const NormalPotential& normal_potential,
     const double normal_stiffness)
     : FaceVertexTangentialCollision(collision)
@@ -29,7 +29,7 @@ FaceVertexTangentialCollision::FaceVertexTangentialCollision(
 // ============================================================================
 
 MatrixMax<double, 3, 2> FaceVertexTangentialCollision::compute_tangent_basis(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return point_triangle_tangent_basis(
@@ -39,7 +39,7 @@ MatrixMax<double, 3, 2> FaceVertexTangentialCollision::compute_tangent_basis(
 
 MatrixMax<double, 36, 2>
 FaceVertexTangentialCollision::compute_tangent_basis_jacobian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return point_triangle_tangent_basis_jacobian(
@@ -50,7 +50,7 @@ FaceVertexTangentialCollision::compute_tangent_basis_jacobian(
 // ============================================================================
 
 VectorMax2d FaceVertexTangentialCollision::compute_closest_point(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return point_triangle_closest_point(
@@ -60,7 +60,7 @@ VectorMax2d FaceVertexTangentialCollision::compute_closest_point(
 
 MatrixMax<double, 2, 12>
 FaceVertexTangentialCollision::compute_closest_point_jacobian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return point_triangle_closest_point_jacobian(
@@ -71,7 +71,7 @@ FaceVertexTangentialCollision::compute_closest_point_jacobian(
 // ============================================================================
 
 VectorMax3d FaceVertexTangentialCollision::relative_velocity(
-    const VectorMax12d& velocities) const
+    Eigen::ConstRef<VectorMax12d> velocities) const
 {
     assert(velocities.size() == 12);
     return point_triangle_relative_velocity(
@@ -81,7 +81,7 @@ VectorMax3d FaceVertexTangentialCollision::relative_velocity(
 
 MatrixMax<double, 3, 12>
 FaceVertexTangentialCollision::relative_velocity_matrix(
-    const VectorMax2d& _closest_point) const
+    Eigen::ConstRef<VectorMax2d> _closest_point) const
 {
     assert(_closest_point.size() == 2);
     return point_triangle_relative_velocity_matrix(dim(), _closest_point);
@@ -89,7 +89,7 @@ FaceVertexTangentialCollision::relative_velocity_matrix(
 
 MatrixMax<double, 6, 12>
 FaceVertexTangentialCollision::relative_velocity_matrix_jacobian(
-    const VectorMax2d& _closest_point) const
+    Eigen::ConstRef<VectorMax2d> _closest_point) const
 {
     assert(_closest_point.size() == 2);
     return point_triangle_relative_velocity_matrix_jacobian(

--- a/src/ipc/collisions/tangential/face_vertex.hpp
+++ b/src/ipc/collisions/tangential/face_vertex.hpp
@@ -15,33 +15,33 @@ public:
 
     FaceVertexTangentialCollision(
         const FaceVertexNormalCollision& collision,
-        const VectorMax12d& positions,
+        Eigen::ConstRef<VectorMax12d> positions,
         const NormalPotential& normal_potential,
         const double normal_stiffness);
 
 protected:
-    MatrixMax<double, 3, 2>
-    compute_tangent_basis(const VectorMax12d& positions) const override;
+    MatrixMax<double, 3, 2> compute_tangent_basis(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     MatrixMax<double, 36, 2> compute_tangent_basis_jacobian(
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax2d
-    compute_closest_point(const VectorMax12d& positions) const override;
+    VectorMax2d compute_closest_point(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     MatrixMax<double, 2, 12> compute_closest_point_jacobian(
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     VectorMax3d
-    relative_velocity(const VectorMax12d& velocities) const override;
+    relative_velocity(Eigen::ConstRef<VectorMax12d> velocities) const override;
 
     using TangentialCollision::relative_velocity_matrix;
 
-    MatrixMax<double, 3, 12>
-    relative_velocity_matrix(const VectorMax2d& closest_point) const override;
+    MatrixMax<double, 3, 12> relative_velocity_matrix(
+        Eigen::ConstRef<VectorMax2d> closest_point) const override;
 
     MatrixMax<double, 6, 12> relative_velocity_matrix_jacobian(
-        const VectorMax2d& closest_point) const override;
+        Eigen::ConstRef<VectorMax2d> closest_point) const override;
 };
 
 } // namespace ipc

--- a/src/ipc/collisions/tangential/tangential_collision.cpp
+++ b/src/ipc/collisions/tangential/tangential_collision.cpp
@@ -8,7 +8,7 @@ namespace ipc {
 
 void TangentialCollision::init(
     const NormalCollision& collision,
-    const VectorMax12d& positions,
+    Eigen::ConstRef<VectorMax12d> positions,
     const NormalPotential& normal_potential,
     const double normal_stiffness)
 {

--- a/src/ipc/collisions/tangential/tangential_collision.hpp
+++ b/src/ipc/collisions/tangential/tangential_collision.hpp
@@ -16,7 +16,7 @@ protected:
     /// @param normal_stiffness Normal potential stiffness.
     void init(
         const NormalCollision& collision,
-        const VectorMax12d& positions,
+        Eigen::ConstRef<VectorMax12d> positions,
         const NormalPotential& normal_potential,
         const double normal_stiffness);
 
@@ -35,31 +35,31 @@ public:
     /// @param positions Collision stencil's vertex positions.
     /// @return Tangent basis of the collision.
     virtual MatrixMax<double, 3, 2>
-    compute_tangent_basis(const VectorMax12d& positions) const = 0;
+    compute_tangent_basis(Eigen::ConstRef<VectorMax12d> positions) const = 0;
 
     /// @brief Compute the Jacobian of the tangent basis of the collision.
     /// @param positions Collision stencil's vertex positions.
     /// @return Jacobian of the tangent basis of the collision.
-    virtual MatrixMax<double, 36, 2>
-    compute_tangent_basis_jacobian(const VectorMax12d& positions) const = 0;
+    virtual MatrixMax<double, 36, 2> compute_tangent_basis_jacobian(
+        Eigen::ConstRef<VectorMax12d> positions) const = 0;
 
     /// @brief Compute the barycentric coordinates of the closest point.
     /// @param positions Collision stencil's vertex positions.
     /// @return Barycentric coordinates of the closest point.
     virtual VectorMax2d
-    compute_closest_point(const VectorMax12d& positions) const = 0;
+    compute_closest_point(Eigen::ConstRef<VectorMax12d> positions) const = 0;
 
     /// @brief Compute the Jacobian of the barycentric coordinates of the closest point.
     /// @param positions Collision stencil's vertex positions.
     /// @return Jacobian of the barycentric coordinates of the closest point.
-    virtual MatrixMax<double, 2, 12>
-    compute_closest_point_jacobian(const VectorMax12d& positions) const = 0;
+    virtual MatrixMax<double, 2, 12> compute_closest_point_jacobian(
+        Eigen::ConstRef<VectorMax12d> positions) const = 0;
 
     /// @brief Compute the relative velocity of the collision.
     /// @param velocities Collision stencil's vertex velocities.
     /// @return Relative velocity of the collision.
     virtual VectorMax3d
-    relative_velocity(const VectorMax12d& velocities) const = 0;
+    relative_velocity(Eigen::ConstRef<VectorMax12d> velocities) const = 0;
 
     /// @brief Construct the premultiplier matrix for the relative velocity.
     /// @note Uses the cached closest point.
@@ -72,14 +72,14 @@ public:
     /// @brief Construct the premultiplier matrix for the relative velocity.
     /// @param closest_point Barycentric coordinates of the closest point.
     /// @return A matrix M such that `relative_velocity = M * velocities`.
-    virtual MatrixMax<double, 3, 12>
-    relative_velocity_matrix(const VectorMax2d& closest_point) const = 0;
+    virtual MatrixMax<double, 3, 12> relative_velocity_matrix(
+        Eigen::ConstRef<VectorMax2d> closest_point) const = 0;
 
     /// @brief Construct the Jacobian of the relative velocity premultiplier wrt the closest points.
     /// @param closest_point Barycentric coordinates of the closest point.
     /// @return Jacobian of the relative velocity premultiplier wrt the closest points.
     virtual MatrixMax<double, 6, 12> relative_velocity_matrix_jacobian(
-        const VectorMax2d& closest_point) const = 0;
+        Eigen::ConstRef<VectorMax2d> closest_point) const = 0;
 
 public:
     /// @brief Normal force magnitude

--- a/src/ipc/collisions/tangential/tangential_collisions.cpp
+++ b/src/ipc/collisions/tangential/tangential_collisions.cpp
@@ -13,11 +13,11 @@ namespace ipc {
 
 void TangentialCollisions::build(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const NormalCollisions& collisions,
     const NormalPotential& normal_potential,
     const double normal_stiffness,
-    const Eigen::VectorXd& mus,
+    Eigen::ConstRef<Eigen::VectorXd> mus,
     const std::function<double(double, double)>& blend_mu)
 {
     assert(mus.size() == vertices.rows());

--- a/src/ipc/collisions/tangential/tangential_collisions.hpp
+++ b/src/ipc/collisions/tangential/tangential_collisions.hpp
@@ -24,7 +24,7 @@ public:
 
     void build(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const NormalCollisions& collisions,
         const NormalPotential& normal_potential,
         double normal_stiffness,
@@ -37,11 +37,11 @@ public:
 
     void build(
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices,
+        Eigen::ConstRef<Eigen::MatrixXd> vertices,
         const NormalCollisions& collisions,
         const NormalPotential& normal_potential,
         const double normal_stiffness,
-        const Eigen::VectorXd& mus,
+        Eigen::ConstRef<Eigen::VectorXd> mus,
         const std::function<double(double, double)>& blend_mu =
             default_blend_mu);
 

--- a/src/ipc/collisions/tangential/vertex_vertex.cpp
+++ b/src/ipc/collisions/tangential/vertex_vertex.cpp
@@ -17,7 +17,7 @@ VertexVertexTangentialCollision::VertexVertexTangentialCollision(
 
 VertexVertexTangentialCollision::VertexVertexTangentialCollision(
     const VertexVertexNormalCollision& collision,
-    const VectorMax12d& positions,
+    Eigen::ConstRef<VectorMax12d> positions,
     const NormalPotential& normal_potential,
     const double normal_stiffness)
     : VertexVertexTangentialCollision(collision)
@@ -29,7 +29,7 @@ VertexVertexTangentialCollision::VertexVertexTangentialCollision(
 // ============================================================================
 
 MatrixMax<double, 3, 2> VertexVertexTangentialCollision::compute_tangent_basis(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return point_point_tangent_basis(
@@ -38,7 +38,7 @@ MatrixMax<double, 3, 2> VertexVertexTangentialCollision::compute_tangent_basis(
 
 MatrixMax<double, 36, 2>
 VertexVertexTangentialCollision::compute_tangent_basis_jacobian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     assert(positions.size() == ndof());
     return point_point_tangent_basis_jacobian(
@@ -48,14 +48,14 @@ VertexVertexTangentialCollision::compute_tangent_basis_jacobian(
 // ============================================================================
 
 VectorMax2d VertexVertexTangentialCollision::compute_closest_point(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     return VectorMax2d();
 }
 
 MatrixMax<double, 2, 12>
 VertexVertexTangentialCollision::compute_closest_point_jacobian(
-    const VectorMax12d& positions) const
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     return MatrixMax<double, 2, 12>();
 }
@@ -63,7 +63,7 @@ VertexVertexTangentialCollision::compute_closest_point_jacobian(
 // ============================================================================
 
 VectorMax3d VertexVertexTangentialCollision::relative_velocity(
-    const VectorMax12d& velocities) const
+    Eigen::ConstRef<VectorMax12d> velocities) const
 {
     assert(velocities.size() == ndof());
     return point_point_relative_velocity(
@@ -72,7 +72,7 @@ VectorMax3d VertexVertexTangentialCollision::relative_velocity(
 
 MatrixMax<double, 3, 12>
 VertexVertexTangentialCollision::relative_velocity_matrix(
-    const VectorMax2d& _closest_point) const
+    Eigen::ConstRef<VectorMax2d> _closest_point) const
 {
     assert(_closest_point.size() == 0);
     return point_point_relative_velocity_matrix(dim());
@@ -80,7 +80,7 @@ VertexVertexTangentialCollision::relative_velocity_matrix(
 
 MatrixMax<double, 6, 12>
 VertexVertexTangentialCollision::relative_velocity_matrix_jacobian(
-    const VectorMax2d& _closest_point) const
+    Eigen::ConstRef<VectorMax2d> _closest_point) const
 {
     assert(_closest_point.size() == 0);
     return point_point_relative_velocity_matrix_jacobian(dim());

--- a/src/ipc/collisions/tangential/vertex_vertex.hpp
+++ b/src/ipc/collisions/tangential/vertex_vertex.hpp
@@ -16,33 +16,33 @@ public:
 
     VertexVertexTangentialCollision(
         const VertexVertexNormalCollision& collision,
-        const VectorMax12d& positions,
+        Eigen::ConstRef<VectorMax12d> positions,
         const NormalPotential& normal_potential,
         const double normal_stiffness);
 
 protected:
-    MatrixMax<double, 3, 2>
-    compute_tangent_basis(const VectorMax12d& positions) const override;
+    MatrixMax<double, 3, 2> compute_tangent_basis(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     MatrixMax<double, 36, 2> compute_tangent_basis_jacobian(
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
-    VectorMax2d
-    compute_closest_point(const VectorMax12d& positions) const override;
+    VectorMax2d compute_closest_point(
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     MatrixMax<double, 2, 12> compute_closest_point_jacobian(
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     VectorMax3d
-    relative_velocity(const VectorMax12d& velocities) const override;
+    relative_velocity(Eigen::ConstRef<VectorMax12d> velocities) const override;
 
     using TangentialCollision::relative_velocity_matrix;
 
-    MatrixMax<double, 3, 12>
-    relative_velocity_matrix(const VectorMax2d& closest_point) const override;
+    MatrixMax<double, 3, 12> relative_velocity_matrix(
+        Eigen::ConstRef<VectorMax2d> closest_point) const override;
 
     MatrixMax<double, 6, 12> relative_velocity_matrix_jacobian(
-        const VectorMax2d& closest_point) const override;
+        Eigen::ConstRef<VectorMax2d> closest_point) const override;
 };
 
 } // namespace ipc

--- a/src/ipc/distance/distance_type.cpp
+++ b/src/ipc/distance/distance_type.cpp
@@ -8,9 +8,9 @@
 namespace ipc {
 
 PointEdgeDistanceType point_edge_distance_type(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1)
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1)
 {
     assert(p.size() == 2 || p.size() == 3);
     assert(e0.size() == 2 || e0.size() == 3);
@@ -34,10 +34,10 @@ PointEdgeDistanceType point_edge_distance_type(
 }
 
 PointTriangleDistanceType point_triangle_distance_type(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     const Eigen::Vector3d normal = (t1 - t0).cross(t2 - t0);
 
@@ -80,10 +80,10 @@ PointTriangleDistanceType point_triangle_distance_type(
 
 // A more robust implementation of http://geomalgorithms.com/a07-_distance.html
 EdgeEdgeDistanceType edge_edge_distance_type(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     constexpr double PARALLEL_THRESHOLD = 1.0e-20;
 
@@ -169,10 +169,10 @@ EdgeEdgeDistanceType edge_edge_distance_type(
 }
 
 EdgeEdgeDistanceType edge_edge_parallel_distance_type(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     const Eigen::Vector3d ea = ea1 - ea0;
     const double alpha = (eb0 - ea0).dot(ea) / ea.squaredNorm();

--- a/src/ipc/distance/distance_type.hpp
+++ b/src/ipc/distance/distance_type.hpp
@@ -54,9 +54,9 @@ enum class EdgeEdgeDistanceType {
 /// @param e1 The second vertex of the edge.
 /// @return The distance type of the point-edge pair.
 PointEdgeDistanceType point_edge_distance_type(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1);
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1);
 
 /// @brief Determine the closest pair between a point and triangle.
 /// @param p The point.
@@ -65,10 +65,10 @@ PointEdgeDistanceType point_edge_distance_type(
 /// @param t2 The third vertex of the triangle.
 /// @return The distance type of the point-triangle pair.
 PointTriangleDistanceType point_triangle_distance_type(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 
 /// @brief Determine the closest pair between two edges.
 /// @param ea0 The first vertex of the first edge.
@@ -77,10 +77,10 @@ PointTriangleDistanceType point_triangle_distance_type(
 /// @param eb1 The second vertex of the second edge.
 /// @return The distance type of the edge-edge pair.
 EdgeEdgeDistanceType edge_edge_distance_type(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Determine the closest pair between two parallel edges.
 /// @param ea0 The first vertex of the first edge.
@@ -89,9 +89,9 @@ EdgeEdgeDistanceType edge_edge_distance_type(
 /// @param eb1 The second vertex of the second edge.
 /// @return The distance type of the edge-edge pair.
 EdgeEdgeDistanceType edge_edge_parallel_distance_type(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 } // namespace ipc

--- a/src/ipc/distance/edge_edge.cpp
+++ b/src/ipc/distance/edge_edge.cpp
@@ -11,10 +11,10 @@
 namespace ipc {
 
 double edge_edge_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     EdgeEdgeDistanceType dtype)
 {
     if (dtype == EdgeEdgeDistanceType::AUTO) {
@@ -56,10 +56,10 @@ double edge_edge_distance(
 }
 
 Vector12d edge_edge_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     EdgeEdgeDistanceType dtype)
 {
     if (dtype == EdgeEdgeDistanceType::AUTO) {
@@ -132,10 +132,10 @@ Vector12d edge_edge_distance_gradient(
 }
 
 Matrix12d edge_edge_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     EdgeEdgeDistanceType dtype)
 {
     if (dtype == EdgeEdgeDistanceType::AUTO) {

--- a/src/ipc/distance/edge_edge.hpp
+++ b/src/ipc/distance/edge_edge.hpp
@@ -13,10 +13,10 @@ namespace ipc {
 /// @param dtype The point edge distance type to compute.
 /// @return The distance between the two edges.
 double edge_edge_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     EdgeEdgeDistanceType dtype = EdgeEdgeDistanceType::AUTO);
 
 /// @brief Compute the gradient of the distance between a two lines segments.
@@ -28,10 +28,10 @@ double edge_edge_distance(
 /// @param dtype The point edge distance type to compute.
 /// @return The gradient of the distance wrt ea0, ea1, eb0, and eb1.
 Vector12d edge_edge_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     EdgeEdgeDistanceType dtype = EdgeEdgeDistanceType::AUTO);
 
 /// @brief Compute the hessian of the distance between a two lines segments.
@@ -43,10 +43,10 @@ Vector12d edge_edge_distance_gradient(
 /// @param dtype The point edge distance type to compute.
 /// @return The hessian of the distance wrt ea0, ea1, eb0, and eb1.
 Matrix12d edge_edge_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     EdgeEdgeDistanceType dtype = EdgeEdgeDistanceType::AUTO);
 
 } // namespace ipc

--- a/src/ipc/distance/edge_edge_mollifier.cpp
+++ b/src/ipc/distance/edge_edge_mollifier.cpp
@@ -5,19 +5,19 @@
 namespace ipc {
 
 double edge_edge_cross_squarednorm(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     return (ea1 - ea0).cross(eb1 - eb0).squaredNorm();
 }
 
 Vector12d edge_edge_cross_squarednorm_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     Vector12d grad;
     autogen::edge_edge_cross_squarednorm_gradient(
@@ -27,10 +27,10 @@ Vector12d edge_edge_cross_squarednorm_gradient(
 }
 
 Matrix12d edge_edge_cross_squarednorm_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     Matrix12d hess;
     autogen::edge_edge_cross_squarednorm_hessian(
@@ -81,10 +81,10 @@ double edge_edge_mollifier_gradient_derivative_wrt_eps_x(
 }
 
 double edge_edge_mollifier(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     const double eps_x)
 {
     const double ee_cross_norm_sqr =
@@ -97,10 +97,10 @@ double edge_edge_mollifier(
 }
 
 Vector12d edge_edge_mollifier_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     const double eps_x)
 {
     const double ee_cross_norm_sqr =
@@ -114,10 +114,10 @@ Vector12d edge_edge_mollifier_gradient(
 }
 
 Matrix12d edge_edge_mollifier_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     const double eps_x)
 {
     const double ee_cross_norm_sqr =
@@ -136,14 +136,14 @@ Matrix12d edge_edge_mollifier_hessian(
 }
 
 Vector12d edge_edge_mollifier_gradient_wrt_x(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     const double eps_x =
         edge_edge_mollifier_threshold(ea0_rest, ea1_rest, eb0_rest, eb1_rest);
@@ -160,14 +160,14 @@ Vector12d edge_edge_mollifier_gradient_wrt_x(
 }
 
 Matrix12d edge_edge_mollifier_gradient_jacobian_wrt_x(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     const double eps_x =
         edge_edge_mollifier_threshold(ea0_rest, ea1_rest, eb0_rest, eb1_rest);
@@ -189,20 +189,20 @@ Matrix12d edge_edge_mollifier_gradient_jacobian_wrt_x(
 }
 
 double edge_edge_mollifier_threshold(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1_rest)
+    Eigen::ConstRef<Eigen::Vector3d> ea0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_rest)
 {
     return 1e-3 * (ea0_rest - ea1_rest).squaredNorm()
         * (eb0_rest - eb1_rest).squaredNorm();
 }
 
 Vector12d edge_edge_mollifier_threshold_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1_rest)
+    Eigen::ConstRef<Eigen::Vector3d> ea0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_rest)
 {
     Vector12d grad;
     autogen::edge_edge_mollifier_threshold_gradient(

--- a/src/ipc/distance/edge_edge_mollifier.hpp
+++ b/src/ipc/distance/edge_edge_mollifier.hpp
@@ -11,10 +11,10 @@ namespace ipc {
 /// @param eb1 The second vertex of the second edge.
 /// @return The squared norm of the edge-edge cross product.
 double edge_edge_cross_squarednorm(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Compute the gradient of the squared norm of the edge cross product.
 /// @param ea0 The first vertex of the first edge.
@@ -23,10 +23,10 @@ double edge_edge_cross_squarednorm(
 /// @param eb1 The second vertex of the second edge.
 /// @return The gradient of the squared norm of the edge cross product wrt ea0, ea1, eb0, and eb1.
 Vector12d edge_edge_cross_squarednorm_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Compute the hessian of the squared norm of the edge cross product.
 /// @param ea0 The first vertex of the first edge.
@@ -35,10 +35,10 @@ Vector12d edge_edge_cross_squarednorm_gradient(
 /// @param eb1 The second vertex of the second edge.
 /// @return The hessian of the squared norm of the edge cross product wrt ea0, ea1, eb0, and eb1.
 Matrix12d edge_edge_cross_squarednorm_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Mollifier function for edge-edge distance.
 /// @param x Squared norm of the edge-edge cross product.
@@ -83,10 +83,10 @@ double edge_edge_mollifier_gradient_derivative_wrt_eps_x(
 /// @param eps_x Mollifier activation threshold.
 /// @return The mollifier coefficient to premultiply the edge-edge distance.
 double edge_edge_mollifier(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     const double eps_x);
 
 /// @brief Compute the gradient of the mollifier for the edge-edge distance.
@@ -97,10 +97,10 @@ double edge_edge_mollifier(
 /// @param eps_x Mollifier activation threshold.
 /// @return The gradient of the mollifier.
 Vector12d edge_edge_mollifier_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     const double eps_x);
 
 /// @brief Compute the hessian of the mollifier for the edge-edge distance.
@@ -111,10 +111,10 @@ Vector12d edge_edge_mollifier_gradient(
 /// @param eps_x Mollifier activation threshold.
 /// @return The hessian of the mollifier.
 Matrix12d edge_edge_mollifier_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1,
     const double eps_x);
 
 /// @brief Compute the gradient of the mollifier for the edge-edge distance wrt rest positions.
@@ -128,14 +128,14 @@ Matrix12d edge_edge_mollifier_hessian(
 /// @param eb1 The second vertex of the second edge.
 /// @return The derivative of the mollifier wrt rest positions.
 Vector12d edge_edge_mollifier_gradient_wrt_x(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Compute the jacobian of the edge-edge distance mollifier's gradient wrt rest positions.
 /// @note This is not the hessian of the mollifier wrt rest positions, but the jacobian wrt rest positions of the mollifier's gradient wrt positions.
@@ -149,14 +149,14 @@ Vector12d edge_edge_mollifier_gradient_wrt_x(
 /// @param eb1 The second vertex of the second edge.
 /// @return The jacobian of the mollifier's gradient wrt rest positions.
 Matrix12d edge_edge_mollifier_gradient_jacobian_wrt_x(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Compute the threshold of the mollifier edge-edge distance.
 ///
@@ -168,10 +168,10 @@ Matrix12d edge_edge_mollifier_gradient_jacobian_wrt_x(
 /// @param eb1_rest The rest position of the second vertex of the second edge.
 /// @return Threshold for edge-edge mollification.
 double edge_edge_mollifier_threshold(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1_rest);
+    Eigen::ConstRef<Eigen::Vector3d> ea0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_rest);
 
 /// @brief Compute the gradient of the threshold of the mollifier edge-edge distance.
 ///
@@ -183,10 +183,10 @@ double edge_edge_mollifier_threshold(
 /// @param eb1_rest The rest position of the second vertex of the second edge.
 /// @return Gradient of the threshold for edge-edge mollification.
 Vector12d edge_edge_mollifier_threshold_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0_rest,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1_rest);
+    Eigen::ConstRef<Eigen::Vector3d> ea0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> ea1_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb0_rest,
+    Eigen::ConstRef<Eigen::Vector3d> eb1_rest);
 
 // Symbolically generated derivatives;
 namespace autogen {

--- a/src/ipc/distance/line_line.cpp
+++ b/src/ipc/distance/line_line.cpp
@@ -5,10 +5,10 @@
 namespace ipc {
 
 double line_line_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     const Eigen::Vector3d normal = (ea1 - ea0).cross(eb1 - eb0);
     const double line_to_line = (eb0 - ea0).dot(normal);
@@ -16,10 +16,10 @@ double line_line_distance(
 }
 
 Vector12d line_line_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     Vector12d grad;
     autogen::line_line_distance_gradient(
@@ -29,10 +29,10 @@ Vector12d line_line_distance_gradient(
 }
 
 Matrix12d line_line_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     Matrix12d hess;
     autogen::line_line_distance_hessian(

--- a/src/ipc/distance/line_line.hpp
+++ b/src/ipc/distance/line_line.hpp
@@ -13,10 +13,10 @@ namespace ipc {
 /// @param ea1 The second vertex of the edge defining the second line.
 /// @return The distance between the two lines.
 double line_line_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Compute the gradient of the distance between a two lines in 3D.
 /// @note The distance is actually squared distance.
@@ -27,10 +27,10 @@ double line_line_distance(
 /// @param ea1 The second vertex of the edge defining the second line.
 /// @return The gradient of the distance wrt ea0, ea1, eb0, and eb1.
 Vector12d line_line_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Compute the hessian of the distance between a two lines in 3D.
 /// @note The distance is actually squared distance.
@@ -41,10 +41,10 @@ Vector12d line_line_distance_gradient(
 /// @param ea1 The second vertex of the edge defining the second line.
 /// @return The hessian of the distance wrt ea0, ea1, eb0, and eb1.
 Matrix12d line_line_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 // Symbolically generated derivatives;
 namespace autogen {

--- a/src/ipc/distance/point_edge.cpp
+++ b/src/ipc/distance/point_edge.cpp
@@ -8,9 +8,9 @@
 namespace ipc {
 
 double point_edge_distance(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1,
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1,
     PointEdgeDistanceType dtype)
 {
     assert(p.size() == 2 || p.size() == 3);
@@ -38,9 +38,9 @@ double point_edge_distance(
 }
 
 VectorMax9d point_edge_distance_gradient(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1,
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1,
     PointEdgeDistanceType dtype)
 {
     const int dim = p.size();
@@ -78,9 +78,9 @@ VectorMax9d point_edge_distance_gradient(
 }
 
 MatrixMax9d point_edge_distance_hessian(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1,
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1,
     PointEdgeDistanceType dtype)
 {
     const int dim = p.size();

--- a/src/ipc/distance/point_edge.hpp
+++ b/src/ipc/distance/point_edge.hpp
@@ -12,9 +12,9 @@ namespace ipc {
 /// @param dtype The point edge distance type to compute.
 /// @return The distance between the point and edge.
 double point_edge_distance(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1,
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1,
     PointEdgeDistanceType dtype = PointEdgeDistanceType::AUTO);
 
 /// @brief Compute the gradient of the distance between a point and edge.
@@ -25,9 +25,9 @@ double point_edge_distance(
 /// @param dtype The point edge distance type to compute.
 /// @return grad The gradient of the distance wrt p, e0, and e1.
 VectorMax9d point_edge_distance_gradient(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1,
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1,
     PointEdgeDistanceType dtype = PointEdgeDistanceType::AUTO);
 
 /// @brief Compute the hessian of the distance between a point and edge.
@@ -38,9 +38,9 @@ VectorMax9d point_edge_distance_gradient(
 /// @param dtype The point edge distance type to compute.
 /// @return hess The hessian of the distance wrt p, e0, and e1.
 MatrixMax9d point_edge_distance_hessian(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1,
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1,
     PointEdgeDistanceType dtype = PointEdgeDistanceType::AUTO);
 
 } // namespace ipc

--- a/src/ipc/distance/point_line.cpp
+++ b/src/ipc/distance/point_line.cpp
@@ -3,9 +3,9 @@
 namespace ipc {
 
 double point_line_distance(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1)
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1)
 {
     assert(p.size() == 2 || p.size() == 3);
     assert(e0.size() == 2 || e0.size() == 3);
@@ -23,9 +23,9 @@ double point_line_distance(
 }
 
 VectorMax9d point_line_distance_gradient(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1)
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1)
 {
     const int dim = p.size();
     assert(e0.size() == dim);
@@ -44,9 +44,9 @@ VectorMax9d point_line_distance_gradient(
 }
 
 MatrixMax9d point_line_distance_hessian(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1)
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1)
 {
     const int dim = p.size();
     assert(e0.size() == dim);

--- a/src/ipc/distance/point_line.hpp
+++ b/src/ipc/distance/point_line.hpp
@@ -11,9 +11,9 @@ namespace ipc {
 /// @param e1 The second vertex of the edge defining the line.
 /// @return The distance between the point and line.
 double point_line_distance(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1);
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1);
 
 /// @brief Compute the gradient of the distance between a point and line.
 /// @note The distance is actually squared distance.
@@ -22,9 +22,9 @@ double point_line_distance(
 /// @param e1 The second vertex of the edge defining the line.
 /// @return The gradient of the distance wrt p, e0, and e1.
 VectorMax9d point_line_distance_gradient(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1);
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1);
 
 /// @brief Compute the hessian of the distance between a point and line.
 /// @note The distance is actually squared distance.
@@ -33,9 +33,9 @@ VectorMax9d point_line_distance_gradient(
 /// @param e1 The second vertex of the edge defining the line.
 /// @return The hessian of the distance wrt p, e0, and e1.
 MatrixMax9d point_line_distance_hessian(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1);
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1);
 
 // Symbolically generated derivatives;
 namespace autogen {

--- a/src/ipc/distance/point_plane.cpp
+++ b/src/ipc/distance/point_plane.cpp
@@ -7,36 +7,36 @@
 namespace ipc {
 
 double point_plane_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& origin,
-    const Eigen::Ref<const Eigen::Vector3d>& normal)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> origin,
+    Eigen::ConstRef<Eigen::Vector3d> normal)
 {
     const double point_to_plane = (p - origin).dot(normal);
     return point_to_plane * point_to_plane / normal.squaredNorm();
 }
 
 double point_plane_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     return point_plane_distance(p, t0, (t1 - t0).cross(t2 - t0));
 }
 
 Eigen::Vector3d point_plane_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& origin,
-    const Eigen::Ref<const Eigen::Vector3d>& normal)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> origin,
+    Eigen::ConstRef<Eigen::Vector3d> normal)
 {
     return (2 / normal.squaredNorm()) * (p - origin).dot(normal) * normal;
 }
 
 Vector12d point_plane_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     Vector12d grad;
     autogen::point_plane_distance_gradient(
@@ -46,18 +46,18 @@ Vector12d point_plane_distance_gradient(
 }
 
 Eigen::Matrix3d point_plane_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& origin,
-    const Eigen::Ref<const Eigen::Vector3d>& normal)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> origin,
+    Eigen::ConstRef<Eigen::Vector3d> normal)
 {
     return 2 / normal.squaredNorm() * normal * normal.transpose();
 }
 
 Matrix12d point_plane_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     Matrix12d hess;
     autogen::point_plane_distance_hessian(

--- a/src/ipc/distance/point_plane.hpp
+++ b/src/ipc/distance/point_plane.hpp
@@ -11,9 +11,9 @@ namespace ipc {
 /// @param normal The normal of the plane.
 /// @return The distance between the point and plane.
 double point_plane_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& origin,
-    const Eigen::Ref<const Eigen::Vector3d>& normal);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> origin,
+    Eigen::ConstRef<Eigen::Vector3d> normal);
 
 /// @brief Compute the distance between a point and a plane.
 /// @note The distance is actually squared distance.
@@ -23,10 +23,10 @@ double point_plane_distance(
 /// @param t2 The third vertex of the triangle.
 /// @return The distance between the point and plane.
 double point_plane_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 
 /// @brief Compute the gradient of the distance between a point and a plane.
 /// @note The distance is actually squared distance.
@@ -35,9 +35,9 @@ double point_plane_distance(
 /// @param normal The normal of the plane.
 /// @return The gradient of the distance wrt p.
 Eigen::Vector3d point_plane_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& origin,
-    const Eigen::Ref<const Eigen::Vector3d>& normal);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> origin,
+    Eigen::ConstRef<Eigen::Vector3d> normal);
 
 /// @brief Compute the gradient of the distance between a point and a plane.
 /// @note The distance is actually squared distance.
@@ -47,10 +47,10 @@ Eigen::Vector3d point_plane_distance_gradient(
 /// @param t2 The third vertex of the triangle.
 /// @return The gradient of the distance wrt p, t0, t1, and t2.
 Vector12d point_plane_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 
 /// @brief Compute the hessian of the distance between a point and a plane.
 /// @note The distance is actually squared distance.
@@ -59,9 +59,9 @@ Vector12d point_plane_distance_gradient(
 /// @param normal The normal of the plane.
 /// @return The hessian of the distance wrt p.
 Eigen::Matrix3d point_plane_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& origin,
-    const Eigen::Ref<const Eigen::Vector3d>& normal);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> origin,
+    Eigen::ConstRef<Eigen::Vector3d> normal);
 
 /// @brief Compute the hessian of the distance between a point and a plane.
 /// @note The distance is actually squared distance.
@@ -71,10 +71,10 @@ Eigen::Matrix3d point_plane_distance_hessian(
 /// @param t2 The third vertex of the triangle.
 /// @return The hessian of the distance wrt p, t0, t1, and t2.
 Matrix12d point_plane_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 
 // Symbolically generated derivatives;
 namespace autogen {

--- a/src/ipc/distance/point_point.cpp
+++ b/src/ipc/distance/point_point.cpp
@@ -3,15 +3,13 @@
 namespace ipc {
 
 double point_point_distance(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1)
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1)
 {
     return (p1 - p0).squaredNorm();
 }
 
 VectorMax6d point_point_distance_gradient(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1)
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1)
 {
     int dim = p0.size();
     assert(p1.size() == dim);
@@ -25,8 +23,7 @@ VectorMax6d point_point_distance_gradient(
 }
 
 MatrixMax6d point_point_distance_hessian(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1)
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1)
 {
     int dim = p0.size();
     assert(p1.size() == dim);

--- a/src/ipc/distance/point_point.hpp
+++ b/src/ipc/distance/point_point.hpp
@@ -10,8 +10,7 @@ namespace ipc {
 /// @param p1 The second point.
 /// @return The distance between p0 and p1.
 double point_point_distance(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1);
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1);
 
 /// @brief Compute the gradient of the distance between two points.
 /// @note The distance is actually squared distance.
@@ -19,8 +18,7 @@ double point_point_distance(
 /// @param p1 The second point.
 /// @return The computed gradient.
 VectorMax6d point_point_distance_gradient(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1);
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1);
 
 /// @brief Compute the hessian of the distance between two points.
 /// @note The distance is actually squared distance.
@@ -28,7 +26,6 @@ VectorMax6d point_point_distance_gradient(
 /// @param p1 The second point.
 /// @return The computed hessian.
 MatrixMax6d point_point_distance_hessian(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1);
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1);
 
 } // namespace ipc

--- a/src/ipc/distance/point_triangle.cpp
+++ b/src/ipc/distance/point_triangle.cpp
@@ -9,10 +9,10 @@
 namespace ipc {
 
 double point_triangle_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2,
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     PointTriangleDistanceType dtype)
 {
     if (dtype == PointTriangleDistanceType::AUTO) {
@@ -48,10 +48,10 @@ double point_triangle_distance(
 }
 
 Vector12d point_triangle_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2,
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     PointTriangleDistanceType dtype)
 {
     if (dtype == PointTriangleDistanceType::AUTO) {
@@ -111,10 +111,10 @@ Vector12d point_triangle_distance_gradient(
 }
 
 Matrix12d point_triangle_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2,
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     PointTriangleDistanceType dtype)
 {
     if (dtype == PointTriangleDistanceType::AUTO) {

--- a/src/ipc/distance/point_triangle.hpp
+++ b/src/ipc/distance/point_triangle.hpp
@@ -13,10 +13,10 @@ namespace ipc {
 /// @param dtype The point-triangle distance type to compute.
 /// @return The distance between the point and triangle.
 double point_triangle_distance(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2,
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     PointTriangleDistanceType dtype = PointTriangleDistanceType::AUTO);
 
 /// @brief Compute the gradient of the distance between a points and a triangle.
@@ -28,10 +28,10 @@ double point_triangle_distance(
 /// @param dtype The point-triangle distance type to compute.
 /// @return The gradient of the distance wrt p, t0, t1, and t2.
 Vector12d point_triangle_distance_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2,
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     PointTriangleDistanceType dtype = PointTriangleDistanceType::AUTO);
 
 /// @brief Compute the hessian of the distance between a points and a triangle.
@@ -43,10 +43,10 @@ Vector12d point_triangle_distance_gradient(
 /// @param dtype The point-triangle distance type to compute.
 /// @return The hessian of the distance wrt p, t0, t1, and t2.
 Matrix12d point_triangle_distance_hessian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2,
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2,
     PointTriangleDistanceType dtype = PointTriangleDistanceType::AUTO);
 
 } // namespace ipc

--- a/src/ipc/implicits/plane.cpp
+++ b/src/ipc/implicits/plane.cpp
@@ -9,9 +9,9 @@
 namespace ipc {
 
 void construct_point_plane_collisions(
-    const Eigen::MatrixXd& points,
-    const Eigen::MatrixXd& plane_origins,
-    const Eigen::MatrixXd& plane_normals,
+    Eigen::ConstRef<Eigen::MatrixXd> points,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_normals,
     const double dhat,
     std::vector<PlaneVertexNormalCollision>& pv_collisions,
     const double dmin,
@@ -51,10 +51,10 @@ void construct_point_plane_collisions(
 // ============================================================================
 
 bool is_step_point_plane_collision_free(
-    const Eigen::MatrixXd& points_t0,
-    const Eigen::MatrixXd& points_t1,
-    const Eigen::MatrixXd& plane_origins,
-    const Eigen::MatrixXd& plane_normals,
+    Eigen::ConstRef<Eigen::MatrixXd> points_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> points_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_normals,
     const std::function<bool(size_t, size_t)>& can_collide)
 {
     size_t n_planes = plane_origins.rows();
@@ -87,10 +87,10 @@ bool is_step_point_plane_collision_free(
 // ============================================================================
 
 double compute_point_plane_collision_free_stepsize(
-    const Eigen::MatrixXd& points_t0,
-    const Eigen::MatrixXd& points_t1,
-    const Eigen::MatrixXd& plane_origins,
-    const Eigen::MatrixXd& plane_normals,
+    Eigen::ConstRef<Eigen::MatrixXd> points_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> points_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_normals,
     const std::function<bool(size_t, size_t)>& can_collide)
 {
     size_t n_planes = plane_origins.rows();

--- a/src/ipc/implicits/plane.hpp
+++ b/src/ipc/implicits/plane.hpp
@@ -23,9 +23,9 @@ inline bool default_can_point_plane_collide(size_t, size_t) { return true; }
 /// @param[in] dmin  Minimum distance.
 /// @param[in] can_collide A function that takes a vertex ID (row numbers in points) and a plane ID (row number in plane_origins) then returns true if the vertex can collide with the plane. By default all points can collide with all planes.
 void construct_point_plane_collisions(
-    const Eigen::MatrixXd& points,
-    const Eigen::MatrixXd& plane_origins,
-    const Eigen::MatrixXd& plane_normals,
+    Eigen::ConstRef<Eigen::MatrixXd> points,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_normals,
     const double dhat,
     std::vector<PlaneVertexNormalCollision>& pv_collisions,
     const double dmin = 0,
@@ -46,10 +46,10 @@ void construct_point_plane_collisions(
 /// @param[in] can_collide A function that takes a vertex ID (row numbers in points) and a plane ID (row number in plane_origins) then returns true if the vertex can collide with the plane. By default all points can collide with all planes.
 /// @returns True if <b>any</b> collisions occur.
 bool is_step_point_plane_collision_free(
-    const Eigen::MatrixXd& points_t0,
-    const Eigen::MatrixXd& points_t1,
-    const Eigen::MatrixXd& plane_origins,
-    const Eigen::MatrixXd& plane_normals,
+    Eigen::ConstRef<Eigen::MatrixXd> points_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> points_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_normals,
     const std::function<bool(size_t, size_t)>& can_collide =
         default_can_point_plane_collide);
 
@@ -66,10 +66,10 @@ bool is_step_point_plane_collision_free(
 /// @param can_collide A function that takes a vertex ID (row numbers in points) and a plane ID (row number in plane_origins) then returns true if the vertex can collide with the plane. By default all points can collide with all planes.
 /// @returns A step-size \f$\in [0, 1]\f$ that is collision free.
 double compute_point_plane_collision_free_stepsize(
-    const Eigen::MatrixXd& points_t0,
-    const Eigen::MatrixXd& points_t1,
-    const Eigen::MatrixXd& plane_origins,
-    const Eigen::MatrixXd& plane_normals,
+    Eigen::ConstRef<Eigen::MatrixXd> points_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> points_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_origins,
+    Eigen::ConstRef<Eigen::MatrixXd> plane_normals,
     const std::function<bool(size_t, size_t)>& can_collide =
         default_can_point_plane_collide);
 

--- a/src/ipc/ipc.cpp
+++ b/src/ipc/ipc.cpp
@@ -16,8 +16,8 @@ namespace ipc {
 
 bool is_step_collision_free(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     const double min_distance,
     const std::shared_ptr<BroadPhase> broad_phase,
     const NarrowPhaseCCD& narrow_phase_ccd)
@@ -40,8 +40,8 @@ bool is_step_collision_free(
 
 double compute_collision_free_stepsize(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     const double min_distance,
     const std::shared_ptr<BroadPhase> broad_phase,
     const NarrowPhaseCCD& narrow_phase_ccd)
@@ -90,7 +90,7 @@ double compute_collision_free_stepsize(
 
 bool has_intersections(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::shared_ptr<BroadPhase> broad_phase)
 {
     assert(broad_phase != nullptr);

--- a/src/ipc/ipc.hpp
+++ b/src/ipc/ipc.hpp
@@ -24,8 +24,8 @@ namespace ipc {
 /// @returns True if <b>any</b> collisions occur.
 bool is_step_collision_free(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     const double min_distance = 0.0,
     const std::shared_ptr<BroadPhase> broad_phase = make_default_broad_phase(),
     const NarrowPhaseCCD& narrow_phase_ccd = DEFAULT_NARROW_PHASE_CCD);
@@ -41,8 +41,8 @@ bool is_step_collision_free(
 /// @returns A step-size \f$\in [0, 1]\f$ that is collision free. A value of 1.0 if a full step and 0.0 is no step.
 double compute_collision_free_stepsize(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices_t0,
-    const Eigen::MatrixXd& vertices_t1,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t0,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices_t1,
     const double min_distance = 0.0,
     const std::shared_ptr<BroadPhase> broad_phase = make_default_broad_phase(),
     const NarrowPhaseCCD& narrow_phase_ccd = DEFAULT_NARROW_PHASE_CCD);
@@ -57,7 +57,7 @@ double compute_collision_free_stepsize(
 /// @return A boolean for if the mesh has intersections.
 bool has_intersections(
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices,
+    Eigen::ConstRef<Eigen::MatrixXd> vertices,
     const std::shared_ptr<BroadPhase> broad_phase = make_default_broad_phase());
 
 } // namespace ipc

--- a/src/ipc/potentials/barrier_potential.cpp
+++ b/src/ipc/potentials/barrier_potential.cpp
@@ -40,7 +40,7 @@ double BarrierPotential::force_magnitude(
 
 VectorMax12d BarrierPotential::force_magnitude_gradient(
     const double distance_squared,
-    const VectorMax12d& distance_squared_gradient,
+    Eigen::ConstRef<VectorMax12d> distance_squared_gradient,
     const double dmin,
     const double barrier_stiffness) const
 {

--- a/src/ipc/potentials/barrier_potential.hpp
+++ b/src/ipc/potentials/barrier_potential.hpp
@@ -73,7 +73,7 @@ public:
     /// @return The gradient of the force.
     VectorMax12d force_magnitude_gradient(
         const double distance_squared,
-        const VectorMax12d& distance_squared_gradient,
+        Eigen::ConstRef<VectorMax12d> distance_squared_gradient,
         const double dmin,
         const double barrier_stiffness) const override;
 

--- a/src/ipc/potentials/normal_adhesion_potential.cpp
+++ b/src/ipc/potentials/normal_adhesion_potential.cpp
@@ -26,7 +26,7 @@ double NormalAdhesionPotential::force_magnitude(
 
 VectorMax12d NormalAdhesionPotential::force_magnitude_gradient(
     const double,
-    const VectorMax12d& distance_squared_gradient,
+    Eigen::ConstRef<VectorMax12d> distance_squared_gradient,
     const double,
     const double) const
 {

--- a/src/ipc/potentials/normal_adhesion_potential.hpp
+++ b/src/ipc/potentials/normal_adhesion_potential.hpp
@@ -37,7 +37,7 @@ public:
     /// @return The gradient of the force.
     VectorMax12d force_magnitude_gradient(
         const double distance_squared,
-        const VectorMax12d& distance_squared_gradient,
+        Eigen::ConstRef<VectorMax12d> distance_squared_gradient,
         const double dmin,
         const double barrier_stiffness) const override;
 

--- a/src/ipc/potentials/normal_potential.cpp
+++ b/src/ipc/potentials/normal_potential.cpp
@@ -7,7 +7,7 @@ namespace ipc {
 Eigen::SparseMatrix<double> NormalPotential::shape_derivative(
     const NormalCollisions& collisions,
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& vertices) const
+    Eigen::ConstRef<Eigen::MatrixXd> vertices) const
 {
     assert(vertices.rows() == mesh.num_vertices());
 
@@ -50,7 +50,8 @@ Eigen::SparseMatrix<double> NormalPotential::shape_derivative(
 // -- Single collision methods -------------------------------------------------
 
 double NormalPotential::operator()(
-    const NormalCollision& collision, const VectorMax12d& positions) const
+    const NormalCollision& collision,
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     // w * m(x) * f(d(x))
     // NOTE: can save a multiplication by checking if !collision.is_mollified()
@@ -60,7 +61,8 @@ double NormalPotential::operator()(
 }
 
 VectorMax12d NormalPotential::gradient(
-    const NormalCollision& collision, const VectorMax12d& positions) const
+    const NormalCollision& collision,
+    Eigen::ConstRef<VectorMax12d> positions) const
 {
     // d(x)
     const double d = collision.compute_distance(positions);
@@ -88,7 +90,7 @@ VectorMax12d NormalPotential::gradient(
 
 MatrixMax12d NormalPotential::hessian(
     const NormalCollision& collision,
-    const VectorMax12d& positions,
+    Eigen::ConstRef<VectorMax12d> positions,
     const PSDProjectionMethod project_hessian_to_psd) const
 {
     // d(x)
@@ -141,8 +143,8 @@ MatrixMax12d NormalPotential::hessian(
 void NormalPotential::shape_derivative(
     const NormalCollision& collision,
     const std::array<long, 4>& vertex_ids,
-    const VectorMax12d& rest_positions, // = x̄
-    const VectorMax12d& positions,      // = x̄ + u
+    Eigen::ConstRef<VectorMax12d> rest_positions, // = x̄
+    Eigen::ConstRef<VectorMax12d> positions,      // = x̄ + u
     std::vector<Eigen::Triplet<double>>& out) const
 {
     assert(rest_positions.size() == positions.size());

--- a/src/ipc/potentials/normal_potential.hpp
+++ b/src/ipc/potentials/normal_potential.hpp
@@ -30,7 +30,7 @@ public:
     Eigen::SparseMatrix<double> shape_derivative(
         const NormalCollisions& collisions,
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& vertices) const;
+        Eigen::ConstRef<Eigen::MatrixXd> vertices) const;
 
     // -- Single collision methods ---------------------------------------------
 
@@ -40,7 +40,7 @@ public:
     /// @return The potential.
     double operator()(
         const NormalCollision& collision,
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     /// @brief Compute the gradient of the potential for a single collision.
     /// @param collision The collision.
@@ -48,7 +48,7 @@ public:
     /// @return The gradient of the potential.
     VectorMax12d gradient(
         const NormalCollision& collision,
-        const VectorMax12d& positions) const override;
+        Eigen::ConstRef<VectorMax12d> positions) const override;
 
     /// @brief Compute the hessian of the potential for a single collision.
     /// @param collision The collision.
@@ -56,7 +56,7 @@ public:
     /// @return The hessian of the potential.
     MatrixMax12d hessian(
         const NormalCollision& collision,
-        const VectorMax12d& positions,
+        Eigen::ConstRef<VectorMax12d> positions,
         const PSDProjectionMethod project_hessian_to_psd =
             PSDProjectionMethod::NONE) const override;
 
@@ -69,8 +69,8 @@ public:
     void shape_derivative(
         const NormalCollision& collision,
         const std::array<long, 4>& vertex_ids,
-        const VectorMax12d& rest_positions,
-        const VectorMax12d& positions,
+        Eigen::ConstRef<VectorMax12d> rest_positions,
+        Eigen::ConstRef<VectorMax12d> positions,
         std::vector<Eigen::Triplet<double>>& out) const;
 
     /// @brief Compute the force magnitude for a collision.
@@ -91,7 +91,7 @@ public:
     /// @return The gradient of the force.
     virtual VectorMax12d force_magnitude_gradient(
         const double distance_squared,
-        const VectorMax12d& distance_squared_gradient,
+        Eigen::ConstRef<VectorMax12d> distance_squared_gradient,
         const double dmin,
         const double barrier_stiffness) const = 0;
 

--- a/src/ipc/potentials/potential.hpp
+++ b/src/ipc/potentials/potential.hpp
@@ -25,7 +25,7 @@ public:
     double operator()(
         const TCollisions& collisions,
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& X) const;
+        Eigen::ConstRef<Eigen::MatrixXd> X) const;
 
     /// @brief Compute the gradient of the potential.
     /// @param collisions The set of collisions.
@@ -35,7 +35,7 @@ public:
     Eigen::VectorXd gradient(
         const TCollisions& collisions,
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& X) const;
+        Eigen::ConstRef<Eigen::MatrixXd> X) const;
 
     /// @brief Compute the hessian of the potential.
     /// @param collisions The set of collisions.
@@ -46,7 +46,7 @@ public:
     Eigen::SparseMatrix<double> hessian(
         const TCollisions& collisions,
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& X,
+        Eigen::ConstRef<Eigen::MatrixXd> X,
         const PSDProjectionMethod project_hessian_to_psd =
             PSDProjectionMethod::NONE) const;
 
@@ -56,15 +56,15 @@ public:
     /// @param collision The collision.
     /// @param x The collision stencil's degrees of freedom.
     /// @return The potential.
-    virtual double
-    operator()(const TCollision& collision, const VectorMax12d& x) const = 0;
+    virtual double operator()(
+        const TCollision& collision, Eigen::ConstRef<VectorMax12d> x) const = 0;
 
     /// @brief Compute the gradient of the potential for a single collision.
     /// @param collision The collision.
     /// @param x The collision stencil's degrees of freedom.
     /// @return The gradient of the potential.
-    virtual VectorMax12d
-    gradient(const TCollision& collision, const VectorMax12d& x) const = 0;
+    virtual VectorMax12d gradient(
+        const TCollision& collision, Eigen::ConstRef<VectorMax12d> x) const = 0;
 
     /// @brief Compute the hessian of the potential for a single collision.
     /// @param collision The collision.
@@ -72,7 +72,7 @@ public:
     /// @return The hessian of the potential.
     virtual MatrixMax12d hessian(
         const TCollision& collision,
-        const VectorMax12d& x,
+        Eigen::ConstRef<VectorMax12d> x,
         const PSDProjectionMethod project_hessian_to_psd =
             PSDProjectionMethod::NONE) const = 0;
 };

--- a/src/ipc/potentials/potential.tpp
+++ b/src/ipc/potentials/potential.tpp
@@ -16,7 +16,7 @@ template <class TCollisions>
 double Potential<TCollisions>::operator()(
     const TCollisions& collisions,
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& X) const
+    Eigen::ConstRef<Eigen::MatrixXd> X) const
 {
     assert(X.rows() == mesh.num_vertices());
 
@@ -38,7 +38,7 @@ template <class TCollisions>
 Eigen::VectorXd Potential<TCollisions>::gradient(
     const TCollisions& collisions,
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& X) const
+    Eigen::ConstRef<Eigen::MatrixXd> X) const
 {
     assert(X.rows() == mesh.num_vertices());
 
@@ -76,7 +76,7 @@ template <class TCollisions>
 Eigen::SparseMatrix<double> Potential<TCollisions>::hessian(
     const TCollisions& collisions,
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& X,
+    Eigen::ConstRef<Eigen::MatrixXd> X,
     const PSDProjectionMethod project_hessian_to_psd) const
 {
     assert(X.rows() == mesh.num_vertices());

--- a/src/ipc/potentials/tangential_potential.cpp
+++ b/src/ipc/potentials/tangential_potential.cpp
@@ -7,9 +7,9 @@ namespace ipc {
 Eigen::VectorXd TangentialPotential::force(
     const TangentialCollisions& collisions,
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& rest_positions,
-    const Eigen::MatrixXd& lagged_displacements,
-    const Eigen::MatrixXd& velocities,
+    Eigen::ConstRef<Eigen::MatrixXd> rest_positions,
+    Eigen::ConstRef<Eigen::MatrixXd> lagged_displacements,
+    Eigen::ConstRef<Eigen::MatrixXd> velocities,
     const NormalPotential& normal_potential,
     const double normal_stiffness,
     const double dmin,
@@ -54,9 +54,9 @@ Eigen::VectorXd TangentialPotential::force(
 Eigen::SparseMatrix<double> TangentialPotential::force_jacobian(
     const TangentialCollisions& collisions,
     const CollisionMesh& mesh,
-    const Eigen::MatrixXd& rest_positions,
-    const Eigen::MatrixXd& lagged_displacements,
-    const Eigen::MatrixXd& velocities,
+    Eigen::ConstRef<Eigen::MatrixXd> rest_positions,
+    Eigen::ConstRef<Eigen::MatrixXd> lagged_displacements,
+    Eigen::ConstRef<Eigen::MatrixXd> velocities,
     const NormalPotential& normal_potential,
     const double normal_stiffness,
     const DiffWRT wrt,
@@ -68,8 +68,8 @@ Eigen::SparseMatrix<double> TangentialPotential::force_jacobian(
     }
 
     const int dim = velocities.cols();
-    const Eigen::MatrixXi& edges = mesh.edges();
-    const Eigen::MatrixXi& faces = mesh.faces();
+    Eigen::ConstRef<Eigen::MatrixXi> edges = mesh.edges();
+    Eigen::ConstRef<Eigen::MatrixXi> faces = mesh.faces();
 
     tbb::enumerable_thread_specific<std::vector<Eigen::Triplet<double>>>
         storage;
@@ -137,7 +137,8 @@ Eigen::SparseMatrix<double> TangentialPotential::force_jacobian(
 // -- Single collision methods -------------------------------------------------
 
 double TangentialPotential::operator()(
-    const TangentialCollision& collision, const VectorMax12d& velocities) const
+    const TangentialCollision& collision,
+    Eigen::ConstRef<VectorMax12d> velocities) const
 {
     // μ N(xᵗ) f₀(‖u‖) (where u = T(xᵗ)ᵀv)
 
@@ -150,7 +151,8 @@ double TangentialPotential::operator()(
 }
 
 VectorMax12d TangentialPotential::gradient(
-    const TangentialCollision& collision, const VectorMax12d& velocities) const
+    const TangentialCollision& collision,
+    Eigen::ConstRef<VectorMax12d> velocities) const
 {
     // ∇ₓ μ N(xᵗ) f₀(‖u‖) (where u = T(xᵗ)ᵀv)
     //  = μ N(xᵗ) f₁(‖u‖)/‖u‖ T(xᵗ) u
@@ -177,7 +179,7 @@ VectorMax12d TangentialPotential::gradient(
 
 MatrixMax12d TangentialPotential::hessian(
     const TangentialCollision& collision,
-    const VectorMax12d& velocities,
+    Eigen::ConstRef<VectorMax12d> velocities,
     const PSDProjectionMethod project_hessian_to_psd) const
 {
     // ∇ₓ μ N(xᵗ) f₁(‖u‖)/‖u‖ T(xᵗ) u (where u = T(xᵗ)ᵀ v)
@@ -250,9 +252,9 @@ MatrixMax12d TangentialPotential::hessian(
 
 VectorMax12d TangentialPotential::force(
     const TangentialCollision& collision,
-    const VectorMax12d& rest_positions,       // = x
-    const VectorMax12d& lagged_displacements, // = u
-    const VectorMax12d& velocities,           // = v
+    Eigen::ConstRef<VectorMax12d> rest_positions,       // = x
+    Eigen::ConstRef<VectorMax12d> lagged_displacements, // = u
+    Eigen::ConstRef<VectorMax12d> velocities,           // = v
     const NormalPotential& normal_potential,
     const double normal_stiffness,
     const double dmin,
@@ -306,9 +308,9 @@ VectorMax12d TangentialPotential::force(
 
 MatrixMax12d TangentialPotential::force_jacobian(
     const TangentialCollision& collision,
-    const VectorMax12d& rest_positions,       // = x
-    const VectorMax12d& lagged_displacements, // = u
-    const VectorMax12d& velocities,           // = v
+    Eigen::ConstRef<VectorMax12d> rest_positions,       // = x
+    Eigen::ConstRef<VectorMax12d> lagged_displacements, // = u
+    Eigen::ConstRef<VectorMax12d> velocities,           // = v
     const NormalPotential& normal_potential,
     const double normal_stiffness,
     const DiffWRT wrt,

--- a/src/ipc/potentials/tangential_potential.hpp
+++ b/src/ipc/potentials/tangential_potential.hpp
@@ -41,9 +41,9 @@ public:
     Eigen::VectorXd force(
         const TangentialCollisions& collisions,
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& rest_positions,
-        const Eigen::MatrixXd& lagged_displacements,
-        const Eigen::MatrixXd& velocities,
+        Eigen::ConstRef<Eigen::MatrixXd> rest_positions,
+        Eigen::ConstRef<Eigen::MatrixXd> lagged_displacements,
+        Eigen::ConstRef<Eigen::MatrixXd> velocities,
         const NormalPotential& normal_potential,
         const double normal_stiffness,
         const double dmin = 0,
@@ -63,9 +63,9 @@ public:
     Eigen::SparseMatrix<double> force_jacobian(
         const TangentialCollisions& collisions,
         const CollisionMesh& mesh,
-        const Eigen::MatrixXd& rest_positions,
-        const Eigen::MatrixXd& lagged_displacements,
-        const Eigen::MatrixXd& velocities,
+        Eigen::ConstRef<Eigen::MatrixXd> rest_positions,
+        Eigen::ConstRef<Eigen::MatrixXd> lagged_displacements,
+        Eigen::ConstRef<Eigen::MatrixXd> velocities,
         const NormalPotential& normal_potential,
         const double normal_stiffness,
         const DiffWRT wrt,
@@ -79,7 +79,7 @@ public:
     /// @return The potential.
     double operator()(
         const TangentialCollision& collision,
-        const VectorMax12d& velocities) const override;
+        Eigen::ConstRef<VectorMax12d> velocities) const override;
 
     /// @brief Compute the gradient of the potential for a single collision.
     /// @param collision The collision
@@ -87,7 +87,7 @@ public:
     /// @return The gradient of the potential.
     VectorMax12d gradient(
         const TangentialCollision& collision,
-        const VectorMax12d& velocities) const override;
+        Eigen::ConstRef<VectorMax12d> velocities) const override;
 
     /// @brief Compute the hessian of the potential for a single collision.
     /// @param collision The collision
@@ -95,7 +95,7 @@ public:
     /// @return The hessian of the potential.
     MatrixMax12d hessian(
         const TangentialCollision& collision,
-        const VectorMax12d& velocities,
+        Eigen::ConstRef<VectorMax12d> velocities,
         const PSDProjectionMethod project_hessian_to_psd =
             PSDProjectionMethod::NONE) const override;
 
@@ -111,9 +111,9 @@ public:
     /// @return Friction force
     VectorMax12d force(
         const TangentialCollision& collision,
-        const VectorMax12d& rest_positions,
-        const VectorMax12d& lagged_displacements,
-        const VectorMax12d& velocities,
+        Eigen::ConstRef<VectorMax12d> rest_positions,
+        Eigen::ConstRef<VectorMax12d> lagged_displacements,
+        Eigen::ConstRef<VectorMax12d> velocities,
         const NormalPotential& normal_potential,
         const double normal_stiffness,
         const double dmin = 0,
@@ -131,9 +131,9 @@ public:
     /// @return Friction force Jacobian
     MatrixMax12d force_jacobian(
         const TangentialCollision& collision,
-        const VectorMax12d& rest_positions,
-        const VectorMax12d& lagged_displacements,
-        const VectorMax12d& velocities,
+        Eigen::ConstRef<VectorMax12d> rest_positions,
+        Eigen::ConstRef<VectorMax12d> lagged_displacements,
+        Eigen::ConstRef<VectorMax12d> velocities,
         const NormalPotential& normal_potential,
         const double normal_stiffness,
         const DiffWRT wrt,

--- a/src/ipc/tangent/closest_point.cpp
+++ b/src/ipc/tangent/closest_point.cpp
@@ -9,18 +9,18 @@ namespace ipc {
 // Point - Edge
 
 double point_edge_closest_point(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1)
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1)
 {
     const VectorMax3d e = e1 - e0;
     return (p - e0).dot(e) / e.squaredNorm();
 }
 
 VectorMax9d point_edge_closest_point_jacobian(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1)
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1)
 {
     const int dim = p.size();
     assert(dim == 2 || dim == 3);
@@ -41,10 +41,10 @@ VectorMax9d point_edge_closest_point_jacobian(
 // Edge - Edge
 
 Eigen::Vector2d edge_edge_closest_point(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     const Eigen::Vector3d eb_to_ea = ea0 - eb0;
     const Eigen::Vector3d ea = ea1 - ea0;
@@ -65,10 +65,10 @@ Eigen::Vector2d edge_edge_closest_point(
 }
 
 Eigen::Matrix<double, 2, 12> edge_edge_closest_point_jacobian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     Eigen::Matrix<double, 2, 12> J;
 
@@ -83,10 +83,10 @@ Eigen::Matrix<double, 2, 12> edge_edge_closest_point_jacobian(
 // Point - Triangle
 
 Eigen::Vector2d point_triangle_closest_point(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     Eigen::Matrix<double, 2, 3> basis;
     basis.row(0) = Eigen::RowVector3d(t1 - t0); // edge 0
@@ -99,10 +99,10 @@ Eigen::Vector2d point_triangle_closest_point(
 }
 
 Eigen::Matrix<double, 2, 12> point_triangle_closest_point_jacobian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     Eigen::Matrix<double, 2, 12> J;
     autogen::point_triangle_closest_point_jacobian(

--- a/src/ipc/tangent/closest_point.hpp
+++ b/src/ipc/tangent/closest_point.hpp
@@ -13,9 +13,9 @@ namespace ipc {
 /// @param e1 Second edge point
 /// @return barycentric coordinates of the closest point
 double point_edge_closest_point(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1);
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1);
 
 /// @brief Compute the Jacobian of the closest point on the edge.
 /// @param p Point
@@ -23,9 +23,9 @@ double point_edge_closest_point(
 /// @param e1 Second edge point
 /// @return Jacobian of the closest point
 VectorMax9d point_edge_closest_point_jacobian(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1);
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1);
 
 // ============================================================================
 // Edge - Edge
@@ -37,10 +37,10 @@ VectorMax9d point_edge_closest_point_jacobian(
 /// @param eb1 Second point of the second edge
 /// @return Barycentric coordinates of the closest points
 Eigen::Vector2d edge_edge_closest_point(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Compute the Jacobian of the closest points between two edges.
 /// @param ea0 First point of the first edge
@@ -49,10 +49,10 @@ Eigen::Vector2d edge_edge_closest_point(
 /// @param eb1 Second point of the second edge
 /// @return Jacobian of the closest points
 Eigen::Matrix<double, 2, 12> edge_edge_closest_point_jacobian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 // ============================================================================
 // Point - Triangle
@@ -64,10 +64,10 @@ Eigen::Matrix<double, 2, 12> edge_edge_closest_point_jacobian(
 /// @param t2 Triangle's third vertex
 /// @return Barycentric coordinates of the closest point
 Eigen::Vector2d point_triangle_closest_point(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 
 /// @brief Compute the Jacobian of the closest point on the triangle.
 /// @param p Point
@@ -76,10 +76,10 @@ Eigen::Vector2d point_triangle_closest_point(
 /// @param t2 Triangle's third vertex
 /// @return Jacobian of the closest point
 Eigen::Matrix<double, 2, 12> point_triangle_closest_point_jacobian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 // ============================================================================
 
 namespace autogen {

--- a/src/ipc/tangent/relative_velocity.cpp
+++ b/src/ipc/tangent/relative_velocity.cpp
@@ -6,8 +6,7 @@ namespace ipc {
 // Point - Point
 
 VectorMax3d point_point_relative_velocity(
-    const Eigen::Ref<const VectorMax3d>& dp0,
-    const Eigen::Ref<const VectorMax3d>& dp1)
+    Eigen::ConstRef<VectorMax3d> dp0, Eigen::ConstRef<VectorMax3d> dp1)
 {
     return dp0 - dp1;
 }
@@ -30,9 +29,9 @@ point_point_relative_velocity_matrix_jacobian(const int dim)
 // Point - Edge
 
 VectorMax3d point_edge_relative_velocity(
-    const Eigen::Ref<const VectorMax3d>& dp,
-    const Eigen::Ref<const VectorMax3d>& de0,
-    const Eigen::Ref<const VectorMax3d>& de1,
+    Eigen::ConstRef<VectorMax3d> dp,
+    Eigen::ConstRef<VectorMax3d> de0,
+    Eigen::ConstRef<VectorMax3d> de1,
     const double alpha)
 {
     return dp - ((de1 - de0) * alpha + de0);
@@ -61,11 +60,11 @@ point_edge_relative_velocity_matrix_jacobian(const int dim, const double alpha)
 // Edge - Edge
 
 Eigen::Vector3d edge_edge_relative_velocity(
-    const Eigen::Ref<const Eigen::Vector3d>& dea0,
-    const Eigen::Ref<const Eigen::Vector3d>& dea1,
-    const Eigen::Ref<const Eigen::Vector3d>& deb0,
-    const Eigen::Ref<const Eigen::Vector3d>& deb1,
-    const Eigen::Ref<const Eigen::Vector2d>& coords)
+    Eigen::ConstRef<Eigen::Vector3d> dea0,
+    Eigen::ConstRef<Eigen::Vector3d> dea1,
+    Eigen::ConstRef<Eigen::Vector3d> deb0,
+    Eigen::ConstRef<Eigen::Vector3d> deb1,
+    Eigen::ConstRef<Eigen::Vector2d> coords)
 {
     // closest_point_a_velocity - closest_point_b_velocity
     return ((dea1 - dea0) * coords[0] + dea0)
@@ -73,7 +72,7 @@ Eigen::Vector3d edge_edge_relative_velocity(
 }
 
 MatrixMax<double, 3, 12> edge_edge_relative_velocity_matrix(
-    const int dim, const Eigen::Ref<const Eigen::Vector2d>& coords)
+    const int dim, Eigen::ConstRef<Eigen::Vector2d> coords)
 {
     MatrixMax<double, 3, 12> J = MatrixMax<double, 3, 12>::Zero(dim, 4 * dim);
     J.leftCols(dim).diagonal().setConstant(1 - coords[0]);
@@ -84,7 +83,7 @@ MatrixMax<double, 3, 12> edge_edge_relative_velocity_matrix(
 }
 
 MatrixMax<double, 6, 12> edge_edge_relative_velocity_matrix_jacobian(
-    const int dim, const Eigen::Ref<const Eigen::Vector2d>& coords)
+    const int dim, Eigen::ConstRef<Eigen::Vector2d> coords)
 {
     MatrixMax<double, 6, 12> J =
         MatrixMax<double, 6, 12>::Zero(2 * dim, 4 * dim);
@@ -101,11 +100,11 @@ MatrixMax<double, 6, 12> edge_edge_relative_velocity_matrix_jacobian(
 // Point - Triangle
 
 Eigen::Vector3d point_triangle_relative_velocity(
-    const Eigen::Ref<const Eigen::Vector3d>& dp,
-    const Eigen::Ref<const Eigen::Vector3d>& dt0,
-    const Eigen::Ref<const Eigen::Vector3d>& dt1,
-    const Eigen::Ref<const Eigen::Vector3d>& dt2,
-    const Eigen::Ref<const Eigen::Vector2d>& coords)
+    Eigen::ConstRef<Eigen::Vector3d> dp,
+    Eigen::ConstRef<Eigen::Vector3d> dt0,
+    Eigen::ConstRef<Eigen::Vector3d> dt1,
+    Eigen::ConstRef<Eigen::Vector3d> dt2,
+    Eigen::ConstRef<Eigen::Vector2d> coords)
 {
     // Compute the velocity of the closest point and subtract it from the
     // points velocity.
@@ -113,7 +112,7 @@ Eigen::Vector3d point_triangle_relative_velocity(
 }
 
 MatrixMax<double, 3, 12> point_triangle_relative_velocity_matrix(
-    const int dim, const Eigen::Ref<const Eigen::Vector2d>& coords)
+    const int dim, Eigen::ConstRef<Eigen::Vector2d> coords)
 {
     MatrixMax<double, 3, 12> J = MatrixMax<double, 3, 12>::Zero(dim, 4 * dim);
     J.leftCols(dim).diagonal().setOnes();
@@ -124,7 +123,7 @@ MatrixMax<double, 3, 12> point_triangle_relative_velocity_matrix(
 }
 
 MatrixMax<double, 6, 12> point_triangle_relative_velocity_matrix_jacobian(
-    const int dim, const Eigen::Ref<const Eigen::Vector2d>& coords)
+    const int dim, Eigen::ConstRef<Eigen::Vector2d> coords)
 {
     MatrixMax<double, 6, 12> J =
         MatrixMax<double, 6, 12>::Zero(2 * dim, 4 * dim);

--- a/src/ipc/tangent/relative_velocity.hpp
+++ b/src/ipc/tangent/relative_velocity.hpp
@@ -12,8 +12,7 @@ namespace ipc {
 /// @param dp1 Velocity of the second point
 /// @return The relative velocity of the two points
 VectorMax3d point_point_relative_velocity(
-    const Eigen::Ref<const VectorMax3d>& dp0,
-    const Eigen::Ref<const VectorMax3d>& dp1);
+    Eigen::ConstRef<VectorMax3d> dp0, Eigen::ConstRef<VectorMax3d> dp1);
 
 /// @brief Compute the point-point relative velocity premultiplier matrix
 /// @param dim Dimension (2 or 3)
@@ -36,9 +35,9 @@ point_point_relative_velocity_matrix_jacobian(const int dim);
 /// @param alpha Parametric coordinate of the closest point on the edge
 /// @return The relative velocity of the point and the edge
 VectorMax3d point_edge_relative_velocity(
-    const Eigen::Ref<const VectorMax3d>& dp,
-    const Eigen::Ref<const VectorMax3d>& de0,
-    const Eigen::Ref<const VectorMax3d>& de1,
+    Eigen::ConstRef<VectorMax3d> dp,
+    Eigen::ConstRef<VectorMax3d> de0,
+    Eigen::ConstRef<VectorMax3d> de1,
     const double alpha);
 
 /// @brief Compute the point-edge relative velocity premultiplier matrix
@@ -66,25 +65,25 @@ point_edge_relative_velocity_matrix_jacobian(const int dim, const double alpha);
 /// @param coords Two parametric coordinates of the closest points on the edges
 /// @return The relative velocity of the edges
 Eigen::Vector3d edge_edge_relative_velocity(
-    const Eigen::Ref<const Eigen::Vector3d>& dea0,
-    const Eigen::Ref<const Eigen::Vector3d>& dea1,
-    const Eigen::Ref<const Eigen::Vector3d>& deb0,
-    const Eigen::Ref<const Eigen::Vector3d>& deb1,
-    const Eigen::Ref<const Eigen::Vector2d>& coords);
+    Eigen::ConstRef<Eigen::Vector3d> dea0,
+    Eigen::ConstRef<Eigen::Vector3d> dea1,
+    Eigen::ConstRef<Eigen::Vector3d> deb0,
+    Eigen::ConstRef<Eigen::Vector3d> deb1,
+    Eigen::ConstRef<Eigen::Vector2d> coords);
 
 /// @brief Compute the edge-edge relative velocity matrix.
 /// @param dim Dimension (2 or 3)
 /// @param coords Two parametric coordinates of the closest points on the edges
 /// @return The relative velocity matrix
 MatrixMax<double, 3, 12> edge_edge_relative_velocity_matrix(
-    const int dim, const Eigen::Ref<const Eigen::Vector2d>& coords);
+    const int dim, Eigen::ConstRef<Eigen::Vector2d> coords);
 
 /// @brief Compute the Jacobian of the edge-edge relative velocity matrix.
 /// @param dim Dimension (2 or 3)
 /// @param coords Two parametric coordinates of the closest points on the edges
 /// @return The Jacobian of the relative velocity matrix
 MatrixMax<double, 6, 12> edge_edge_relative_velocity_matrix_jacobian(
-    const int dim, const Eigen::Ref<const Eigen::Vector2d>& coords);
+    const int dim, Eigen::ConstRef<Eigen::Vector2d> coords);
 
 // ============================================================================
 // Point - Triangle
@@ -97,24 +96,24 @@ MatrixMax<double, 6, 12> edge_edge_relative_velocity_matrix_jacobian(
 /// @param coords Baricentric coordinates of the closest point on the triangle
 /// @return The relative velocity of the point to the triangle
 Eigen::Vector3d point_triangle_relative_velocity(
-    const Eigen::Ref<const Eigen::Vector3d>& dp,
-    const Eigen::Ref<const Eigen::Vector3d>& dt0,
-    const Eigen::Ref<const Eigen::Vector3d>& dt1,
-    const Eigen::Ref<const Eigen::Vector3d>& dt2,
-    const Eigen::Ref<const Eigen::Vector2d>& coords);
+    Eigen::ConstRef<Eigen::Vector3d> dp,
+    Eigen::ConstRef<Eigen::Vector3d> dt0,
+    Eigen::ConstRef<Eigen::Vector3d> dt1,
+    Eigen::ConstRef<Eigen::Vector3d> dt2,
+    Eigen::ConstRef<Eigen::Vector2d> coords);
 
 /// @brief Compute the point-triangle relative velocity matrix.
 /// @param dim Dimension (2 or 3)
 /// @param coords Baricentric coordinates of the closest point on the triangle
 /// @return The relative velocity matrix
 MatrixMax<double, 3, 12> point_triangle_relative_velocity_matrix(
-    const int dim, const Eigen::Ref<const Eigen::Vector2d>& coords);
+    const int dim, Eigen::ConstRef<Eigen::Vector2d> coords);
 
 /// @brief Compute the Jacobian of the point-triangle relative velocity matrix.
 /// @param dim Dimension (2 or 3)
 /// @param coords Baricentric coordinates of the closest point on the triangle
 /// @return The Jacobian of the relative velocity matrix
 MatrixMax<double, 6, 12> point_triangle_relative_velocity_matrix_jacobian(
-    const int dim, const Eigen::Ref<const Eigen::Vector2d>& coords);
+    const int dim, Eigen::ConstRef<Eigen::Vector2d> coords);
 
 } // namespace ipc

--- a/src/ipc/tangent/tangent_basis.cpp
+++ b/src/ipc/tangent/tangent_basis.cpp
@@ -15,8 +15,7 @@ namespace {
 // Point - Point
 
 MatrixMax<double, 3, 2> point_point_tangent_basis(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1)
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1)
 {
     const int dim = p0.size();
     assert(dim == p1.size());
@@ -48,8 +47,7 @@ MatrixMax<double, 3, 2> point_point_tangent_basis(
 }
 
 MatrixMax<double, 18, 2> point_point_tangent_basis_jacobian(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1)
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1)
 {
     const int dim = p0.size();
     assert(dim == p1.size());
@@ -72,9 +70,9 @@ MatrixMax<double, 18, 2> point_point_tangent_basis_jacobian(
 // Point - Edge
 
 MatrixMax<double, 3, 2> point_edge_tangent_basis(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1)
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1)
 {
     const int dim = p.size();
     assert(dim == e0.size() && dim == e1.size());
@@ -94,9 +92,9 @@ MatrixMax<double, 3, 2> point_edge_tangent_basis(
 }
 
 MatrixMax<double, 27, 2> point_edge_tangent_basis_jacobian(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1)
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1)
 {
     const int dim = p.size();
     assert(dim == e0.size() && dim == e1.size());
@@ -120,10 +118,10 @@ MatrixMax<double, 27, 2> point_edge_tangent_basis_jacobian(
 // Edge - Edge
 
 Eigen::Matrix<double, 3, 2> edge_edge_tangent_basis(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     const Eigen::Vector3d ea = ea1 - ea0; // Edge A direction
     const Eigen::Vector3d normal = ea.cross(eb1 - eb0);
@@ -140,10 +138,10 @@ Eigen::Matrix<double, 3, 2> edge_edge_tangent_basis(
 }
 
 Eigen::Matrix<double, 36, 2> edge_edge_tangent_basis_jacobian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1)
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1)
 {
     Eigen::Matrix<double, 36, 2> J;
     autogen::edge_edge_tangent_basis_jacobian(
@@ -156,10 +154,10 @@ Eigen::Matrix<double, 36, 2> edge_edge_tangent_basis_jacobian(
 // Point - Triangle
 
 Eigen::Matrix<double, 3, 2> point_triangle_tangent_basis(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     const Eigen::Vector3d e0 = t1 - t0;
     const Eigen::Vector3d normal = e0.cross(t2 - t0);
@@ -177,10 +175,10 @@ Eigen::Matrix<double, 3, 2> point_triangle_tangent_basis(
 }
 
 Eigen::Matrix<double, 36, 2> point_triangle_tangent_basis_jacobian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2)
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     Eigen::Matrix<double, 36, 2> J;
     autogen::point_triangle_tangent_basis_jacobian(

--- a/src/ipc/tangent/tangent_basis.hpp
+++ b/src/ipc/tangent/tangent_basis.hpp
@@ -12,16 +12,14 @@ namespace ipc {
 /// @param p1 Second point
 /// @return A 3x2 matrix whose columns are the basis vectors.
 MatrixMax<double, 3, 2> point_point_tangent_basis(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1);
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1);
 
 /// @brief Compute the Jacobian of the tangent basis for the point-point pair.
 /// @param p0 First point
 /// @param p1 Second point
 /// @return A 6*3x2 matrix whose columns are the basis vectors.
 MatrixMax<double, 18, 2> point_point_tangent_basis_jacobian(
-    const Eigen::Ref<const VectorMax3d>& p0,
-    const Eigen::Ref<const VectorMax3d>& p1);
+    Eigen::ConstRef<VectorMax3d> p0, Eigen::ConstRef<VectorMax3d> p1);
 
 // ============================================================================
 // Point - Edge
@@ -32,9 +30,9 @@ MatrixMax<double, 18, 2> point_point_tangent_basis_jacobian(
 /// @param e1 Second edge point
 /// @return A 3x2 matrix whose columns are the basis vectors.
 MatrixMax<double, 3, 2> point_edge_tangent_basis(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1);
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1);
 
 /// @brief Compute the Jacobian of the tangent basis for the point-edge pair.
 /// @param p Point
@@ -42,9 +40,9 @@ MatrixMax<double, 3, 2> point_edge_tangent_basis(
 /// @param e1 Second edge point
 /// @return A 9*3x2 matrix whose columns are the basis vectors.
 MatrixMax<double, 27, 2> point_edge_tangent_basis_jacobian(
-    const Eigen::Ref<const VectorMax3d>& p,
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1);
+    Eigen::ConstRef<VectorMax3d> p,
+    Eigen::ConstRef<VectorMax3d> e0,
+    Eigen::ConstRef<VectorMax3d> e1);
 
 // ============================================================================
 // Edge - Edge
@@ -56,10 +54,10 @@ MatrixMax<double, 27, 2> point_edge_tangent_basis_jacobian(
 /// @param eb1 Second point of the second edge
 /// @return A 3x2 matrix whose columns are the basis vectors.
 Eigen::Matrix<double, 3, 2> edge_edge_tangent_basis(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 /// @brief Compute the Jacobian of the tangent basis for the edge-edge pair.
 /// @param ea0 First point of the first edge
@@ -68,10 +66,10 @@ Eigen::Matrix<double, 3, 2> edge_edge_tangent_basis(
 /// @param eb1 Second point of the second edge
 /// @return A 12*3x2 matrix whose columns are the basis vectors.
 Eigen::Matrix<double, 36, 2> edge_edge_tangent_basis_jacobian(
-    const Eigen::Ref<const Eigen::Vector3d>& ea0,
-    const Eigen::Ref<const Eigen::Vector3d>& ea1,
-    const Eigen::Ref<const Eigen::Vector3d>& eb0,
-    const Eigen::Ref<const Eigen::Vector3d>& eb1);
+    Eigen::ConstRef<Eigen::Vector3d> ea0,
+    Eigen::ConstRef<Eigen::Vector3d> ea1,
+    Eigen::ConstRef<Eigen::Vector3d> eb0,
+    Eigen::ConstRef<Eigen::Vector3d> eb1);
 
 // ============================================================================
 // Point - Triangle
@@ -91,10 +89,10 @@ Eigen::Matrix<double, 36, 2> edge_edge_tangent_basis_jacobian(
 /// @param t2 Triangle's third vertex
 /// @return A 3x2 matrix whose columns are the basis vectors.
 Eigen::Matrix<double, 3, 2> point_triangle_tangent_basis(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 
 /// @brief Compute the Jacobian of the tangent basis for the point-triangle pair.
 /// @param p Point
@@ -103,10 +101,10 @@ Eigen::Matrix<double, 3, 2> point_triangle_tangent_basis(
 /// @param t2 Triangle's third vertex
 /// @return A 12*3x2 matrix whose columns are the basis vectors.
 Eigen::Matrix<double, 36, 2> point_triangle_tangent_basis_jacobian(
-    const Eigen::Ref<const Eigen::Vector3d>& p,
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2);
+    Eigen::ConstRef<Eigen::Vector3d> p,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 
 // ============================================================================
 

--- a/src/ipc/utils/area_gradient.cpp
+++ b/src/ipc/utils/area_gradient.cpp
@@ -5,8 +5,7 @@
 namespace ipc {
 
 VectorMax6d edge_length_gradient(
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1)
+    Eigen::ConstRef<VectorMax3d> e0, Eigen::ConstRef<VectorMax3d> e1)
 {
     assert(e0.size() == 2 || e0.size() == 3);
     assert(e1.size() == 2 || e1.size() == 3);
@@ -20,9 +19,9 @@ VectorMax6d edge_length_gradient(
 }
 
 Vector9d triangle_area_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2)
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     Vector9d grad;
     autogen::triangle_area_gradient(

--- a/src/ipc/utils/area_gradient.hpp
+++ b/src/ipc/utils/area_gradient.hpp
@@ -9,8 +9,7 @@ namespace ipc {
 /// @param e1 The second vertex of the edge.
 /// @return The gradient of the edge's length wrt e0, and e1.
 VectorMax6d edge_length_gradient(
-    const Eigen::Ref<const VectorMax3d>& e0,
-    const Eigen::Ref<const VectorMax3d>& e1);
+    Eigen::ConstRef<VectorMax3d> e0, Eigen::ConstRef<VectorMax3d> e1);
 
 /// @brief Compute the gradient of the area of a triangle.
 /// @param t0 The first vertex of the triangle.
@@ -18,9 +17,9 @@ VectorMax6d edge_length_gradient(
 /// @param t2 The third vertex of the triangle.
 /// @return The gradient of the triangle's area t0, t1, and t2.
 Vector9d triangle_area_gradient(
-    const Eigen::Ref<const Eigen::Vector3d>& t0,
-    const Eigen::Ref<const Eigen::Vector3d>& t1,
-    const Eigen::Ref<const Eigen::Vector3d>& t2);
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 
 namespace autogen {
 

--- a/src/ipc/utils/eigen_ext.hpp
+++ b/src/ipc/utils/eigen_ext.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
 #include <Eigen/Core>
-#include <Eigen/SparseCore>
+#include <Eigen/Sparse>
 
 #include <cassert>
+
+namespace Eigen {
+template <typename T> using RowRef = Ref<T, 0, Eigen::InnerStride<>>;
+template <typename T> using ConstRef = const Ref<const T>&;
+template <typename T> using ConstRowRef = const RowRef<const T>&;
+} // namespace Eigen
 
 namespace ipc {
 
@@ -169,7 +175,7 @@ project_to_psd(
     const Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>& A,
     const PSDProjectionMethod method = PSDProjectionMethod::CLAMP);
 
-inline Eigen::Vector3d to_3D(const VectorMax3d& v)
+inline Eigen::Vector3d to_3D(Eigen::ConstRef<VectorMax3d> v)
 {
     assert(v.size() == 2 || v.size() == 3);
     return v.size() == 2 ? Eigen::Vector3d(v.x(), v.y(), 0) : v.head<3>();

--- a/src/ipc/utils/intersection.cpp
+++ b/src/ipc/utils/intersection.cpp
@@ -15,11 +15,11 @@ namespace ipc {
 #ifdef IPC_TOOLKIT_WITH_RATIONAL_INTERSECTION
 namespace {
     bool is_edge_intersecting_triangle_rational(
-        const Eigen::Vector3d& e0_float,
-        const Eigen::Vector3d& e1_float,
-        const Eigen::Vector3d& t0_float,
-        const Eigen::Vector3d& t1_float,
-        const Eigen::Vector3d& t2_float)
+        Eigen::ConstRef<Eigen::Vector3d> e0_float,
+        Eigen::ConstRef<Eigen::Vector3d> e1_float,
+        Eigen::ConstRef<Eigen::Vector3d> t0_float,
+        Eigen::ConstRef<Eigen::Vector3d> t1_float,
+        Eigen::ConstRef<Eigen::Vector3d> t2_float)
     {
         using namespace rational;
 
@@ -114,11 +114,11 @@ namespace {
 #endif
 
 bool is_edge_intersecting_triangle(
-    const Eigen::Vector3d& e0,
-    const Eigen::Vector3d& e1,
-    const Eigen::Vector3d& t0,
-    const Eigen::Vector3d& t1,
-    const Eigen::Vector3d& t2)
+    Eigen::ConstRef<Eigen::Vector3d> e0,
+    Eigen::ConstRef<Eigen::Vector3d> e1,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2)
 {
     igl::predicates::exactinit();
     const auto ori1 = igl::predicates::orient3d(t0, t1, t2, e0);

--- a/src/ipc/utils/intersection.hpp
+++ b/src/ipc/utils/intersection.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Eigen/Core>
+#include <ipc/utils/eigen_ext.hpp>
 
 namespace ipc {
 
@@ -12,10 +12,10 @@ namespace ipc {
 /// @param t2 Triangle vertex 2.
 /// @return True if the edge intersects the triangle.
 bool is_edge_intersecting_triangle(
-    const Eigen::Vector3d& e0,
-    const Eigen::Vector3d& e1,
-    const Eigen::Vector3d& t0,
-    const Eigen::Vector3d& t1,
-    const Eigen::Vector3d& t2);
+    Eigen::ConstRef<Eigen::Vector3d> e0,
+    Eigen::ConstRef<Eigen::Vector3d> e1,
+    Eigen::ConstRef<Eigen::Vector3d> t0,
+    Eigen::ConstRef<Eigen::Vector3d> t1,
+    Eigen::ConstRef<Eigen::Vector3d> t2);
 
 } // namespace ipc

--- a/src/ipc/utils/interval.cpp
+++ b/src/ipc/utils/interval.cpp
@@ -4,7 +4,7 @@
 
 namespace ipc {
 
-filib::Interval squared_norm(const Eigen::Ref<const VectorXI>& x)
+filib::Interval squared_norm(Eigen::ConstRef<VectorXI> x)
 {
     filib::Interval sqr_norm(0);
     for (int i = 0; i < x.size(); i++) {
@@ -13,7 +13,7 @@ filib::Interval squared_norm(const Eigen::Ref<const VectorXI>& x)
     return sqr_norm;
 }
 
-filib::Interval norm(const Eigen::Ref<const VectorXI>& x)
+filib::Interval norm(Eigen::ConstRef<VectorXI> x)
 {
     return sqrt(squared_norm(x));
 }

--- a/src/ipc/utils/interval.hpp
+++ b/src/ipc/utils/interval.hpp
@@ -84,13 +84,13 @@ using MatrixMax3I = MatrixMax3<filib::Interval>;
 /// @note This should be used instead of the .squaredNorm() method of Eigen because it avoids negative values in intermediate computations.
 /// @param v The n-dimensional interval
 /// @return The squared L2 norm of the interval
-filib::Interval squared_norm(const Eigen::Ref<const VectorXI>& v); // L2 norm
+filib::Interval squared_norm(Eigen::ConstRef<VectorXI> v); // L2 norm
 
 /// @brief Compute the L2 norm of a n-dimensional interval
 /// @note This should be used instead of the .norm() method of Eigen because it avoids negative values in intermediate computations.
 /// @param v The n-dimensional interval
 /// @return The L2 norm of the interval
-filib::Interval norm(const Eigen::Ref<const VectorXI>& v); // L2 norm
+filib::Interval norm(Eigen::ConstRef<VectorXI> v); // L2 norm
 
 } // namespace ipc
 

--- a/src/ipc/utils/local_to_global.hpp
+++ b/src/ipc/utils/local_to_global.hpp
@@ -7,12 +7,12 @@
 
 namespace ipc {
 
-template <typename DerivedLocalGrad, typename IDContainer, typename DerivedGrad>
+template <typename IDContainer>
 void local_gradient_to_global_gradient(
-    const Eigen::MatrixBase<DerivedLocalGrad>& local_grad,
+    Eigen::ConstRef<Eigen::VectorXd> local_grad,
     const IDContainer& ids,
-    int dim,
-    Eigen::PlainObjectBase<DerivedGrad>& grad)
+    const int dim,
+    Eigen::Ref<Eigen::VectorXd> grad)
 {
     assert(local_grad.size() % dim == 0);
     const int n_verts = local_grad.size() / dim;
@@ -22,15 +22,12 @@ void local_gradient_to_global_gradient(
     }
 }
 
-template <
-    typename DerivedLocalGrad,
-    typename IDContainer,
-    typename Scalar = typename DerivedLocalGrad::Scalar>
+template <typename IDContainer>
 void local_gradient_to_global_gradient(
-    const Eigen::MatrixBase<DerivedLocalGrad>& local_grad,
+    Eigen::ConstRef<Eigen::VectorXd> local_grad,
     const IDContainer& ids,
-    int dim,
-    Eigen::SparseVector<Scalar>& grad)
+    const int dim,
+    Eigen::SparseVector<double>& grad)
 {
     assert(local_grad.size() % dim == 0);
     const int n_verts = local_grad.size() / dim;
@@ -42,11 +39,11 @@ void local_gradient_to_global_gradient(
     }
 }
 
-template <typename Derived, typename IDContainer>
+template <typename IDContainer>
 void local_hessian_to_global_triplets(
-    const Eigen::MatrixBase<Derived>& local_hessian,
+    Eigen::ConstRef<Eigen::MatrixXd> local_hessian,
     const IDContainer& ids,
-    int dim,
+    const int dim,
     std::vector<Eigen::Triplet<double>>& triplets)
 {
     assert(local_hessian.rows() == local_hessian.cols());

--- a/src/ipc/utils/save_obj.cpp
+++ b/src/ipc/utils/save_obj.cpp
@@ -12,9 +12,9 @@ namespace ipc {
 template <>
 void save_obj(
     std::ostream& out,
-    const Eigen::MatrixXd& V,
-    const Eigen::MatrixXi&,
-    const Eigen::MatrixXi&,
+    Eigen::ConstRef<Eigen::MatrixXd> V,
+    Eigen::ConstRef<Eigen::MatrixXi>,
+    Eigen::ConstRef<Eigen::MatrixXi>,
     const std::vector<VertexVertexCandidate>& vv_candidates,
     const int)
 {
@@ -28,9 +28,9 @@ void save_obj(
 template <>
 void save_obj(
     std::ostream& out,
-    const Eigen::MatrixXd& V,
-    const Eigen::MatrixXi& E,
-    const Eigen::MatrixXi& F,
+    Eigen::ConstRef<Eigen::MatrixXd> V,
+    Eigen::ConstRef<Eigen::MatrixXi> E,
+    Eigen::ConstRef<Eigen::MatrixXi> F,
     const std::vector<EdgeVertexCandidate>& ev_candidates,
     const int v_offset)
 {
@@ -48,9 +48,9 @@ void save_obj(
 template <>
 void save_obj(
     std::ostream& out,
-    const Eigen::MatrixXd& V,
-    const Eigen::MatrixXi& E,
-    const Eigen::MatrixXi& F,
+    Eigen::ConstRef<Eigen::MatrixXd> V,
+    Eigen::ConstRef<Eigen::MatrixXi> E,
+    Eigen::ConstRef<Eigen::MatrixXi> F,
     const std::vector<EdgeEdgeCandidate>& ee_candidates,
     const int v_offset)
 {
@@ -70,9 +70,9 @@ void save_obj(
 template <>
 void save_obj(
     std::ostream& out,
-    const Eigen::MatrixXd& V,
-    const Eigen::MatrixXi& E,
-    const Eigen::MatrixXi& F,
+    Eigen::ConstRef<Eigen::MatrixXd> V,
+    Eigen::ConstRef<Eigen::MatrixXi> E,
+    Eigen::ConstRef<Eigen::MatrixXi> F,
     const std::vector<FaceVertexCandidate>& fv_candidates,
     const int v_offset)
 {
@@ -91,9 +91,9 @@ void save_obj(
 template <>
 void save_obj(
     std::ostream& out,
-    const Eigen::MatrixXd& V,
-    const Eigen::MatrixXi& E,
-    const Eigen::MatrixXi& F,
+    Eigen::ConstRef<Eigen::MatrixXd> V,
+    Eigen::ConstRef<Eigen::MatrixXi> E,
+    Eigen::ConstRef<Eigen::MatrixXi> F,
     const std::vector<EdgeFaceCandidate>& ef_candidates,
     const int v_offset)
 {

--- a/src/ipc/utils/save_obj.hpp
+++ b/src/ipc/utils/save_obj.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Eigen/Core>
+#include <ipc/utils/eigen_ext.hpp>
 
 #include <fstream>
 #include <ostream>
@@ -11,18 +11,18 @@ namespace ipc {
 template <typename Candidate>
 void save_obj(
     std::ostream& out,
-    const Eigen::MatrixXd& V,
-    const Eigen::MatrixXi& E,
-    const Eigen::MatrixXi& F,
+    Eigen::ConstRef<Eigen::MatrixXd> V,
+    Eigen::ConstRef<Eigen::MatrixXi> E,
+    Eigen::ConstRef<Eigen::MatrixXi> F,
     const std::vector<Candidate>& candidates,
     const int v_offset = 0);
 
 template <typename Candidate>
 bool save_obj(
     const std::string& filename,
-    const Eigen::MatrixXd& V,
-    const Eigen::MatrixXi& E,
-    const Eigen::MatrixXi& F,
+    Eigen::ConstRef<Eigen::MatrixXd> V,
+    Eigen::ConstRef<Eigen::MatrixXi> E,
+    Eigen::ConstRef<Eigen::MatrixXi> F,
     const std::vector<Candidate>& candidates)
 {
     std::ofstream obj(filename);

--- a/src/ipc/utils/vertex_to_min_edge.cpp
+++ b/src/ipc/utils/vertex_to_min_edge.cpp
@@ -5,7 +5,7 @@
 namespace ipc {
 
 std::vector<size_t>
-vertex_to_min_edge(size_t num_vertices, const Eigen::MatrixXi& edges)
+vertex_to_min_edge(size_t num_vertices, Eigen::ConstRef<Eigen::MatrixXi> edges)
 {
     std::vector<size_t> V2E(num_vertices, edges.rows() + 1);
     // Column first because colmajor

--- a/src/ipc/utils/vertex_to_min_edge.hpp
+++ b/src/ipc/utils/vertex_to_min_edge.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <Eigen/Core>
+#include <ipc/utils/eigen_ext.hpp>
 
 #include <vector>
 
 namespace ipc {
 
 std::vector<size_t>
-vertex_to_min_edge(size_t num_vertices, const Eigen::MatrixXi& edges);
+vertex_to_min_edge(size_t num_vertices, Eigen::ConstRef<Eigen::MatrixXi> edges);
 
 } // namespace ipc

--- a/src/ipc/utils/world_bbox_diagonal_length.hpp
+++ b/src/ipc/utils/world_bbox_diagonal_length.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <Eigen/Core>
+#include <ipc/utils/eigen_ext.hpp>
 
 namespace ipc {
 
 /// @brief Compute the diagonal length of the world bounding box.
 /// @param vertices Vertex positions
 /// @return The diagonal length of the world bounding box.
-inline double world_bbox_diagonal_length(const Eigen::MatrixXd& vertices)
+inline double
+world_bbox_diagonal_length(Eigen::ConstRef<Eigen::MatrixXd> vertices)
 {
     return (vertices.colwise().maxCoeff() - vertices.colwise().minCoeff())
         .norm();


### PR DESCRIPTION
# Description

Change `const Eigen::Matrix&` to `Eigen::ConstRef<Matrix>` for better compatibility and fewer copies.

Drop scalar templating in:
* `local_to_global`
* `CollisionStencil::dof`
* `CollisionStencil::vertices`

## Type of change

- [x] Enhancement (non-breaking change which improves existing functionality)

# How Has This Been Tested?

Existing unit tests.

**Test Configuration**:
* OS and Version: macOS 15.3.2
* Compiler and Version: Apple Clang 16.0.0

# Checklist

- [x] I have followed the project [style guide](https://ipctk.xyz/style_guide.html)
- [x] My code follows the clang-format style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules