### PR TITLE
Fix cmake for non top level inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ if(IPC_TOOLKIT_TOPLEVEL_PROJECT)
 else()
   # If this is not the top-level project, we don't want to build tests or Python
   # bindings. This is useful for projects that use IPC Toolkit as a submodule.
-  set(IPC_TOOLKIT_BUILD_TESTS  OFF CACHE INTERNAL BOOL "Build unit-tests"      FORCE)
-  set(IPC_TOOLKIT_BUILD_PYTHON OFF CACHE INTERNAL BOOL "Build Python bindings" FORCE)
+  set(IPC_TOOLKIT_BUILD_TESTS  OFF CACHE BOOL "Build unit-tests"      FORCE)
+  set(IPC_TOOLKIT_BUILD_PYTHON OFF CACHE BOOL "Build Python bindings" FORCE)
 endif()
 
 if(CMAKE_CUDA_COMPILER)


### PR DESCRIPTION
# Description

I added ipctk as a submodule in my project and was getting the error:
```
CMake Error at vendor/ipc-toolkit/CMakeLists.txt:76 (set):
  set given invalid arguments: FORCE specified without CACHE


CMake Error at vendor/ipc-toolkit/CMakeLists.txt:77 (set):
  set given invalid arguments: FORCE specified without CACHE
```
These changes fix it

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Added to my project's cmake using `add_subdirectory` and now cmake doesn't error.

**Test Configuration**:
```
[sin3point14@lolikawa ipc-toolkit]$ cat /etc/os-release 
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://gitlab.archlinux.org/groups/archlinux/-/issues"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo
[sin3point14@lolikawa ipc-toolkit]$ g++ --version
g++ (GCC) 15.1.1 20250425
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

# Checklist

- [X] I have followed the project [style guide](https://ipctk.xyz/style_guide.html)
- [X] My code follows the clang-format style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules