### PR TITLE
Index Typedef

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,19 +1,148 @@
-# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
-BasedOnStyle: WebKit
-ColumnLimit: 80
-AlignTrailingComments: true
-FixNamespaceComments: true
-ReflowComments: true
-BinPackParameters: false
-AllowAllParametersOfDeclarationOnNextLine: true
+---
+Language:        Cpp
+AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: true
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: Right
+AlignOperands:   DontAlign
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AllowShortNamespacesOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: false
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: None
+BreakArrays: false
 BreakBeforeBinaryOperators: NonAssignment
-SortIncludes: true
-CommentPragmas:  '^@.+'
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakBinaryOperations: Never
+BreakConstructorInitializers: BeforeComma
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeColon
 BreakStringLiterals: false
-PackConstructorInitializers: CurrentLine
-# Regroup includes with a priority system
-IncludeBlocks: Regroup
+BreakTemplateDeclarations: MultiLine
+ColumnLimit: 80
+CommentPragmas:  '^@.+'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - RANGES_FOR
+  - FOREACH
+IfMacros:
+  - IF
+IncludeBlocks:   Regroup
 IncludeCategories:
   # by default, the main header of a cpp will get priority 0
   # regex here are sorted by search pattern, not by sort priority
@@ -37,3 +166,131 @@ IncludeCategories:
     Priority:        1    # internal file group
     SortPriority:    1
     CaseSensitive:   true
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExportBlock: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  true
+  AtStartOfFile:   true
+KeepFormFeed:    false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: CurrentLine
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakBeforeMemberAccess: 150
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  Always
+RemoveBracesLLVM: false
+RemoveEmptyLinesInUnwrappedLines: true
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:    CaseInsensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: true
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TableGenBreakInsideDAGArg: DontBreak
+TabWidth:        8
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+WrapNamespaceBodyWithEmptyLines: Leave
+...

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: clang-format style check
-      uses: jidicula/clang-format-action@v4.13.0
+      uses: jidicula/clang-format-action@v4.15.0
       with:
-        clang-format-version: '18'
+        clang-format-version: '20'
         check-path: ${{ matrix.path }}

--- a/python/src/barrier/adaptive_stiffness.cpp
+++ b/python/src/barrier/adaptive_stiffness.cpp
@@ -72,10 +72,9 @@ void define_adaptive_stiffness(py::module_& m)
     m.def(
         "semi_implicit_stiffness",
         static_cast<double (*)(
-            const CollisionStencil&, const std::array<long, 4>&,
-            Eigen::ConstRef<VectorMax12d>, Eigen::ConstRef<VectorMax4d>,
-            Eigen::ConstRef<MatrixMax12d>, const double)>(
-            &semi_implicit_stiffness),
+            const CollisionStencil&, Eigen::ConstRef<VectorMax12d>,
+            Eigen::ConstRef<VectorMax4d>, Eigen::ConstRef<MatrixMax12d>,
+            const double)>(&semi_implicit_stiffness),
         R"ipc_Qu8mg5v7(
         Compute the semi-implicit stiffness for a single collision.
 
@@ -92,8 +91,8 @@ void define_adaptive_stiffness(py::module_& m)
         Returns:
             The semi-implicit stiffness.
         )ipc_Qu8mg5v7",
-        py::arg("stencil"), py::arg("vertex_ids"), py::arg("vertices"),
-        py::arg("mass"), py::arg("local_hess"), py::arg("dmin"));
+        py::arg("stencil"), py::arg("vertices"), py::arg("mass"),
+        py::arg("local_hess"), py::arg("dmin"));
 
     m.def(
         "semi_implicit_stiffness",

--- a/python/src/candidates/edge_edge.cpp
+++ b/python/src/candidates/edge_edge.cpp
@@ -8,9 +8,11 @@ using namespace ipc;
 void define_edge_edge_candidate(py::module_& m)
 {
     py::class_<EdgeEdgeCandidate, CollisionStencil>(m, "EdgeEdgeCandidate")
-        .def(py::init<long, long>(), py::arg("edge0_id"), py::arg("edge1_id"))
         .def(
-            py::init([](std::tuple<long, long> edge_ids) {
+            py::init<index_t, index_t>(), py::arg("edge0_id"),
+            py::arg("edge1_id"))
+        .def(
+            py::init([](std::tuple<index_t, index_t> edge_ids) {
                 return std::make_unique<EdgeEdgeCandidate>(
                     std::get<0>(edge_ids), std::get<1>(edge_ids));
             }),
@@ -37,5 +39,6 @@ void define_edge_edge_candidate(py::module_& m)
         .def_readwrite(
             "edge1_id", &EdgeEdgeCandidate::edge1_id, "ID of the second edge.");
 
-    py::implicitly_convertible<std::tuple<long, long>, EdgeEdgeCandidate>();
+    py::implicitly_convertible<
+        std::tuple<index_t, index_t>, EdgeEdgeCandidate>();
 }

--- a/python/src/candidates/edge_face.cpp
+++ b/python/src/candidates/edge_face.cpp
@@ -9,9 +9,11 @@ using namespace ipc;
 void define_edge_face_candidate(py::module_& m)
 {
     py::class_<EdgeFaceCandidate>(m, "EdgeFaceCandidate")
-        .def(py::init<long, long>(), py::arg("edge_id"), py::arg("face_id"))
         .def(
-            py::init([](std::tuple<long, long> edge_and_face_id) {
+            py::init<index_t, index_t>(), py::arg("edge_id"),
+            py::arg("face_id"))
+        .def(
+            py::init([](std::tuple<index_t, index_t> edge_and_face_id) {
                 return std::make_unique<EdgeFaceCandidate>(
                     std::get<0>(edge_and_face_id),
                     std::get<1>(edge_and_face_id));
@@ -37,5 +39,6 @@ void define_edge_face_candidate(py::module_& m)
         .def_readwrite(
             "face_id", &EdgeFaceCandidate::face_id, "ID of the face");
 
-    py::implicitly_convertible<std::tuple<long, long>, EdgeFaceCandidate>();
+    py::implicitly_convertible<
+        std::tuple<index_t, index_t>, EdgeFaceCandidate>();
 }

--- a/python/src/candidates/edge_vertex.cpp
+++ b/python/src/candidates/edge_vertex.cpp
@@ -8,9 +8,11 @@ using namespace ipc;
 void define_edge_vertex_candidate(py::module_& m)
 {
     py::class_<EdgeVertexCandidate, CollisionStencil>(m, "EdgeVertexCandidate")
-        .def(py::init<long, long>(), py::arg("edge_id"), py::arg("vertex_id"))
         .def(
-            py::init([](std::tuple<long, long> edge_and_vertex_id) {
+            py::init<index_t, index_t>(), py::arg("edge_id"),
+            py::arg("vertex_id"))
+        .def(
+            py::init([](std::tuple<index_t, index_t> edge_and_vertex_id) {
                 return std::make_unique<EdgeVertexCandidate>(
                     std::get<0>(edge_and_vertex_id),
                     std::get<1>(edge_and_vertex_id));
@@ -39,5 +41,6 @@ void define_edge_vertex_candidate(py::module_& m)
         .def_readwrite(
             "vertex_id", &EdgeVertexCandidate::vertex_id, "ID of the vertex");
 
-    py::implicitly_convertible<std::tuple<long, long>, EdgeVertexCandidate>();
+    py::implicitly_convertible<
+        std::tuple<index_t, index_t>, EdgeVertexCandidate>();
 }

--- a/python/src/candidates/face_face.cpp
+++ b/python/src/candidates/face_face.cpp
@@ -9,9 +9,11 @@ using namespace ipc;
 void define_face_face_candidate(py::module_& m)
 {
     py::class_<FaceFaceCandidate>(m, "FaceFaceCandidate")
-        .def(py::init<long, long>(), py::arg("face0_id"), py::arg("face1_id"))
         .def(
-            py::init([](std::tuple<long, long> face_ids) {
+            py::init<index_t, index_t>(), py::arg("face0_id"),
+            py::arg("face1_id"))
+        .def(
+            py::init([](std::tuple<index_t, index_t> face_ids) {
                 return std::make_unique<FaceFaceCandidate>(
                     std::get<0>(face_ids), std::get<1>(face_ids));
             }),
@@ -37,5 +39,6 @@ void define_face_face_candidate(py::module_& m)
         .def_readwrite(
             "face1_id", &FaceFaceCandidate::face1_id, "ID of the second face.");
 
-    py::implicitly_convertible<std::tuple<long, long>, FaceFaceCandidate>();
+    py::implicitly_convertible<
+        std::tuple<index_t, index_t>, FaceFaceCandidate>();
 }

--- a/python/src/candidates/face_vertex.cpp
+++ b/python/src/candidates/face_vertex.cpp
@@ -8,9 +8,11 @@ using namespace ipc;
 void define_face_vertex_candidate(py::module_& m)
 {
     py::class_<FaceVertexCandidate, CollisionStencil>(m, "FaceVertexCandidate")
-        .def(py::init<long, long>(), py::arg("face_id"), py::arg("vertex_id"))
         .def(
-            py::init([](std::tuple<long, long> face_and_vertex_id) {
+            py::init<index_t, index_t>(), py::arg("face_id"),
+            py::arg("vertex_id"))
+        .def(
+            py::init([](std::tuple<index_t, index_t> face_and_vertex_id) {
                 return std::make_unique<FaceVertexCandidate>(
                     std::get<0>(face_and_vertex_id),
                     std::get<1>(face_and_vertex_id));
@@ -39,5 +41,6 @@ void define_face_vertex_candidate(py::module_& m)
         .def_readwrite(
             "vertex_id", &FaceVertexCandidate::vertex_id, "ID of the vertex");
 
-    py::implicitly_convertible<std::tuple<long, long>, FaceVertexCandidate>();
+    py::implicitly_convertible<
+        std::tuple<index_t, index_t>, FaceVertexCandidate>();
 }

--- a/python/src/candidates/vertex_vertex.cpp
+++ b/python/src/candidates/vertex_vertex.cpp
@@ -10,10 +10,10 @@ void define_vertex_vertex_candidate(py::module_& m)
     py::class_<VertexVertexCandidate, CollisionStencil>(
         m, "VertexVertexCandidate")
         .def(
-            py::init<long, long>(), py::arg("vertex0_id"),
+            py::init<index_t, index_t>(), py::arg("vertex0_id"),
             py::arg("vertex1_id"))
         .def(
-            py::init([](std::tuple<long, long> vertex_ids) {
+            py::init([](std::tuple<index_t, index_t> vertex_ids) {
                 return std::make_unique<VertexVertexCandidate>(
                     std::get<0>(vertex_ids), std::get<1>(vertex_ids));
             }),
@@ -43,5 +43,6 @@ void define_vertex_vertex_candidate(py::module_& m)
             "vertex1_id", &VertexVertexCandidate::vertex1_id,
             "ID of the second vertex");
 
-    py::implicitly_convertible<std::tuple<long, long>, VertexVertexCandidate>();
+    py::implicitly_convertible<
+        std::tuple<index_t, index_t>, VertexVertexCandidate>();
 }

--- a/python/src/collisions/normal/edge_edge.cpp
+++ b/python/src/collisions/normal/edge_edge.cpp
@@ -11,7 +11,7 @@ void define_edge_edge_normal_collision(py::module_& m)
         m, "EdgeEdgeNormalCollision")
         .def(
             py::init<
-                const long, const long, const double,
+                const index_t, const index_t, const double,
                 const EdgeEdgeDistanceType>(),
             py::arg("edge0_id"), py::arg("edge1_id"), py::arg("eps_x"),
             py::arg("dtype") = EdgeEdgeDistanceType::AUTO)
@@ -23,7 +23,7 @@ void define_edge_edge_normal_collision(py::module_& m)
             py::arg("dtype") = EdgeEdgeDistanceType::AUTO)
         // .def(
         //     py::init<
-        //         const long, const long, const double, const double,
+        //         const index_t, const index_t, const double, const double,
         //         const Eigen::SparseVector<double>&,
         //         const EdgeEdgeDistanceType>(),
         //     py::arg("edge0_id"), py::arg("edge1_id"), py::arg("eps_x"),

--- a/python/src/collisions/normal/edge_vertex.cpp
+++ b/python/src/collisions/normal/edge_vertex.cpp
@@ -9,11 +9,13 @@ void define_edge_vertex_normal_collision(py::module_& m)
 {
     py::class_<EdgeVertexNormalCollision, EdgeVertexCandidate, NormalCollision>(
         m, "EdgeVertexNormalCollision")
-        .def(py::init<long, long>(), py::arg("edge_id"), py::arg("vertex_id"))
+        .def(
+            py::init<index_t, index_t>(), py::arg("edge_id"),
+            py::arg("vertex_id"))
         .def(py::init<const EdgeVertexCandidate&>(), py::arg("candidate"));
     // .def(
     //     py::init<
-    //         const long, const long, const double,
+    //         const index_t, const index_t, const double,
     //         const Eigen::SparseVector<double>&>(),
     //     py::arg("edge_id"), py::arg("vertex_id"), py::arg("weight"),
     //     py::arg("weight_gradient"));

--- a/python/src/collisions/normal/face_vertex.cpp
+++ b/python/src/collisions/normal/face_vertex.cpp
@@ -10,12 +10,12 @@ void define_face_vertex_normal_collision(py::module_& m)
     py::class_<FaceVertexNormalCollision, FaceVertexCandidate, NormalCollision>(
         m, "FaceVertexNormalCollision")
         .def(
-            py::init<long, long>(), "", py::arg("face_id"),
+            py::init<index_t, index_t>(), "", py::arg("face_id"),
             py::arg("vertex_id"))
         .def(py::init<const FaceVertexCandidate&>(), py::arg("candidate"));
     // .def(
     //     py::init<
-    //         const long, const long, const double,
+    //         const index_t, const index_t, const double,
     //         const Eigen::SparseVector<double>&>(),
     //     py::arg("face_id"), py::arg("vertex_id"), py::arg("weight"),
     //     py::arg("weight_gradient"));

--- a/python/src/collisions/normal/plane_vertex.cpp
+++ b/python/src/collisions/normal/plane_vertex.cpp
@@ -12,7 +12,7 @@ void define_plane_vertex_normal_collision(py::module_& m)
         .def(
             py::init<
                 Eigen::ConstRef<VectorMax3d>, Eigen::ConstRef<VectorMax3d>,
-                const long>(),
+                const index_t>(),
             py::arg("plane_origin"), py::arg("plane_normal"),
             py::arg("vertex_id"))
         .def_readwrite(

--- a/python/src/collisions/normal/vertex_vertex.cpp
+++ b/python/src/collisions/normal/vertex_vertex.cpp
@@ -11,12 +11,12 @@ void define_vertex_vertex_normal_collision(py::module_& m)
         VertexVertexNormalCollision, VertexVertexCandidate, NormalCollision>(
         m, "VertexVertexNormalCollision")
         .def(
-            py::init<long, long>(), "", py::arg("vertex0_id"),
+            py::init<index_t, index_t>(), "", py::arg("vertex0_id"),
             py::arg("vertex1_id"))
         .def(py::init<const VertexVertexCandidate&>(), py::arg("vv_candidate"));
     // .def(
     //     py::init<
-    //         const long, const long, const double,
+    //         const index_t, const index_t, const double,
     //         const Eigen::SparseVector<double>&>(),
     //     py::arg("vertex0_id"), py::arg("vertex1_id"), py::arg("weight"),
     //     py::arg("weight_gradient"));

--- a/python/src/common.hpp
+++ b/python/src/common.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ipc/config.hpp>
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/iostream.h>

--- a/python/src/potentials/normal_potential.cpp
+++ b/python/src/potentials/normal_potential.cpp
@@ -36,7 +36,7 @@ void define_normal_potential(py::module_& m)
         .def(
             "shape_derivative",
             [](const NormalPotential& self, const NormalCollision& collision,
-               const std::array<long, 4>& vertex_ids,
+               const std::array<index_t, 4>& vertex_ids,
                Eigen::ConstRef<VectorMax12d> rest_positions,
                Eigen::ConstRef<VectorMax12d> positions) {
                 std::vector<Eigen::Triplet<double>> out;

--- a/src/ipc/barrier/adaptive_stiffness.cpp
+++ b/src/ipc/barrier/adaptive_stiffness.cpp
@@ -87,7 +87,6 @@ double update_barrier_stiffness(
 
 double semi_implicit_stiffness(
     const CollisionStencil& stencil,
-    const std::array<long, 4>& vertex_ids,
     Eigen::ConstRef<VectorMax12d> vertices,
     Eigen::ConstRef<VectorMax4d> mass,
     Eigen::ConstRef<MatrixMax12d> local_hess,
@@ -148,7 +147,7 @@ Eigen::VectorXd semi_implicit_stiffness(
         const VectorMax12d positions =
             collision.dof(vertices, mesh.edges(), mesh.faces());
 
-        std::array<long, 4> vertex_ids =
+        std::array<index_t, 4> vertex_ids =
             collision.vertex_ids(mesh.edges(), mesh.faces());
         if (hess.rows() == mesh.full_ndof()) {
             for (int i = 0; i < N; i++) {
@@ -175,7 +174,7 @@ Eigen::VectorXd semi_implicit_stiffness(
         }
 
         stiffnesses[ci] = semi_implicit_stiffness(
-            collision, vertex_ids, positions, local_mass, local_hess, dmin);
+            collision, positions, local_mass, local_hess, dmin);
     }
 
     return stiffnesses;

--- a/src/ipc/barrier/adaptive_stiffness.hpp
+++ b/src/ipc/barrier/adaptive_stiffness.hpp
@@ -61,7 +61,6 @@ double update_barrier_stiffness(
 /// @return The semi-implicit stiffness.
 double semi_implicit_stiffness(
     const CollisionStencil& stencil,
-    const std::array<long, 4>& vertex_ids,
     Eigen::ConstRef<VectorMax12d> vertices,
     Eigen::ConstRef<VectorMax4d> mass,
     Eigen::ConstRef<MatrixMax12d> local_hess,

--- a/src/ipc/broad_phase/aabb.cpp
+++ b/src/ipc/broad_phase/aabb.cpp
@@ -74,7 +74,7 @@ void build_vertex_boxes(
             for (size_t i = r.begin(); i < r.end(); i++) {
                 vertex_boxes[i] =
                     AABB::from_point(vertices.row(i), inflation_radius);
-                vertex_boxes[i].vertex_ids = { { long(i), -1, -1 } };
+                vertex_boxes[i].vertex_ids = { { index_t(i), -1, -1 } };
             }
         });
 }
@@ -93,7 +93,7 @@ void build_vertex_boxes(
             for (size_t i = r.begin(); i < r.end(); i++) {
                 vertex_boxes[i] = AABB::from_point(
                     vertices_t0.row(i), vertices_t1.row(i), inflation_radius);
-                vertex_boxes[i].vertex_ids = { { long(i), -1, -1 } };
+                vertex_boxes[i].vertex_ids = { { index_t(i), -1, -1 } };
             }
         });
 }

--- a/src/ipc/broad_phase/aabb.hpp
+++ b/src/ipc/broad_phase/aabb.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ipc/config.hpp>
 #include <ipc/utils/eigen_ext.hpp>
 
 #include <array>
@@ -64,7 +65,7 @@ public:
     /// @brief Maximum corner of the AABB.
     ArrayMax3d max;
     /// @brief Vertex IDs attached to the AABB.
-    std::array<long, 3> vertex_ids;
+    std::array<index_t, 3> vertex_ids;
 };
 
 /// @brief Build one AABB per vertex position (row of V).

--- a/src/ipc/broad_phase/voxel_size_heuristic.cpp
+++ b/src/ipc/broad_phase/voxel_size_heuristic.cpp
@@ -158,11 +158,12 @@ double max_edge_length(
     double max_edge = -std::numeric_limits<double>::infinity();
     for (int i = 0; i < edges.rows(); i++) {
         const size_t e0i = edges(i, 0), e1i = edges(i, 1);
-        max_edge = std::max({
-            max_edge,
-            (vertices_t0.row(e0i) - vertices_t0.row(e1i)).norm(),
-            (vertices_t1.row(e0i) - vertices_t1.row(e1i)).norm(),
-        });
+        max_edge = std::max(
+            {
+                max_edge,
+                (vertices_t0.row(e0i) - vertices_t0.row(e1i)).norm(),
+                (vertices_t1.row(e0i) - vertices_t1.row(e1i)).norm(),
+            });
     }
     return max_edge;
 }

--- a/src/ipc/candidates/candidates.cpp
+++ b/src/ipc/candidates/candidates.cpp
@@ -277,7 +277,7 @@ double Candidates::compute_noncandidate_conservative_stepsize(
 
     std::vector<bool> is_vertex_a_candidates(mesh.num_vertices(), false);
     for (size_t i = 0; i < size(); i++) {
-        for (const long vid : (*this)[i].vertex_ids(E, F)) {
+        for (const index_t vid : (*this)[i].vertex_ids(E, F)) {
             if (vid < 0) {
                 break;
             }

--- a/src/ipc/candidates/collision_stencil.hpp
+++ b/src/ipc/candidates/collision_stencil.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ipc/config.hpp>
 #include <ipc/ccd/default_narrow_phase_ccd.hpp>
 #include <ipc/utils/eigen_ext.hpp>
 
@@ -30,7 +31,7 @@ public:
     /// @param edges Collision mesh edges
     /// @param faces Collision mesh faces
     /// @return The vertex IDs of the collision stencil. Size is always 4, but elements i > num_vertices() are -1.
-    virtual std::array<long, 4> vertex_ids(
+    virtual std::array<index_t, 4> vertex_ids(
         Eigen::ConstRef<Eigen::MatrixXi> edges,
         Eigen::ConstRef<Eigen::MatrixXi> faces) const = 0;
 
@@ -47,7 +48,7 @@ public:
     {
         constexpr double NaN = std::numeric_limits<double>::signaling_NaN();
 
-        const std::array<long, 4> vertex_ids = this->vertex_ids(edges, faces);
+        const auto vertex_ids = this->vertex_ids(edges, faces);
 
         std::array<VectorMax3d, 4> stencil_vertices;
         for (int i = 0; i < 4; i++) {
@@ -74,7 +75,7 @@ public:
     {
         const int dim = X.cols();
         VectorMax12d x(num_vertices() * dim);
-        const std::array<long, 4> idx = vertex_ids(edges, faces);
+        const auto idx = vertex_ids(edges, faces);
         for (int i = 0; i < num_vertices(); i++) {
             x.segment(i * dim, dim) = X.row(idx[i]);
         }

--- a/src/ipc/candidates/edge_edge.cpp
+++ b/src/ipc/candidates/edge_edge.cpp
@@ -5,7 +5,7 @@
 
 namespace ipc {
 
-EdgeEdgeCandidate::EdgeEdgeCandidate(long _edge0_id, long _edge1_id)
+EdgeEdgeCandidate::EdgeEdgeCandidate(index_t _edge0_id, index_t _edge1_id)
     : edge0_id(_edge0_id)
     , edge1_id(_edge1_id)
 {
@@ -132,8 +132,8 @@ bool EdgeEdgeCandidate::operator!=(const EdgeEdgeCandidate& other) const
 
 bool EdgeEdgeCandidate::operator<(const EdgeEdgeCandidate& other) const
 {
-    long this_min = std::min(this->edge0_id, this->edge1_id);
-    long other_min = std::min(other.edge0_id, other.edge1_id);
+    index_t this_min = std::min(this->edge0_id, this->edge1_id);
+    index_t other_min = std::min(other.edge0_id, other.edge1_id);
     if (this_min == other_min) {
         return std::max(this->edge0_id, this->edge1_id)
             < std::max(other.edge0_id, other.edge1_id);

--- a/src/ipc/candidates/edge_edge.hpp
+++ b/src/ipc/candidates/edge_edge.hpp
@@ -11,14 +11,14 @@ namespace ipc {
 
 class EdgeEdgeCandidate : virtual public CollisionStencil {
 public:
-    EdgeEdgeCandidate(long edge0_id, long edge1_id);
+    EdgeEdgeCandidate(index_t edge0_id, index_t edge1_id);
 
     // ------------------------------------------------------------------------
     // CollisionStencil
 
     int num_vertices() const override { return 4; };
 
-    std::array<long, 4> vertex_ids(
+    std::array<index_t, 4> vertex_ids(
         Eigen::ConstRef<Eigen::MatrixXi> edges,
         Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
@@ -69,15 +69,15 @@ public:
     template <typename H>
     friend H AbslHashValue(H h, const EdgeEdgeCandidate& ee)
     {
-        long min_ei = std::min(ee.edge0_id, ee.edge1_id);
-        long max_ei = std::max(ee.edge0_id, ee.edge1_id);
+        index_t min_ei = std::min(ee.edge0_id, ee.edge1_id);
+        index_t max_ei = std::max(ee.edge0_id, ee.edge1_id);
         return H::combine(std::move(h), min_ei, max_ei);
     }
 
     /// @brief ID of the first edge.
-    long edge0_id;
+    index_t edge0_id;
     /// @brief ID of the second edge.
-    long edge1_id;
+    index_t edge1_id;
 };
 
 } // namespace ipc

--- a/src/ipc/candidates/edge_face.cpp
+++ b/src/ipc/candidates/edge_face.cpp
@@ -2,7 +2,7 @@
 
 namespace ipc {
 
-EdgeFaceCandidate::EdgeFaceCandidate(long _edge_id, long _face_id)
+EdgeFaceCandidate::EdgeFaceCandidate(index_t _edge_id, index_t _face_id)
     : edge_id(_edge_id)
     , face_id(_face_id)
 {

--- a/src/ipc/candidates/edge_face.hpp
+++ b/src/ipc/candidates/edge_face.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ipc/config.hpp>
+
 #include <Eigen/Core>
 
 namespace ipc {
@@ -9,7 +11,7 @@ namespace ipc {
 /// Not included in Candidates because it is not a collision candidate.
 class EdgeFaceCandidate {
 public:
-    EdgeFaceCandidate(long edge_id, long face_id);
+    EdgeFaceCandidate(index_t edge_id, index_t face_id);
 
     bool operator==(const EdgeFaceCandidate& other) const;
     bool operator!=(const EdgeFaceCandidate& other) const;
@@ -23,9 +25,9 @@ public:
     }
 
     /// @brief ID of the edge
-    long edge_id;
+    index_t edge_id;
     /// @brief ID of the face
-    long face_id;
+    index_t face_id;
 };
 
 } // namespace ipc

--- a/src/ipc/candidates/edge_vertex.cpp
+++ b/src/ipc/candidates/edge_vertex.cpp
@@ -7,7 +7,7 @@
 
 namespace ipc {
 
-EdgeVertexCandidate::EdgeVertexCandidate(long _edge_id, long _vertex_id)
+EdgeVertexCandidate::EdgeVertexCandidate(index_t _edge_id, index_t _vertex_id)
     : edge_id(_edge_id)
     , vertex_id(_vertex_id)
 {

--- a/src/ipc/candidates/edge_vertex.hpp
+++ b/src/ipc/candidates/edge_vertex.hpp
@@ -11,14 +11,14 @@ namespace ipc {
 
 class EdgeVertexCandidate : virtual public CollisionStencil {
 public:
-    EdgeVertexCandidate(long edge_id, long vertex_id);
+    EdgeVertexCandidate(index_t edge_id, index_t vertex_id);
 
     // ------------------------------------------------------------------------
     // CollisionStencil
 
     int num_vertices() const override { return 3; };
 
-    std::array<long, 4> vertex_ids(
+    std::array<index_t, 4> vertex_ids(
         Eigen::ConstRef<Eigen::MatrixXi> edges,
         Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
@@ -72,9 +72,9 @@ public:
     }
 
     /// @brief ID of the edge
-    long edge_id;
+    index_t edge_id;
     /// @brief ID of the vertex
-    long vertex_id;
+    index_t vertex_id;
 };
 
 } // namespace ipc

--- a/src/ipc/candidates/face_face.cpp
+++ b/src/ipc/candidates/face_face.cpp
@@ -2,7 +2,7 @@
 
 namespace ipc {
 
-FaceFaceCandidate::FaceFaceCandidate(long _face0_id, long _face1_id)
+FaceFaceCandidate::FaceFaceCandidate(index_t _face0_id, index_t _face1_id)
     : face0_id(_face0_id)
     , face1_id(_face1_id)
 {
@@ -24,8 +24,8 @@ bool FaceFaceCandidate::operator!=(const FaceFaceCandidate& other) const
 
 bool FaceFaceCandidate::operator<(const FaceFaceCandidate& other) const
 {
-    long this_min = std::min(this->face0_id, this->face1_id);
-    long other_min = std::min(other.face0_id, other.face1_id);
+    index_t this_min = std::min(this->face0_id, this->face1_id);
+    index_t other_min = std::min(other.face0_id, other.face1_id);
     if (this_min == other_min) {
         return std::max(this->face0_id, this->face1_id)
             < std::max(other.face0_id, other.face1_id);

--- a/src/ipc/candidates/face_face.hpp
+++ b/src/ipc/candidates/face_face.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ipc/config.hpp>
+
 #include <Eigen/Core>
 
 namespace ipc {
@@ -9,7 +11,7 @@ namespace ipc {
 /// @note This may be useful for nonlinear triangles in the future.
 class FaceFaceCandidate {
 public:
-    FaceFaceCandidate(long face0_id, long face1_id);
+    FaceFaceCandidate(index_t face0_id, index_t face1_id);
 
     bool operator==(const FaceFaceCandidate& other) const;
     bool operator!=(const FaceFaceCandidate& other) const;
@@ -19,15 +21,15 @@ public:
     template <typename H>
     friend H AbslHashValue(H h, const FaceFaceCandidate& ff)
     {
-        long min_fi = std::min(ff.face0_id, ff.face1_id);
-        long max_fi = std::max(ff.face0_id, ff.face1_id);
+        index_t min_fi = std::min(ff.face0_id, ff.face1_id);
+        index_t max_fi = std::max(ff.face0_id, ff.face1_id);
         return H::combine(std::move(h), min_fi, max_fi);
     }
 
     /// @brief ID of the first face.
-    long face0_id;
+    index_t face0_id;
     /// @brief ID of the second face.
-    long face1_id;
+    index_t face1_id;
 };
 
 } // namespace ipc

--- a/src/ipc/candidates/face_vertex.cpp
+++ b/src/ipc/candidates/face_vertex.cpp
@@ -7,7 +7,7 @@
 
 namespace ipc {
 
-FaceVertexCandidate::FaceVertexCandidate(long _face_id, long _vertex_id)
+FaceVertexCandidate::FaceVertexCandidate(index_t _face_id, index_t _vertex_id)
     : face_id(_face_id)
     , vertex_id(_vertex_id)
 {

--- a/src/ipc/candidates/face_vertex.hpp
+++ b/src/ipc/candidates/face_vertex.hpp
@@ -11,14 +11,14 @@ namespace ipc {
 
 class FaceVertexCandidate : virtual public CollisionStencil {
 public:
-    FaceVertexCandidate(long face_id, long vertex_id);
+    FaceVertexCandidate(index_t face_id, index_t vertex_id);
 
     // ------------------------------------------------------------------------
     // CollisionStencil
 
     int num_vertices() const override { return 4; };
 
-    std::array<long, 4> vertex_ids(
+    std::array<index_t, 4> vertex_ids(
         Eigen::ConstRef<Eigen::MatrixXi> edges,
         Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
@@ -75,9 +75,9 @@ public:
     // ------------------------------------------------------------------------
 
     /// @brief ID of the face
-    long face_id;
+    index_t face_id;
     /// @brief ID of the vertex
-    long vertex_id;
+    index_t vertex_id;
 };
 
 } // namespace ipc

--- a/src/ipc/candidates/vertex_vertex.cpp
+++ b/src/ipc/candidates/vertex_vertex.cpp
@@ -6,7 +6,8 @@
 
 namespace ipc {
 
-VertexVertexCandidate::VertexVertexCandidate(long _vertex0_id, long _vertex1_id)
+VertexVertexCandidate::VertexVertexCandidate(
+    index_t _vertex0_id, index_t _vertex1_id)
     : vertex0_id(_vertex0_id)
     , vertex1_id(_vertex1_id)
 {
@@ -78,8 +79,8 @@ bool VertexVertexCandidate::operator!=(const VertexVertexCandidate& other) const
 
 bool VertexVertexCandidate::operator<(const VertexVertexCandidate& other) const
 {
-    long this_min = std::min(this->vertex0_id, this->vertex1_id);
-    long other_min = std::min(other.vertex0_id, other.vertex1_id);
+    index_t this_min = std::min(this->vertex0_id, this->vertex1_id);
+    index_t other_min = std::min(other.vertex0_id, other.vertex1_id);
     if (this_min == other_min) {
         return std::max(this->vertex0_id, this->vertex1_id)
             < std::max(other.vertex0_id, other.vertex1_id);

--- a/src/ipc/candidates/vertex_vertex.hpp
+++ b/src/ipc/candidates/vertex_vertex.hpp
@@ -11,7 +11,7 @@ namespace ipc {
 
 class VertexVertexCandidate : virtual public CollisionStencil {
 public:
-    VertexVertexCandidate(long vertex0_id, long vertex1_id);
+    VertexVertexCandidate(index_t vertex0_id, index_t vertex1_id);
 
     // ------------------------------------------------------------------------
     // CollisionStencil
@@ -22,7 +22,7 @@ public:
     /// @param edges edge matrix of mesh
     /// @param faces face matrix of mesh
     /// @return List of vertex indices
-    std::array<long, 4> vertex_ids(
+    std::array<index_t, 4> vertex_ids(
         Eigen::ConstRef<Eigen::MatrixXi> edges,
         Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
@@ -67,15 +67,15 @@ public:
     template <typename H>
     friend H AbslHashValue(H h, const VertexVertexCandidate& vv)
     {
-        long min_vi = std::min(vv.vertex0_id, vv.vertex1_id);
-        long max_vi = std::max(vv.vertex0_id, vv.vertex1_id);
+        index_t min_vi = std::min(vv.vertex0_id, vv.vertex1_id);
+        index_t max_vi = std::max(vv.vertex0_id, vv.vertex1_id);
         return H::combine(std::move(h), min_vi, max_vi);
     }
 
     /// @brief ID of the first vertex
-    long vertex0_id;
+    index_t vertex0_id;
     /// @brief ID of the second vertex
-    long vertex1_id;
+    index_t vertex1_id;
 };
 
 } // namespace ipc

--- a/src/ipc/ccd/nonlinear_ccd.cpp
+++ b/src/ipc/ccd/nonlinear_ccd.cpp
@@ -286,9 +286,10 @@ bool point_triangle_nonlinear_ccd(
         },
         [&](const double ti0, const double ti1) {
             return p.max_distance_from_linear(ti0, ti1)
-                + std::max({ t0.max_distance_from_linear(ti0, ti1),
-                             t1.max_distance_from_linear(ti0, ti1),
-                             t2.max_distance_from_linear(ti0, ti1) });
+                + std::max(
+                       { t0.max_distance_from_linear(ti0, ti1),
+                         t1.max_distance_from_linear(ti0, ti1),
+                         t2.max_distance_from_linear(ti0, ti1) });
         },
         [&](const double ti0, const double ti1, const double _min_distance,
             const bool no_zero_toi, double& _toi) {

--- a/src/ipc/collision_mesh.cpp
+++ b/src/ipc/collision_mesh.cpp
@@ -88,7 +88,7 @@ CollisionMesh::CollisionMesh(
     if (!include_all_vertices) {
         for (int i = 0; i < m_edges.rows(); i++) {
             for (int j = 0; j < m_edges.cols(); j++) {
-                long new_id = m_full_vertex_to_vertex[m_edges(i, j)];
+                index_t new_id = m_full_vertex_to_vertex[m_edges(i, j)];
                 assert(new_id >= 0 && new_id < num_vertices());
                 m_edges(i, j) = new_id;
             }
@@ -96,7 +96,7 @@ CollisionMesh::CollisionMesh(
 
         for (int i = 0; i < m_faces.rows(); i++) {
             for (int j = 0; j < m_faces.cols(); j++) {
-                long new_id = m_full_vertex_to_vertex[m_faces(i, j)];
+                index_t new_id = m_full_vertex_to_vertex[m_faces(i, j)];
                 assert(new_id >= 0 && new_id < num_vertices());
                 m_faces(i, j) = new_id;
             }
@@ -421,7 +421,7 @@ CollisionMesh::to_full_dof(const Eigen::SparseMatrix<double>& X) const
 // ============================================================================/
 
 std::vector<bool> CollisionMesh::construct_is_on_surface(
-    const long num_vertices,
+    const size_t num_vertices,
     Eigen::ConstRef<Eigen::MatrixXi> edges,
     Eigen::ConstRef<Eigen::VectorXi> codim_vertices)
 {

--- a/src/ipc/collision_mesh.hpp
+++ b/src/ipc/collision_mesh.hpp
@@ -142,7 +142,7 @@ public:
     /// @brief Map a vertex ID to the corresponding vertex ID in the full mesh.
     /// @param id Vertex ID in the collision mesh.
     /// @return Vertex ID in the full mesh.
-    size_t to_full_vertex_id(const size_t id) const
+    index_t to_full_vertex_id(const index_t id) const
     {
         assert(id < num_vertices());
         return m_vertex_to_full_vertex[id];
@@ -267,7 +267,7 @@ public:
     /// @param codim_vertices The indices of codimensional vertices (#CV x 1).
     /// @return A vector of bools indicating whether each vertex is on the surface.
     static std::vector<bool> construct_is_on_surface(
-        const long num_vertices,
+        const size_t num_vertices,
         Eigen::ConstRef<Eigen::MatrixXi> edges,
         Eigen::ConstRef<Eigen::VectorXi> codim_vertices = Eigen::VectorXi());
 

--- a/src/ipc/collisions/normal/edge_edge.cpp
+++ b/src/ipc/collisions/normal/edge_edge.cpp
@@ -7,8 +7,8 @@
 namespace ipc {
 
 EdgeEdgeNormalCollision::EdgeEdgeNormalCollision(
-    const long _edge0_id,
-    const long _edge1_id,
+    const index_t _edge0_id,
+    const index_t _edge1_id,
     const double _eps_x,
     const EdgeEdgeDistanceType _dtype)
     : EdgeEdgeCandidate(_edge0_id, _edge1_id)
@@ -28,8 +28,8 @@ EdgeEdgeNormalCollision::EdgeEdgeNormalCollision(
 }
 
 EdgeEdgeNormalCollision::EdgeEdgeNormalCollision(
-    const long _edge0_id,
-    const long _edge1_id,
+    const index_t _edge0_id,
+    const index_t _edge1_id,
     const double _eps_x,
     const double _weight,
     const Eigen::SparseVector<double>& _weight_gradient,

--- a/src/ipc/collisions/normal/edge_edge.hpp
+++ b/src/ipc/collisions/normal/edge_edge.hpp
@@ -10,8 +10,8 @@ class EdgeEdgeNormalCollision : public EdgeEdgeCandidate,
                                 public NormalCollision {
 public:
     EdgeEdgeNormalCollision(
-        const long edge0_id,
-        const long edge1_id,
+        const index_t edge0_id,
+        const index_t edge1_id,
         const double eps_x,
         const EdgeEdgeDistanceType dtype = EdgeEdgeDistanceType::AUTO);
 
@@ -21,8 +21,8 @@ public:
         const EdgeEdgeDistanceType dtype = EdgeEdgeDistanceType::AUTO);
 
     EdgeEdgeNormalCollision(
-        const long edge0_id,
-        const long edge1_id,
+        const index_t edge0_id,
+        const index_t edge1_id,
         const double eps_x,
         const double weight,
         const Eigen::SparseVector<double>& weight_gradient,

--- a/src/ipc/collisions/normal/edge_vertex.hpp
+++ b/src/ipc/collisions/normal/edge_vertex.hpp
@@ -16,8 +16,8 @@ public:
     }
 
     EdgeVertexNormalCollision(
-        const long _edge_id,
-        const long _vertex_id,
+        const index_t _edge_id,
+        const index_t _vertex_id,
         const double _weight,
         const Eigen::SparseVector<double>& _weight_gradient)
         : EdgeVertexCandidate(_edge_id, _vertex_id)

--- a/src/ipc/collisions/normal/face_vertex.hpp
+++ b/src/ipc/collisions/normal/face_vertex.hpp
@@ -16,8 +16,8 @@ public:
     }
 
     FaceVertexNormalCollision(
-        const long _face_id,
-        const long _vertex_id,
+        const index_t _face_id,
+        const index_t _vertex_id,
         const double _weight,
         const Eigen::SparseVector<double>& _weight_gradient)
         : FaceVertexCandidate(_face_id, _vertex_id)

--- a/src/ipc/collisions/normal/normal_collisions.cpp
+++ b/src/ipc/collisions/normal/normal_collisions.cpp
@@ -283,8 +283,9 @@ void NormalCollisions::build(
 void NormalCollisions::set_use_area_weighting(const bool use_area_weighting)
 {
     if (!empty() && use_area_weighting != m_use_area_weighting) {
-        logger().warn("Setting use_area_weighting after building collisions. "
-                      "Re-build collisions for this to have an effect.");
+        logger().warn(
+            "Setting use_area_weighting after building collisions. "
+            "Re-build collisions for this to have an effect.");
     }
 
     if (!use_area_weighting && use_improved_max_approximator()) {
@@ -487,8 +488,8 @@ std::string NormalCollisions::to_string(
                       ev.dof(vertices, mesh.edges(), mesh.faces())));
     }
     for (const auto& ee : ee_collisions) {
-        const long min_ei = std::min(ee.edge0_id, ee.edge1_id);
-        const long max_ei = std::max(ee.edge0_id, ee.edge1_id);
+        const index_t min_ei = std::min(ee.edge0_id, ee.edge1_id);
+        const index_t max_ei = std::max(ee.edge0_id, ee.edge1_id);
         ss << "\n"
            << fmt::format(
                   "ee: {}=({}, {}) {}=({}, {}), w: {:g}, dtype: {}, d: {:g}",

--- a/src/ipc/collisions/normal/normal_collisions_builder.cpp
+++ b/src/ipc/collisions/normal/normal_collisions_builder.cpp
@@ -233,8 +233,8 @@ void NormalCollisionsBuilder::add_face_vertex_collisions(
 {
     for (size_t i = start_i; i < end_i; i++) {
         const auto& [fi, vi] = candidates[i];
-        const long f0i = mesh.faces()(fi, 0), f1i = mesh.faces()(fi, 1),
-                   f2i = mesh.faces()(fi, 2);
+        const index_t f0i = mesh.faces()(fi, 0), f1i = mesh.faces()(fi, 1),
+                      f2i = mesh.faces()(fi, 2);
 
         const auto [v, f0, f1, f2] =
             candidates[i].vertices(vertices, mesh.edges(), mesh.faces());
@@ -312,8 +312,8 @@ void NormalCollisionsBuilder::add_edge_vertex_negative_vertex_vertex_collisions(
                                 double& weight,
                                 Eigen::SparseVector<double>& weight_gradient) {
         const auto& incident_vertices = mesh.vertex_vertex_adjacencies()[vj];
-        const int incident_edge_amt = incident_vertices.size()
-            - int(incident_vertices.find(vi) != incident_vertices.end());
+        const index_t incident_edge_amt = incident_vertices.size()
+            - index_t(incident_vertices.find(vi) != incident_vertices.end());
 
         if (incident_edge_amt > 1) {
             // ÷ 2 to handle double counting for correct integration
@@ -401,8 +401,8 @@ void NormalCollisionsBuilder::add_face_vertex_negative_edge_vertex_collisions(
         assert(vi != mesh.edges()(ei, 0) && vi != mesh.edges()(ei, 1));
 
         const auto& incident_vertices = mesh.edge_vertex_adjacencies()[ei];
-        const int incident_triangle_amt = incident_vertices.size()
-            - int(incident_vertices.find(vi) != incident_vertices.end());
+        const index_t incident_triangle_amt = incident_vertices.size()
+            - index_t(incident_vertices.find(vi) != incident_vertices.end());
 
         if (incident_triangle_amt > 1) {
             // ÷ 4 to handle double counting and PT + EE for correct integration
@@ -438,7 +438,7 @@ void NormalCollisionsBuilder::add_edge_edge_negative_edge_vertex_collisions(
 
     for (size_t i = start_i; i < end_i; i++) {
         const auto& [ea, p] = candidates[i];
-        const int ea0 = mesh.edges()(ea, 0), ea1 = mesh.edges()(ea, 1);
+        const index_t ea0 = mesh.edges()(ea, 0), ea1 = mesh.edges()(ea, 1);
         assert(p != ea0 && p != ea1);
 
         // ÷ 4 to handle double counting and PT + EE for correct integration
@@ -454,12 +454,12 @@ void NormalCollisionsBuilder::add_edge_edge_negative_edge_vertex_collisions(
         const PointEdgeDistanceType dtype = point_edge_distance_type(
             vertices.row(p), vertices.row(ea0), vertices.row(ea1));
 
-        int nonmollified_incident_edge_amt = 0;
+        index_t nonmollified_incident_edge_amt = 0;
 
         const auto& incident_edges = mesh.vertex_edge_adjacencies()[p];
-        for (const int eb : incident_edges) {
-            const int eb0 = mesh.edges()(eb, 0), eb1 = mesh.edges()(eb, 1);
-            const int q = mesh.edges()(eb, int(p == eb0));
+        for (const index_t eb : incident_edges) {
+            const index_t eb0 = mesh.edges()(eb, 0), eb1 = mesh.edges()(eb, 1);
+            const index_t q = mesh.edges()(eb, index_t(p == eb0));
             assert(p != q);
             if (q == ea0 || q == ea1) {
                 continue;
@@ -519,7 +519,7 @@ void NormalCollisionsBuilder::add_edge_edge_negative_edge_vertex_collisions(
 
 void NormalCollisionsBuilder::add_vertex_vertex_collision(
     const VertexVertexNormalCollision& vv_collision,
-    unordered_map<VertexVertexNormalCollision, long>& vv_to_id,
+    unordered_map<VertexVertexNormalCollision, size_t>& vv_to_id,
     std::vector<VertexVertexNormalCollision>& vv_collisions)
 {
     auto found_item = vv_to_id.find(vv_collision);
@@ -537,7 +537,7 @@ void NormalCollisionsBuilder::add_vertex_vertex_collision(
 
 void NormalCollisionsBuilder::add_edge_vertex_collision(
     const EdgeVertexNormalCollision& ev_collision,
-    unordered_map<EdgeVertexNormalCollision, long>& ev_to_id,
+    unordered_map<EdgeVertexNormalCollision, size_t>& ev_to_id,
     std::vector<EdgeVertexNormalCollision>& ev_collisions)
 {
     auto found_item = ev_to_id.find(ev_collision);
@@ -555,7 +555,7 @@ void NormalCollisionsBuilder::add_edge_vertex_collision(
 
 void NormalCollisionsBuilder::add_edge_edge_collision(
     const EdgeEdgeNormalCollision& ee_collision,
-    unordered_map<EdgeEdgeNormalCollision, long>& ee_to_id,
+    unordered_map<EdgeEdgeNormalCollision, size_t>& ee_to_id,
     std::vector<EdgeEdgeNormalCollision>& ee_collisions)
 {
     auto found_item = ee_to_id.find(ee_collision);
@@ -579,9 +579,9 @@ void NormalCollisionsBuilder::merge(
         local_storage,
     NormalCollisions& merged_collisions)
 {
-    unordered_map<VertexVertexNormalCollision, long> vv_to_id;
-    unordered_map<EdgeVertexNormalCollision, long> ev_to_id;
-    unordered_map<EdgeEdgeNormalCollision, long> ee_to_id;
+    unordered_map<VertexVertexNormalCollision, size_t> vv_to_id;
+    unordered_map<EdgeVertexNormalCollision, size_t> ev_to_id;
+    unordered_map<EdgeEdgeNormalCollision, size_t> ee_to_id;
     auto& vv_collisions = merged_collisions.vv_collisions;
     auto& ev_collisions = merged_collisions.ev_collisions;
     auto& ee_collisions = merged_collisions.ee_collisions;

--- a/src/ipc/collisions/normal/normal_collisions_builder.hpp
+++ b/src/ipc/collisions/normal/normal_collisions_builder.hpp
@@ -87,12 +87,12 @@ public:
 protected:
     static void add_vertex_vertex_collision(
         const VertexVertexNormalCollision& vv_collision,
-        unordered_map<VertexVertexNormalCollision, long>& vv_to_id,
+        unordered_map<VertexVertexNormalCollision, size_t>& vv_to_id,
         std::vector<VertexVertexNormalCollision>& vv_collisions);
 
     void add_vertex_vertex_collision(
-        const long vertex0_id,
-        const long vertex1_id,
+        const index_t vertex0_id,
+        const index_t vertex1_id,
         const double weight,
         const Eigen::SparseVector<double>& weight_gradient)
     {
@@ -106,12 +106,12 @@ protected:
 
     static void add_edge_vertex_collision(
         const EdgeVertexNormalCollision& ev_collision,
-        unordered_map<EdgeVertexNormalCollision, long>& ev_to_id,
+        unordered_map<EdgeVertexNormalCollision, size_t>& ev_to_id,
         std::vector<EdgeVertexNormalCollision>& ev_collisions);
 
     void add_edge_vertex_collision(
-        const long edge_id,
-        const long vertex_id,
+        const index_t edge_id,
+        const index_t vertex_id,
         const double weight,
         const Eigen::SparseVector<double>& weight_gradient)
     {
@@ -132,12 +132,12 @@ protected:
 
     static void add_edge_edge_collision(
         const EdgeEdgeNormalCollision& ee_collision,
-        unordered_map<EdgeEdgeNormalCollision, long>& ee_to_id,
+        unordered_map<EdgeEdgeNormalCollision, size_t>& ee_to_id,
         std::vector<EdgeEdgeNormalCollision>& ee_collisions);
 
     void add_edge_edge_collision(
-        const long edge0_id,
-        const long edge1_id,
+        const index_t edge0_id,
+        const index_t edge1_id,
         const double eps_x,
         const double weight,
         const Eigen::SparseVector<double>& weight_gradient,
@@ -152,9 +152,9 @@ protected:
     // -------------------------------------------------------------------------
 
     // Store the indices to pairs to avoid duplicates.
-    unordered_map<VertexVertexNormalCollision, long> vv_to_id;
-    unordered_map<EdgeVertexNormalCollision, long> ev_to_id;
-    unordered_map<EdgeEdgeNormalCollision, long> ee_to_id;
+    unordered_map<VertexVertexNormalCollision, size_t> vv_to_id;
+    unordered_map<EdgeVertexNormalCollision, size_t> ev_to_id;
+    unordered_map<EdgeEdgeNormalCollision, size_t> ee_to_id;
 
     // Constructed collisions
     std::vector<VertexVertexNormalCollision> vv_collisions;

--- a/src/ipc/collisions/normal/plane_vertex.cpp
+++ b/src/ipc/collisions/normal/plane_vertex.cpp
@@ -8,7 +8,7 @@ namespace ipc {
 PlaneVertexNormalCollision::PlaneVertexNormalCollision(
     Eigen::ConstRef<VectorMax3d> _plane_origin,
     Eigen::ConstRef<VectorMax3d> _plane_normal,
-    const long _vertex_id)
+    const index_t _vertex_id)
     : plane_origin(_plane_origin)
     , plane_normal(_plane_normal)
     , vertex_id(_vertex_id)

--- a/src/ipc/collisions/normal/plane_vertex.hpp
+++ b/src/ipc/collisions/normal/plane_vertex.hpp
@@ -10,11 +10,11 @@ public:
     PlaneVertexNormalCollision(
         Eigen::ConstRef<VectorMax3d> plane_origin,
         Eigen::ConstRef<VectorMax3d> plane_normal,
-        const long vertex_id);
+        const index_t vertex_id);
 
     int num_vertices() const override { return 1; };
 
-    std::array<long, 4> vertex_ids(
+    std::array<index_t, 4> vertex_ids(
         Eigen::ConstRef<Eigen::MatrixXi> edges,
         Eigen::ConstRef<Eigen::MatrixXi> faces) const override
     {
@@ -73,7 +73,7 @@ public:
     VectorMax3d plane_normal;
 
     /// @brief The vertex's id.
-    long vertex_id;
+    index_t vertex_id;
 };
 
 } // namespace ipc

--- a/src/ipc/collisions/normal/vertex_vertex.hpp
+++ b/src/ipc/collisions/normal/vertex_vertex.hpp
@@ -17,8 +17,8 @@ public:
     }
 
     VertexVertexNormalCollision(
-        const long _vertex0_id,
-        const long _vertex1_id,
+        const index_t _vertex0_id,
+        const index_t _vertex1_id,
         const double _weight,
         const Eigen::SparseVector<double>& _weight_gradient)
         : VertexVertexCandidate(_vertex0_id, _vertex1_id)

--- a/src/ipc/config.hpp.in
+++ b/src/ipc/config.hpp.in
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 // WARNING: Do not modify config.hpp directly. Instead, modify config.hpp.in.
 
 #define IPC_TOOLKIT_NAME "@PROJECT_NAME@"
@@ -14,3 +16,11 @@
 #cmakedefine IPC_TOOLKIT_WITH_ROBIN_MAP
 #cmakedefine IPC_TOOLKIT_WITH_ABSEIL
 #cmakedefine IPC_TOOLKIT_WITH_FILIB
+
+namespace ipc {
+
+// Type definitions
+using index_t = int32_t;
+// using scalar_t = double;
+
+} // namespace ipc

--- a/src/ipc/potentials/normal_potential.cpp
+++ b/src/ipc/potentials/normal_potential.cpp
@@ -142,7 +142,7 @@ MatrixMax12d NormalPotential::hessian(
 
 void NormalPotential::shape_derivative(
     const NormalCollision& collision,
-    const std::array<long, 4>& vertex_ids,
+    const std::array<index_t, 4>& vertex_ids,
     Eigen::ConstRef<VectorMax12d> rest_positions, // = x̄
     Eigen::ConstRef<VectorMax12d> positions,      // = x̄ + u
     std::vector<Eigen::Triplet<double>>& out) const

--- a/src/ipc/potentials/normal_potential.hpp
+++ b/src/ipc/potentials/normal_potential.hpp
@@ -68,7 +68,7 @@ public:
     /// @param[in,out] out Store the triplets of the shape derivative here.
     void shape_derivative(
         const NormalCollision& collision,
-        const std::array<long, 4>& vertex_ids,
+        const std::array<index_t, 4>& vertex_ids,
         Eigen::ConstRef<VectorMax12d> rest_positions,
         Eigen::ConstRef<VectorMax12d> positions,
         std::vector<Eigen::Triplet<double>>& out) const;

--- a/src/ipc/potentials/potential.tpp
+++ b/src/ipc/potentials/potential.tpp
@@ -59,7 +59,7 @@ Eigen::VectorXd Potential<TCollisions>::gradient(
                 const VectorMax12d local_grad = this->gradient(
                     collision, collision.dof(X, mesh.edges(), mesh.faces()));
 
-                const std::array<long, 4> vids =
+                const std::array<index_t, 4> vids =
                     collision.vertex_ids(mesh.edges(), mesh.faces());
 
                 local_gradient_to_global_gradient(
@@ -106,7 +106,7 @@ Eigen::SparseMatrix<double> Potential<TCollisions>::hessian(
                     collisions[i], collisions[i].dof(X, edges, faces),
                     project_hessian_to_psd);
 
-                const std::array<long, 4> vids =
+                const std::array<index_t, 4> vids =
                     collision.vertex_ids(edges, faces);
 
                 local_hessian_to_global_triplets(

--- a/src/ipc/potentials/tangential_potential.cpp
+++ b/src/ipc/potentials/tangential_potential.cpp
@@ -39,7 +39,7 @@ Eigen::VectorXd TangentialPotential::force(
                     collision.dof(velocities, edges, faces), //
                     normal_potential, normal_stiffness, dmin, no_mu);
 
-                const std::array<long, 4> vis =
+                const std::array<index_t, 4> vis =
                     collision.vertex_ids(mesh.edges(), mesh.faces());
 
                 local_gradient_to_global_gradient(
@@ -88,7 +88,7 @@ Eigen::SparseMatrix<double> TangentialPotential::force_jacobian(
                     collision.dof(velocities, edges, faces), //
                     normal_potential, normal_stiffness, wrt, dmin);
 
-                const std::array<long, 4> vis =
+                const std::array<index_t, 4> vis =
                     collision.vertex_ids(mesh.edges(), mesh.faces());
 
                 local_hessian_to_global_triplets(

--- a/src/ipc/utils/unordered_map_and_set.hpp
+++ b/src/ipc/utils/unordered_map_and_set.hpp
@@ -13,7 +13,7 @@ template <typename H, typename T> H AbslHashValue(H h, T t);
 
 template <class T> struct Hash {
     Hash() = default;
-    Hash(size_t h) : hash(h) {};
+    Hash(size_t h) : hash(h) { };
 
     template <typename Value>
     static Hash combine(const Hash& h, const Value value)

--- a/tests/src/tests/collisions/test_normal_collisions.cpp
+++ b/tests/src/tests/collisions/test_normal_collisions.cpp
@@ -279,7 +279,7 @@ TEST_CASE("Plane-Vertex NormalCollision", "[collision][plane-vertex]")
     CHECK(c.num_vertices() == 1);
     CHECK(
         c.vertex_ids(edges, faces)
-        == std::array<long, 4> { { 0, -1, -1, -1 } });
+        == std::array<index_t, 4> { { 0, -1, -1, -1 } });
     CHECK(c.plane_origin == o);
     CHECK(c.plane_normal == n);
     CHECK(c.vertex_id == 0);


### PR DESCRIPTION
# Description

Add a `index_t` typedef for vertex/edge/face ids. Changes default from `long` to `int32_t`.

## Type of change

- [x] Enhancement (non-breaking change which improves existing functionality)

# Checklist

- [x] I have followed the project [style guide](https://ipctk.xyz/style_guide.html)
- [x] My code follows the clang-format style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules