### PR TITLE
Switch from py::arg to _a literals

### DIFF
--- a/python/src/adhesion/adhesion.cpp
+++ b/python/src/adhesion/adhesion.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/adhesion/adhesion.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_adhesion(py::module_& m)
@@ -21,7 +20,7 @@ void define_adhesion(py::module_& m)
         Returns:
             The normal adhesion potential.
         )ipc_Qu8mg5v7",
-        py::arg("d"), py::arg("dhat_p"), py::arg("dhat_a"), py::arg("a2"));
+        "d"_a, "dhat_p"_a, "dhat_a"_a, "a2"_a);
 
     m.def(
         "normal_adhesion_potential_first_derivative",
@@ -38,7 +37,7 @@ void define_adhesion(py::module_& m)
         Returns:
             The first derivative of the normal adhesion potential wrt d.
         )ipc_Qu8mg5v7",
-        py::arg("d"), py::arg("dhat_p"), py::arg("dhat_a"), py::arg("a2"));
+        "d"_a, "dhat_p"_a, "dhat_a"_a, "a2"_a);
 
     m.def(
         "normal_adhesion_potential_second_derivative",
@@ -55,7 +54,7 @@ void define_adhesion(py::module_& m)
         Returns:
             The second derivative of the normal adhesion potential wrt d.
         )ipc_Qu8mg5v7",
-        py::arg("d"), py::arg("dhat_p"), py::arg("dhat_a"), py::arg("a2"));
+        "d"_a, "dhat_p"_a, "dhat_a"_a, "a2"_a);
 
     m.def(
         "max_normal_adhesion_force_magnitude",
@@ -71,7 +70,7 @@ void define_adhesion(py::module_& m)
         Returns:
             The maximum normal adhesion force magnitude.
         )ipc_Qu8mg5v7",
-        py::arg("dhat_p"), py::arg("dhat_a"), py::arg("a2"));
+        "dhat_p"_a, "dhat_a"_a, "a2"_a);
 
     m.def(
         "tangential_adhesion_f0", &tangential_adhesion_f0,
@@ -85,7 +84,7 @@ void define_adhesion(py::module_& m)
         Returns:
             The tangential adhesion mollifier function at y.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_a"));
+        "y"_a, "eps_a"_a);
 
     m.def(
         "tangential_adhesion_f1", &tangential_adhesion_f1,
@@ -99,7 +98,7 @@ void define_adhesion(py::module_& m)
         Returns:
             The first derivative of the tangential adhesion mollifier function at y.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_a"));
+        "y"_a, "eps_a"_a);
 
     m.def(
         "tangential_adhesion_f2", &tangential_adhesion_f2,
@@ -113,7 +112,7 @@ void define_adhesion(py::module_& m)
         Returns:
             The second derivative of the tangential adhesion mollifier function at y.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_a"));
+        "y"_a, "eps_a"_a);
 
     m.def(
         "tangential_adhesion_f1_over_x", &tangential_adhesion_f1_over_x,
@@ -127,7 +126,7 @@ void define_adhesion(py::module_& m)
         Returns:
             The first derivative of the tangential adhesion mollifier function divided by y.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_a"));
+        "y"_a, "eps_a"_a);
 
     m.def(
         "tangential_adhesion_f2_x_minus_f1_over_x3",
@@ -142,5 +141,5 @@ void define_adhesion(py::module_& m)
         Returns:
             The second derivative of the tangential adhesion mollifier function times y minus the first derivative all divided by y cubed.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_a"));
+        "y"_a, "eps_a"_a);
 }

--- a/python/src/adhesion/bindings.hpp
+++ b/python/src/adhesion/bindings.hpp
@@ -2,6 +2,4 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
 void define_adhesion(py::module_& m);

--- a/python/src/barrier/adaptive_stiffness.cpp
+++ b/python/src/barrier/adaptive_stiffness.cpp
@@ -4,7 +4,6 @@
 #include <ipc/candidates/candidates.hpp>
 #include <ipc/collisions/normal/normal_collisions.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_adaptive_stiffness(py::module_& m)
@@ -42,10 +41,9 @@ void define_adaptive_stiffness(py::module_& m)
             The initial barrier stiffness.
             Maximum stiffness of the barrier.
         )ipc_Qu8mg5v7",
-        py::arg("bbox_diagonal"), py::arg("barrier"), py::arg("dhat"),
-        py::arg("average_mass"), py::arg("grad_energy"),
-        py::arg("grad_barrier"), py::arg("min_barrier_stiffness_scale") = 1e11,
-        py::arg("dmin") = 0);
+        "bbox_diagonal"_a, "barrier"_a, "dhat"_a, "average_mass"_a,
+        "grad_energy"_a, "grad_barrier"_a,
+        "min_barrier_stiffness_scale"_a = 1e11, "dmin"_a = 0);
 
     m.def(
         "update_barrier_stiffness", &update_barrier_stiffness,
@@ -64,10 +62,9 @@ void define_adaptive_stiffness(py::module_& m)
         Returns:
             The updated barrier stiffness.
         )ipc_Qu8mg5v7",
-        py::arg("prev_min_distance"), py::arg("min_distance"),
-        py::arg("max_barrier_stiffness"), py::arg("barrier_stiffness"),
-        py::arg("bbox_diagonal"), py::arg("dhat_epsilon_scale") = 1e-9,
-        py::arg("dmin") = 0);
+        "prev_min_distance"_a, "min_distance"_a, "max_barrier_stiffness"_a,
+        "barrier_stiffness"_a, "bbox_diagonal"_a, "dhat_epsilon_scale"_a = 1e-9,
+        "dmin"_a = 0);
 
     m.def(
         "semi_implicit_stiffness",
@@ -91,8 +88,7 @@ void define_adaptive_stiffness(py::module_& m)
         Returns:
             The semi-implicit stiffness.
         )ipc_Qu8mg5v7",
-        py::arg("stencil"), py::arg("vertices"), py::arg("mass"),
-        py::arg("local_hess"), py::arg("dmin"));
+        "stencil"_a, "vertices"_a, "mass"_a, "local_hess"_a, "dmin"_a);
 
     m.def(
         "semi_implicit_stiffness",
@@ -117,8 +113,8 @@ void define_adaptive_stiffness(py::module_& m)
         Returns:
             The semi-implicit stiffness's.
         )ipc_Qu8mg5v7",
-        py::arg("mesh"), py::arg("vertices"), py::arg("collisions"),
-        py::arg("vertex_masses"), py::arg("hess"), py::arg("dmin"));
+        "mesh"_a, "vertices"_a, "collisions"_a, "vertex_masses"_a, "hess"_a,
+        "dmin"_a);
 
     m.def(
         "semi_implicit_stiffness",
@@ -143,6 +139,6 @@ void define_adaptive_stiffness(py::module_& m)
         Returns:
             The semi-implicit stiffness's.
         )ipc_Qu8mg5v7",
-        py::arg("mesh"), py::arg("vertices"), py::arg("collisions"),
-        py::arg("vertex_masses"), py::arg("hess"), py::arg("dmin"));
+        "mesh"_a, "vertices"_a, "collisions"_a, "vertex_masses"_a, "hess"_a,
+        "dmin"_a);
 }

--- a/python/src/barrier/barrier.cpp
+++ b/python/src/barrier/barrier.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/barrier/barrier.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 class PyBarrier : public Barrier {
@@ -21,7 +20,7 @@ void define_barrier(py::module_& m)
     py::class_<Barrier, PyBarrier, std::shared_ptr<Barrier>>(m, "Barrier")
         .def(py::init<>())
         .def(
-            "__call__", &Barrier::operator(), py::arg("d"), py::arg("dhat"),
+            "__call__", &Barrier::operator(), "d"_a, "dhat"_a,
             R"ipc_Qu8mg5v7(
             Evaluate the barrier function.
 
@@ -33,8 +32,7 @@ void define_barrier(py::module_& m)
                 The value of the barrier function at d.
             )ipc_Qu8mg5v7")
         .def(
-            "first_derivative", &Barrier::first_derivative, py::arg("d"),
-            py::arg("dhat"),
+            "first_derivative", &Barrier::first_derivative, "d"_a, "dhat"_a,
             R"ipc_Qu8mg5v7(
             Evaluate the first derivative of the barrier function wrt d.
 
@@ -46,8 +44,7 @@ void define_barrier(py::module_& m)
                 The value of the first derivative of the barrier function at d.
             )ipc_Qu8mg5v7")
         .def(
-            "second_derivative", &Barrier::second_derivative, py::arg("d"),
-            py::arg("dhat"),
+            "second_derivative", &Barrier::second_derivative, "d"_a, "dhat"_a,
             R"ipc_Qu8mg5v7(
             Evaluate the second derivative of the barrier function wrt d.
 
@@ -59,7 +56,7 @@ void define_barrier(py::module_& m)
                 The value of the second derivative of the barrier function at d.
             )ipc_Qu8mg5v7")
         .def(
-            "units", &Barrier::units, py::arg("dhat"),
+            "units", &Barrier::units, "dhat"_a,
             R"ipc_Qu8mg5v7(
             Get the units of the barrier function.
 
@@ -121,7 +118,8 @@ void define_barrier(py::module_& m)
         .def(py::init());
 
     m.def(
-        "barrier", &barrier,
+        "barrier", &barrier, "d"_a,
+        "dhat"_a
         R"ipc_Qu8mg5v7(
         Function that grows to infinity as d approaches 0 from the right.
 
@@ -135,11 +133,10 @@ void define_barrier(py::module_& m)
 
         Returns:
             The value of the barrier function at d.
-        )ipc_Qu8mg5v7",
-        py::arg("d"), py::arg("dhat"));
+        )ipc_Qu8mg5v7");
 
     m.def(
-        "barrier_first_derivative", &barrier_first_derivative,
+        "barrier_first_derivative", &barrier_first_derivative, "d"_a, "dhat"_a,
         R"ipc_Qu8mg5v7(
         Derivative of the barrier function.
 
@@ -154,11 +151,11 @@ void define_barrier(py::module_& m)
 
         Returns:
             The derivative of the barrier wrt d.
-        )ipc_Qu8mg5v7",
-        py::arg("d"), py::arg("dhat"));
+        )ipc_Qu8mg5v7");
 
     m.def(
-        "barrier_second_derivative", &barrier_second_derivative,
+        "barrier_second_derivative", &barrier_second_derivative, "d"_a,
+        "dhat"_a,
         R"ipc_Qu8mg5v7(
         Second derivative of the barrier function.
 
@@ -173,6 +170,5 @@ void define_barrier(py::module_& m)
 
         Returns:
             The second derivative of the barrier wrt d.
-        )ipc_Qu8mg5v7",
-        py::arg("d"), py::arg("dhat"));
+        )ipc_Qu8mg5v7");
 }

--- a/python/src/barrier/barrier_force_magnitude.cpp
+++ b/python/src/barrier/barrier_force_magnitude.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/barrier/barrier_force_magnitude.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_barrier_force_magnitude(py::module_& m)
@@ -22,8 +21,8 @@ void define_barrier_force_magnitude(py::module_& m)
         Returns:
             The magnitude of the force.
         )ipc_Qu8mg5v7",
-        py::arg("distance_squared"), py::arg("barrier"), py::arg("dhat"),
-        py::arg("barrier_stiffness"), py::arg("dmin") = 0);
+        "distance_squared"_a, "barrier"_a, "dhat"_a, "barrier_stiffness"_a,
+        "dmin"_a = 0);
 
     m.def(
         "barrier_force_magnitude_gradient", &barrier_force_magnitude_gradient,
@@ -41,7 +40,6 @@ void define_barrier_force_magnitude(py::module_& m)
         Returns:
             The gradient of the force.
         )ipc_Qu8mg5v7",
-        py::arg("distance_squared"), py::arg("distance_squared_gradient"),
-        py::arg("barrier"), py::arg("dhat"), py::arg("barrier_stiffness"),
-        py::arg("dmin") = 0);
+        "distance_squared"_a, "distance_squared_gradient"_a, "barrier"_a,
+        "dhat"_a, "barrier_stiffness"_a, "dmin"_a = 0);
 }

--- a/python/src/barrier/bindings.hpp
+++ b/python/src/barrier/bindings.hpp
@@ -2,8 +2,6 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
 void define_adaptive_stiffness(py::module_& m);
 void define_barrier_force_magnitude(py::module_& m);
 void define_barrier(py::module_& m);

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -1,8 +1,6 @@
 #include <common.hpp>
 #include <bindings.hpp>
 
-namespace py = pybind11;
-
 PYBIND11_MODULE(ipctk, m)
 {
     // py::options options;

--- a/python/src/bindings.hpp
+++ b/python/src/bindings.hpp
@@ -15,7 +15,5 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
 void define_collision_mesh(py::module_& m);
 void define_ipc(py::module_& m);

--- a/python/src/broad_phase/aabb.cpp
+++ b/python/src/broad_phase/aabb.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/broad_phase/aabb.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_aabb(py::module_& m)
@@ -12,13 +11,11 @@ void define_aabb(py::module_& m)
         .def(
             py::init<
                 Eigen::ConstRef<ArrayMax3d>, Eigen::ConstRef<ArrayMax3d>>(),
-            py::arg("min"), py::arg("max"))
+            "min"_a, "max"_a)
+        .def(py::init<const AABB&, const AABB&>(), "aabb1"_a, "aabb2"_a)
         .def(
-            py::init<const AABB&, const AABB&>(), py::arg("aabb1"),
-            py::arg("aabb2"))
-        .def(
-            py::init<const AABB&, const AABB&, const AABB&>(), py::arg("aabb1"),
-            py::arg("aabb2"), py::arg("aabb3"))
+            py::init<const AABB&, const AABB&, const AABB&>(), "aabb1"_a,
+            "aabb2"_a, "aabb3"_a)
         .def_static(
             "from_point",
             py::overload_cast<Eigen::ConstRef<VectorMax3d>, const double>(
@@ -33,7 +30,7 @@ void define_aabb(py::module_& m)
             Returns:
                 The constructed AABB.
             )ipc_Qu8mg5v7",
-            py::arg("p"), py::arg("inflation_radius") = 0)
+            "p"_a, "inflation_radius"_a = 0)
         .def_static(
             "from_point",
             py::overload_cast<
@@ -50,7 +47,7 @@ void define_aabb(py::module_& m)
             Returns:
                 The constructed AABB.
             )ipc_Qu8mg5v7",
-            py::arg("p_t0"), py::arg("p_t1"), py::arg("inflation_radius") = 0)
+            "p_t0"_a, "p_t1"_a, "inflation_radius"_a = 0)
         .def(
             "intersects", &AABB::intersects,
             R"ipc_Qu8mg5v7(
@@ -62,15 +59,15 @@ void define_aabb(py::module_& m)
             Returns:
                 If the two AABBs intersect.
             )ipc_Qu8mg5v7",
-            py::arg("other"))
+            "other"_a)
         .def_static(
             "conservative_inflation",
             [](ArrayMax3d min, ArrayMax3d max, const double inflation_radius) {
                 AABB::conservative_inflation(min, max, inflation_radius);
                 return std::make_tuple(min, max);
             },
-            "Compute a conservative inflation of the AABB.", py::arg("min"),
-            py::arg("max"), py::arg("inflation_radius"))
+            "Compute a conservative inflation of the AABB.", "min"_a, "max"_a,
+            "inflation_radius"_a)
         .def_readwrite("min", &AABB::min, "Minimum corner of the AABB.")
         .def_readwrite("max", &AABB::max, "Maximum corner of the AABB.")
         .def_readwrite(
@@ -95,7 +92,7 @@ void define_aabb(py::module_& m)
         Returns:
             Vertex AABBs.
         )ipc_Qu8mg5v7",
-        py::arg("vertices"), py::arg("inflation_radius") = 0);
+        "vertices"_a, "inflation_radius"_a = 0);
 
     m.def(
         "build_vertex_boxes",
@@ -118,8 +115,7 @@ void define_aabb(py::module_& m)
         Returns:
             Vertex AABBs.
         )ipc_Qu8mg5v7",
-        py::arg("vertices_t0"), py::arg("vertices_t1"),
-        py::arg("inflation_radius") = 0);
+        "vertices_t0"_a, "vertices_t1"_a, "inflation_radius"_a = 0);
 
     m.def(
         "build_edge_boxes",
@@ -139,7 +135,7 @@ void define_aabb(py::module_& m)
         Returns:
             edge_boxes: Edge AABBs.
         )ipc_Qu8mg5v7",
-        py::arg("vertex_boxes"), py::arg("edges"));
+        "vertex_boxes"_a, "edges"_a);
 
     m.def(
         "build_face_boxes",
@@ -159,5 +155,5 @@ void define_aabb(py::module_& m)
         Returns:
             face_boxes: Face AABBs.
         )ipc_Qu8mg5v7",
-        py::arg("vertex_boxes"), py::arg("faces"));
+        "vertex_boxes"_a, "faces"_a);
 }

--- a/python/src/broad_phase/bindings.hpp
+++ b/python/src/broad_phase/bindings.hpp
@@ -2,8 +2,6 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
 void define_aabb(py::module_& m);
 void define_broad_phase(py::module_& m);
 void define_brute_force(py::module_& m);

--- a/python/src/broad_phase/broad_phase.cpp
+++ b/python/src/broad_phase/broad_phase.cpp
@@ -3,7 +3,6 @@
 #include <ipc/broad_phase/broad_phase.hpp>
 #include <ipc/candidates/candidates.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 class PyBroadPhase : public BroadPhase {
@@ -146,8 +145,7 @@ void define_broad_phase(py::module_& m)
                 faces: Collision mesh faces
                 inflation_radius: Radius of inflation around all elements.
             )ipc_Qu8mg5v7",
-            py::arg("vertices"), py::arg("edges"), py::arg("faces"),
-            py::arg("inflation_radius") = 0)
+            "vertices"_a, "edges"_a, "faces"_a, "inflation_radius"_a = 0)
         .def(
             "build",
             py::overload_cast<
@@ -166,8 +164,8 @@ void define_broad_phase(py::module_& m)
                 faces: Collision mesh faces
                 inflation_radius: Radius of inflation around all elements.
             )ipc_Qu8mg5v7",
-            py::arg("vertices_t0"), py::arg("vertices_t1"), py::arg("edges"),
-            py::arg("faces"), py::arg("inflation_radius") = 0)
+            "vertices_t0"_a, "vertices_t1"_a, "edges"_a, "faces"_a,
+            "inflation_radius"_a = 0)
         .def("clear", &BroadPhase::clear, "Clear any built data.")
         .def(
             "detect_vertex_vertex_candidates",
@@ -261,7 +259,7 @@ void define_broad_phase(py::module_& m)
                 dim: The dimension of the simulation (i.e., 2 or 3).
                 candidates: The detected collision candidates.
             )ipc_Qu8mg5v7",
-            py::arg("dim"))
+            "dim"_a)
         .def_readwrite(
             "can_vertices_collide", &BroadPhase::can_vertices_collide,
             "Function for determining if two vertices can collide.");

--- a/python/src/broad_phase/brute_force.cpp
+++ b/python/src/broad_phase/brute_force.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/broad_phase/brute_force.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_brute_force(py::module_& m)

--- a/python/src/broad_phase/bvh.cpp
+++ b/python/src/broad_phase/bvh.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/broad_phase/bvh.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_bvh(py::module_& m)

--- a/python/src/broad_phase/hash_grid.cpp
+++ b/python/src/broad_phase/hash_grid.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/broad_phase/hash_grid.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_hash_grid(py::module_& m)
@@ -10,11 +9,10 @@ void define_hash_grid(py::module_& m)
     py::class_<HashItem>(m, "HashItem")
         .def(
             py::init<int, int>(),
-            "Construct a hash item as a (key, value) pair.", py::arg("key"),
-            py::arg("id"))
+            "Construct a hash item as a (key, value) pair.", "key"_a, "id"_a)
         .def(
             "__lt__", &HashItem::operator<,
-            "Compare HashItems by their keys for sorting.", py::arg("other"))
+            "Compare HashItems by their keys for sorting.", "other"_a)
         .def_readwrite("key", &HashItem::key, "The key of the item.")
         .def_readwrite("id", &HashItem::id, "The value of the item.");
 

--- a/python/src/broad_phase/spatial_hash.cpp
+++ b/python/src/broad_phase/spatial_hash.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/broad_phase/spatial_hash.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_spatial_hash(py::module_& m)
@@ -15,17 +14,16 @@ void define_spatial_hash(py::module_& m)
                 Eigen::ConstRef<Eigen::MatrixXd>,
                 Eigen::ConstRef<Eigen::MatrixXi>,
                 Eigen::ConstRef<Eigen::MatrixXi>, double, double>(),
-            py::arg("vertices"), py::arg("edges"), py::arg("faces"),
-            py::arg("inflation_radius") = 0, py::arg("voxel_size") = -1)
+            "vertices"_a, "edges"_a, "faces"_a, "inflation_radius"_a = 0,
+            "voxel_size"_a = -1)
         .def(
             py::init<
                 Eigen::ConstRef<Eigen::MatrixXd>,
                 Eigen::ConstRef<Eigen::MatrixXd>,
                 Eigen::ConstRef<Eigen::MatrixXi>,
                 Eigen::ConstRef<Eigen::MatrixXi>, double, double>(),
-            py::arg("vertices_t0"), py::arg("vertices_t1"), py::arg("edges"),
-            py::arg("faces"), py::arg("inflation_radius") = 0,
-            py::arg("voxel_size") = -1)
+            "vertices_t0"_a, "vertices_t1"_a, "edges"_a, "faces"_a,
+            "inflation_radius"_a = 0, "voxel_size"_a = -1)
         .def(
             "build",
             py::overload_cast<
@@ -33,8 +31,8 @@ void define_spatial_hash(py::module_& m)
                 Eigen::ConstRef<Eigen::MatrixXi>,
                 Eigen::ConstRef<Eigen::MatrixXi>, double, double>(
                 &SpatialHash::build),
-            py::arg("vertices"), py::arg("edges"), py::arg("faces"),
-            py::arg("inflation_radius") = 0, py::arg("voxel_size") = -1)
+            "vertices"_a, "edges"_a, "faces"_a, "inflation_radius"_a = 0,
+            "voxel_size"_a = -1)
         .def(
             "build",
             py::overload_cast<
@@ -43,25 +41,24 @@ void define_spatial_hash(py::module_& m)
                 Eigen::ConstRef<Eigen::MatrixXi>,
                 Eigen::ConstRef<Eigen::MatrixXi>, double, double>(
                 &SpatialHash::build),
-            py::arg("vertices_t0"), py::arg("vertices_t1"), py::arg("edges"),
-            py::arg("faces"), py::arg("inflation_radius") = 0,
-            py::arg("voxel_size") = -1)
+            "vertices_t0"_a, "vertices_t1"_a, "edges"_a, "faces"_a,
+            "inflation_radius"_a = 0, "voxel_size"_a = -1)
         .def("clear", &SpatialHash::clear)
         .def(
             "is_vertex_index", &SpatialHash::is_vertex_index,
-            "Check if primitive index refers to a vertex.", py::arg("idx"))
+            "Check if primitive index refers to a vertex.", "idx"_a)
         .def(
             "is_edge_index", &SpatialHash::is_edge_index,
-            "Check if primitive index refers to an edge.", py::arg("idx"))
+            "Check if primitive index refers to an edge.", "idx"_a)
         .def(
             "is_triangle_index", &SpatialHash::is_triangle_index,
-            "Check if primitive index refers to a triangle.", py::arg("idx"))
+            "Check if primitive index refers to a triangle.", "idx"_a)
         .def(
             "to_edge_index", &SpatialHash::to_edge_index,
-            "Convert a primitive index to an edge index.", py::arg("idx"))
+            "Convert a primitive index to an edge index.", "idx"_a)
         .def(
             "to_triangle_index", &SpatialHash::to_triangle_index,
-            "Convert a primitive index to a triangle index.", py::arg("idx"))
+            "Convert a primitive index to a triangle index.", "idx"_a)
         .def_readwrite(
             "left_bottom_corner", &SpatialHash::left_bottom_corner,
             "The left bottom corner of the world bounding box.")

--- a/python/src/broad_phase/sweep_and_prune.cpp
+++ b/python/src/broad_phase/sweep_and_prune.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/broad_phase/sweep_and_prune.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_sweep_and_prune(py::module_& m)

--- a/python/src/broad_phase/sweep_and_tiniest_queue.cpp
+++ b/python/src/broad_phase/sweep_and_tiniest_queue.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/broad_phase/sweep_and_tiniest_queue.hpp>
 
-namespace py = pybind11;
 #ifdef IPC_TOOLKIT_WITH_CUDA
 using namespace ipc; // not defined if IPC_TOOLKIT_WITH_CUDA is not defined
 #endif

--- a/python/src/broad_phase/voxel_size_heuristic.cpp
+++ b/python/src/broad_phase/voxel_size_heuristic.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/broad_phase/voxel_size_heuristic.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_voxel_size_heuristic(py::module_& m)
@@ -12,7 +11,7 @@ void define_voxel_size_heuristic(py::module_& m)
         py::overload_cast<
             Eigen::ConstRef<Eigen::MatrixXd>, Eigen::ConstRef<Eigen::MatrixXi>,
             const double>(&suggest_good_voxel_size),
-        py::arg("vertices"), py::arg("edges"), py::arg("inflation_radius") = 0);
+        "vertices"_a, "edges"_a, "inflation_radius"_a = 0);
 
     m.def(
         "suggest_good_voxel_size",
@@ -20,8 +19,7 @@ void define_voxel_size_heuristic(py::module_& m)
             Eigen::ConstRef<Eigen::MatrixXd>, Eigen::ConstRef<Eigen::MatrixXd>,
             Eigen::ConstRef<Eigen::MatrixXi>, const double>(
             &suggest_good_voxel_size),
-        py::arg("vertices_t0"), py::arg("vertices_t1"), py::arg("edges"),
-        py::arg("inflation_radius") = 0);
+        "vertices_t0"_a, "vertices_t1"_a, "edges"_a, "inflation_radius"_a = 0);
 
     m.def(
         "mean_edge_length",
@@ -33,8 +31,8 @@ void define_voxel_size_heuristic(py::module_& m)
                 vertices_t0, vertices_t1, edges, std_deviation);
             return std::make_tuple(r, std_deviation);
         },
-        "Compute the average edge length of a mesh.", py::arg("vertices_t0"),
-        py::arg("vertices_t1"), py::arg("edges"));
+        "Compute the average edge length of a mesh.", "vertices_t0"_a,
+        "vertices_t1"_a, "edges"_a);
 
     m.def(
         "mean_displacement_length",
@@ -43,23 +41,23 @@ void define_voxel_size_heuristic(py::module_& m)
             double r = mean_displacement_length(displacements, std_deviation);
             return std::make_tuple(r, std_deviation);
         },
-        "Compute the average displacement length.", py::arg("displacements"));
+        "Compute the average displacement length.", "displacements"_a);
 
     m.def(
         "median_edge_length", &median_edge_length,
-        "Compute the median edge length of a mesh.", py::arg("vertices_t0"),
-        py::arg("vertices_t1"), py::arg("edges"));
+        "Compute the median edge length of a mesh.", "vertices_t0"_a,
+        "vertices_t1"_a, "edges"_a);
 
     m.def(
         "median_displacement_length", &median_displacement_length,
-        "Compute the median displacement length.", py::arg("displacements"));
+        "Compute the median displacement length.", "displacements"_a);
 
     m.def(
         "max_edge_length", &max_edge_length,
-        "Compute the maximum edge length of a mesh.", py::arg("vertices_t0"),
-        py::arg("vertices_t1"), py::arg("edges"));
+        "Compute the maximum edge length of a mesh.", "vertices_t0"_a,
+        "vertices_t1"_a, "edges"_a);
 
     m.def(
         "max_displacement_length", &max_displacement_length,
-        "Compute the maximum displacement length.", py::arg("displacements"));
+        "Compute the maximum displacement length.", "displacements"_a);
 }

--- a/python/src/candidates/candidates.cpp
+++ b/python/src/candidates/candidates.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/candidates/candidates.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_candidates(py::module_& m)
@@ -23,9 +22,8 @@ void define_candidates(py::module_& m)
                 inflation_radius: Amount to inflate the bounding boxes.
                 broad_phase: Broad phase to use.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("vertices"),
-            py::arg("inflation_radius") = 0,
-            py::arg("broad_phase") = make_default_broad_phase())
+            "mesh"_a, "vertices"_a, "inflation_radius"_a = 0,
+            "broad_phase"_a = make_default_broad_phase())
         .def(
             "build",
             py::overload_cast<
@@ -45,9 +43,9 @@ void define_candidates(py::module_& m)
                 inflation_radius: Amount to inflate the bounding boxes.
                 broad_phase: Broad phase to use.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("vertices_t0"), py::arg("vertices_t1"),
-            py::arg("inflation_radius") = 0,
-            py::arg("broad_phase") = make_default_broad_phase())
+            "mesh"_a, "vertices_t0"_a, "vertices_t1"_a,
+            "inflation_radius"_a = 0,
+            "broad_phase"_a = make_default_broad_phase())
         .def("__len__", &Candidates::size)
         .def("empty", &Candidates::empty)
         .def("clear", &Candidates::clear)
@@ -75,9 +73,8 @@ void define_candidates(py::module_& m)
             Returns:
                 True if <b>any</b> collisions occur.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("vertices_t0"), py::arg("vertices_t1"),
-            py::arg("min_distance") = 0.0,
-            py::arg("narrow_phase_ccd") = DEFAULT_NARROW_PHASE_CCD)
+            "mesh"_a, "vertices_t0"_a, "vertices_t1"_a, "min_distance"_a = 0.0,
+            "narrow_phase_ccd"_a = DEFAULT_NARROW_PHASE_CCD)
         .def(
             "compute_collision_free_stepsize",
             &Candidates::compute_collision_free_stepsize,
@@ -97,9 +94,8 @@ void define_candidates(py::module_& m)
             Returns:
                 A step-size :math:`\in [0, 1]` that is collision free. A value of 1.0 if a full step and 0.0 is no step.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("vertices_t0"), py::arg("vertices_t1"),
-            py::arg("min_distance") = 0.0,
-            py::arg("narrow_phase_ccd") = DEFAULT_NARROW_PHASE_CCD)
+            "mesh"_a, "vertices_t0"_a, "vertices_t1"_a, "min_distance"_a = 0.0,
+            "narrow_phase_ccd"_a = DEFAULT_NARROW_PHASE_CCD)
         .def(
             "compute_noncandidate_conservative_stepsize",
             &Candidates::compute_noncandidate_conservative_stepsize,
@@ -111,7 +107,7 @@ void define_candidates(py::module_& m)
                 displacements: Surface vertex displacements (rowwise).
                 dhat: Barrier activation distance.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("displacements"), py::arg("dhat"))
+            "mesh"_a, "displacements"_a, "dhat"_a)
         .def(
             "compute_cfl_stepsize", &Candidates::compute_cfl_stepsize,
             R"ipc_Qu8mg5v7(
@@ -126,13 +122,13 @@ void define_candidates(py::module_& m)
                 broad_phase: Broad phase algorithm to use.
                 narrow_phase_ccd: Narrow phase CCD algorithm to use.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("vertices_t0"), py::arg("vertices_t1"),
-            py::arg("dhat"), py::arg("min_distance") = 0.0,
-            py::arg("broad_phase") = make_default_broad_phase(),
-            py::arg("narrow_phase_ccd") = DEFAULT_NARROW_PHASE_CCD)
+            "mesh"_a, "vertices_t0"_a, "vertices_t1"_a, "dhat"_a,
+            "min_distance"_a = 0.0,
+            "broad_phase"_a = make_default_broad_phase(),
+            "narrow_phase_ccd"_a = DEFAULT_NARROW_PHASE_CCD)
         .def(
-            "save_obj", &Candidates::save_obj, py::arg("filename"),
-            py::arg("vertices"), py::arg("edges"), py::arg("faces"))
+            "save_obj", &Candidates::save_obj, "filename"_a, "vertices"_a,
+            "edges"_a, "faces"_a)
         .def_readwrite("vv_candidates", &Candidates::vv_candidates)
         .def_readwrite("ev_candidates", &Candidates::ev_candidates)
         .def_readwrite("ee_candidates", &Candidates::ee_candidates)

--- a/python/src/candidates/collision_stencil.cpp
+++ b/python/src/candidates/collision_stencil.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/candidates/collision_stencil.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_collision_stencil(py::module_& m)
@@ -22,7 +21,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 The dimension of the collision stencil.
             )ipc_Qu8mg5v7",
-            py::arg("ndof"))
+            "ndof"_a)
         .def(
             "vertex_ids", &CollisionStencil::vertex_ids,
             R"ipc_Qu8mg5v7(
@@ -35,7 +34,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 The vertex IDs of the collision stencil. Size is always 4, but elements i > num_vertices() are -1.
             )ipc_Qu8mg5v7",
-            py::arg("edges"), py::arg("faces"))
+            "edges"_a, "faces"_a)
         .def(
             "vertices", &CollisionStencil::vertices,
             R"ipc_Qu8mg5v7(
@@ -51,7 +50,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 The vertex positions of the collision stencil. Size is always 4, but elements i > num_vertices() are NaN.
             )ipc_Qu8mg5v7",
-            py::arg("vertices"), py::arg("edges"), py::arg("faces"))
+            "vertices"_a, "edges"_a, "faces"_a)
         .def(
             "dof", &CollisionStencil::dof,
             R"ipc_Qu8mg5v7(
@@ -67,7 +66,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 This stencil's DOF.
             )ipc_Qu8mg5v7",
-            py::arg("X"), py::arg("edges"), py::arg("faces"))
+            "X"_a, "edges"_a, "faces"_a)
         .def(
             "compute_distance",
             py::overload_cast<
@@ -86,7 +85,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 Distance of the stencil.
             )ipc_Qu8mg5v7",
-            py::arg("vertices"), py::arg("edges"), py::arg("faces"))
+            "vertices"_a, "edges"_a, "faces"_a)
         .def(
             "compute_distance_gradient",
             py::overload_cast<
@@ -105,7 +104,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 Distance gradient of the stencil w.r.t. the stencil's vertex positions.
             )ipc_Qu8mg5v7",
-            py::arg("vertices"), py::arg("edges"), py::arg("faces"))
+            "vertices"_a, "edges"_a, "faces"_a)
         .def(
             "compute_distance_hessian",
             py::overload_cast<
@@ -124,7 +123,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 Distance Hessian of the stencil w.r.t. the stencil's vertex positions.
             )ipc_Qu8mg5v7",
-            py::arg("vertices"), py::arg("edges"), py::arg("faces"))
+            "vertices"_a, "edges"_a, "faces"_a)
         .def(
             "compute_distance",
             py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
@@ -141,7 +140,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 Distance of the stencil.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "compute_distance_gradient",
             py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
@@ -158,7 +157,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 Distance gradient of the stencil w.r.t. the stencil's vertex positions.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "compute_distance_hessian",
             py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
@@ -175,7 +174,7 @@ void define_collision_stencil(py::module_& m)
             Returns:
                 Distance Hessian of the stencil w.r.t. the stencil's vertex positions.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "ccd",
             [](const CollisionStencil& self,
@@ -204,9 +203,8 @@ void define_collision_stencil(py::module_& m)
                     If the candidate had a collision over the time interval.
                     Computed time of impact (normalized).
                 )ipc_Qu8mg5v7",
-            py::arg("vertices_t0"), py::arg("vertices_t1"),
-            py::arg("min_distance") = 0.0, py::arg("tmax") = 1.0,
-            py::arg("narrow_phase_ccd") = DEFAULT_NARROW_PHASE_CCD)
+            "vertices_t0"_a, "vertices_t1"_a, "min_distance"_a = 0.0,
+            "tmax"_a = 1.0, "narrow_phase_ccd"_a = DEFAULT_NARROW_PHASE_CCD)
         .def(
             "print_ccd_query",
             [](const CollisionStencil& self,
@@ -221,5 +219,5 @@ void define_collision_stencil(py::module_& m)
                                     vertices_t0: Stencil vertices at the start of the time step.
                     vertices_t1: Stencil vertices at the end of the time step.
                 )ipc_Qu8mg5v7",
-            py::arg("vertices_t0"), py::arg("vertices_t1"));
+            "vertices_t0"_a, "vertices_t1"_a);
 }

--- a/python/src/candidates/edge_edge.cpp
+++ b/python/src/candidates/edge_edge.cpp
@@ -2,21 +2,18 @@
 
 #include <ipc/candidates/edge_edge.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_edge_edge_candidate(py::module_& m)
 {
     py::class_<EdgeEdgeCandidate, CollisionStencil>(m, "EdgeEdgeCandidate")
-        .def(
-            py::init<index_t, index_t>(), py::arg("edge0_id"),
-            py::arg("edge1_id"))
+        .def(py::init<index_t, index_t>(), "edge0_id"_a, "edge1_id"_a)
         .def(
             py::init([](std::tuple<index_t, index_t> edge_ids) {
                 return std::make_unique<EdgeEdgeCandidate>(
                     std::get<0>(edge_ids), std::get<1>(edge_ids));
             }),
-            py::arg("edge_ids"))
+            "edge_ids"_a)
         .def("known_dtype", &EdgeEdgeCandidate::known_dtype)
         .def(
             "__str__",
@@ -29,11 +26,11 @@ void define_edge_edge_candidate(py::module_& m)
                 return fmt::format(
                     "EdgeEdgeCandidate({:d}, {:d})", ee.edge0_id, ee.edge1_id);
             })
-        .def("__eq__", &EdgeEdgeCandidate::operator==, py::arg("other"))
-        .def("__ne__", &EdgeEdgeCandidate::operator!=, py::arg("other"))
+        .def("__eq__", &EdgeEdgeCandidate::operator==, "other"_a)
+        .def("__ne__", &EdgeEdgeCandidate::operator!=, "other"_a)
         .def(
             "__lt__", &EdgeEdgeCandidate::operator<,
-            "Compare EdgeEdgeCandidates for sorting.", py::arg("other"))
+            "Compare EdgeEdgeCandidates for sorting.", "other"_a)
         .def_readwrite(
             "edge0_id", &EdgeEdgeCandidate::edge0_id, "ID of the first edge.")
         .def_readwrite(

--- a/python/src/candidates/edge_face.cpp
+++ b/python/src/candidates/edge_face.cpp
@@ -3,22 +3,19 @@
 #include <ipc/candidates/edge_face.hpp>
 #include <ipc/utils/logger.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_edge_face_candidate(py::module_& m)
 {
     py::class_<EdgeFaceCandidate>(m, "EdgeFaceCandidate")
-        .def(
-            py::init<index_t, index_t>(), py::arg("edge_id"),
-            py::arg("face_id"))
+        .def(py::init<index_t, index_t>(), "edge_id"_a, "face_id"_a)
         .def(
             py::init([](std::tuple<index_t, index_t> edge_and_face_id) {
                 return std::make_unique<EdgeFaceCandidate>(
                     std::get<0>(edge_and_face_id),
                     std::get<1>(edge_and_face_id));
             }),
-            py::arg("edge_and_face_id"))
+            "edge_and_face_id"_a)
         .def(
             "__str__",
             [](const EdgeFaceCandidate& ev) {
@@ -30,11 +27,11 @@ void define_edge_face_candidate(py::module_& m)
                 return fmt::format(
                     "EdgeFaceCandidate({:d}, {:d})", ev.edge_id, ev.face_id);
             })
-        .def("__eq__", &EdgeFaceCandidate::operator==, py::arg("other"))
-        .def("__ne__", &EdgeFaceCandidate::operator!=, py::arg("other"))
+        .def("__eq__", &EdgeFaceCandidate::operator==, "other"_a)
+        .def("__ne__", &EdgeFaceCandidate::operator!=, "other"_a)
         .def(
             "__lt__", &EdgeFaceCandidate::operator<,
-            "Compare EdgeFaceCandidate for sorting.", py::arg("other"))
+            "Compare EdgeFaceCandidate for sorting.", "other"_a)
         .def_readwrite("edge_id", &EdgeFaceCandidate::edge_id, "ID of the edge")
         .def_readwrite(
             "face_id", &EdgeFaceCandidate::face_id, "ID of the face");

--- a/python/src/candidates/edge_vertex.cpp
+++ b/python/src/candidates/edge_vertex.cpp
@@ -2,22 +2,19 @@
 
 #include <ipc/candidates/edge_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_edge_vertex_candidate(py::module_& m)
 {
     py::class_<EdgeVertexCandidate, CollisionStencil>(m, "EdgeVertexCandidate")
-        .def(
-            py::init<index_t, index_t>(), py::arg("edge_id"),
-            py::arg("vertex_id"))
+        .def(py::init<index_t, index_t>(), "edge_id"_a, "vertex_id"_a)
         .def(
             py::init([](std::tuple<index_t, index_t> edge_and_vertex_id) {
                 return std::make_unique<EdgeVertexCandidate>(
                     std::get<0>(edge_and_vertex_id),
                     std::get<1>(edge_and_vertex_id));
             }),
-            py::arg("edge_and_vertex_id"))
+            "edge_and_vertex_id"_a)
         .def("known_dtype", &EdgeVertexCandidate::known_dtype)
         .def(
             "__str__",
@@ -31,11 +28,11 @@ void define_edge_vertex_candidate(py::module_& m)
                     "EdgeVertexCandidate({:d}, {:d})", ev.edge_id,
                     ev.vertex_id);
             })
-        .def("__eq__", &EdgeVertexCandidate::operator==, py::arg("other"))
-        .def("__ne__", &EdgeVertexCandidate::operator!=, py::arg("other"))
+        .def("__eq__", &EdgeVertexCandidate::operator==, "other"_a)
+        .def("__ne__", &EdgeVertexCandidate::operator!=, "other"_a)
         .def(
             "__lt__", &EdgeVertexCandidate::operator<,
-            "Compare EdgeVertexCandidates for sorting.", py::arg("other"))
+            "Compare EdgeVertexCandidates for sorting.", "other"_a)
         .def_readwrite(
             "edge_id", &EdgeVertexCandidate::edge_id, "ID of the edge")
         .def_readwrite(

--- a/python/src/candidates/face_face.cpp
+++ b/python/src/candidates/face_face.cpp
@@ -3,21 +3,18 @@
 #include <ipc/candidates/face_face.hpp>
 #include <ipc/utils/logger.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_face_face_candidate(py::module_& m)
 {
     py::class_<FaceFaceCandidate>(m, "FaceFaceCandidate")
-        .def(
-            py::init<index_t, index_t>(), py::arg("face0_id"),
-            py::arg("face1_id"))
+        .def(py::init<index_t, index_t>(), "face0_id"_a, "face1_id"_a)
         .def(
             py::init([](std::tuple<index_t, index_t> face_ids) {
                 return std::make_unique<FaceFaceCandidate>(
                     std::get<0>(face_ids), std::get<1>(face_ids));
             }),
-            py::arg("face_ids"))
+            "face_ids"_a)
         .def(
             "__str__",
             [](const FaceFaceCandidate& ff) {
@@ -29,11 +26,11 @@ void define_face_face_candidate(py::module_& m)
                 return fmt::format(
                     "FaceFaceCandidate({:d}, {:d})", ff.face0_id, ff.face1_id);
             })
-        .def("__eq__", &FaceFaceCandidate::operator==, py::arg("other"))
-        .def("__ne__", &FaceFaceCandidate::operator!=, py::arg("other"))
+        .def("__eq__", &FaceFaceCandidate::operator==, "other"_a)
+        .def("__ne__", &FaceFaceCandidate::operator!=, "other"_a)
         .def(
             "__lt__", &FaceFaceCandidate::operator<,
-            "Compare FaceFaceCandidate for sorting.", py::arg("other"))
+            "Compare FaceFaceCandidate for sorting.", "other"_a)
         .def_readwrite(
             "face0_id", &FaceFaceCandidate::face0_id, "ID of the first face.")
         .def_readwrite(

--- a/python/src/candidates/face_vertex.cpp
+++ b/python/src/candidates/face_vertex.cpp
@@ -2,22 +2,19 @@
 
 #include <ipc/candidates/face_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_face_vertex_candidate(py::module_& m)
 {
     py::class_<FaceVertexCandidate, CollisionStencil>(m, "FaceVertexCandidate")
-        .def(
-            py::init<index_t, index_t>(), py::arg("face_id"),
-            py::arg("vertex_id"))
+        .def(py::init<index_t, index_t>(), "face_id"_a, "vertex_id"_a)
         .def(
             py::init([](std::tuple<index_t, index_t> face_and_vertex_id) {
                 return std::make_unique<FaceVertexCandidate>(
                     std::get<0>(face_and_vertex_id),
                     std::get<1>(face_and_vertex_id));
             }),
-            py::arg("face_and_vertex_id"))
+            "face_and_vertex_id"_a)
         .def("known_dtype", &FaceVertexCandidate::known_dtype)
         .def(
             "__str__",
@@ -31,11 +28,11 @@ void define_face_vertex_candidate(py::module_& m)
                     "FaceVertexCandidate({:d}, {:d})", ev.face_id,
                     ev.vertex_id);
             })
-        .def("__eq__", &FaceVertexCandidate::operator==, py::arg("other"))
-        .def("__ne__", &FaceVertexCandidate::operator!=, py::arg("other"))
+        .def("__eq__", &FaceVertexCandidate::operator==, "other"_a)
+        .def("__ne__", &FaceVertexCandidate::operator!=, "other"_a)
         .def(
             "__lt__", &FaceVertexCandidate::operator<,
-            "Compare FaceVertexCandidate for sorting.", py::arg("other"))
+            "Compare FaceVertexCandidate for sorting.", "other"_a)
         .def_readwrite(
             "face_id", &FaceVertexCandidate::face_id, "ID of the face")
         .def_readwrite(

--- a/python/src/candidates/vertex_vertex.cpp
+++ b/python/src/candidates/vertex_vertex.cpp
@@ -2,22 +2,19 @@
 
 #include <ipc/candidates/vertex_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_vertex_vertex_candidate(py::module_& m)
 {
     py::class_<VertexVertexCandidate, CollisionStencil>(
         m, "VertexVertexCandidate")
-        .def(
-            py::init<index_t, index_t>(), py::arg("vertex0_id"),
-            py::arg("vertex1_id"))
+        .def(py::init<index_t, index_t>(), "vertex0_id"_a, "vertex1_id"_a)
         .def(
             py::init([](std::tuple<index_t, index_t> vertex_ids) {
                 return std::make_unique<VertexVertexCandidate>(
                     std::get<0>(vertex_ids), std::get<1>(vertex_ids));
             }),
-            py::arg("vertex_ids"))
+            "vertex_ids"_a)
         .def(
             "__str__",
             [](const VertexVertexCandidate& ev) {
@@ -31,11 +28,11 @@ void define_vertex_vertex_candidate(py::module_& m)
                     "VertexVertexCandidate({:d}, {:d})", ev.vertex0_id,
                     ev.vertex1_id);
             })
-        .def("__eq__", &VertexVertexCandidate::operator==, py::arg("other"))
-        .def("__ne__", &VertexVertexCandidate::operator!=, py::arg("other"))
+        .def("__eq__", &VertexVertexCandidate::operator==, "other"_a)
+        .def("__ne__", &VertexVertexCandidate::operator!=, "other"_a)
         .def(
             "__lt__", &VertexVertexCandidate::operator<,
-            "Compare EdgeVertexCandidates for sorting.", py::arg("other"))
+            "Compare EdgeVertexCandidates for sorting.", "other"_a)
         .def_readwrite(
             "vertex0_id", &VertexVertexCandidate::vertex0_id,
             "ID of the first vertex")

--- a/python/src/ccd/aabb.cpp
+++ b/python/src/ccd/aabb.cpp
@@ -2,41 +2,37 @@
 
 #include <ipc/ccd/aabb.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_ccd_aabb(py::module_& m)
 {
     m.def(
-        "point_edge_aabb_cd", &point_edge_aabb_cd, py::arg("p"), py::arg("e0"),
-        py::arg("e1"), py::arg("dist"));
+        "point_edge_aabb_cd", &point_edge_aabb_cd, "p"_a, "e0"_a, "e1"_a,
+        "dist"_a);
 
     m.def(
-        "edge_edge_aabb_cd", &edge_edge_aabb_cd, py::arg("ea0"), py::arg("ea1"),
-        py::arg("eb0"), py::arg("eb1"), py::arg("dist"));
+        "edge_edge_aabb_cd", &edge_edge_aabb_cd, "ea0"_a, "ea1"_a, "eb0"_a,
+        "eb1"_a, "dist"_a);
 
     m.def(
-        "point_triangle_aabb_cd", &point_triangle_aabb_cd, py::arg("p"),
-        py::arg("t0"), py::arg("t1"), py::arg("t2"), py::arg("dist"));
+        "point_triangle_aabb_cd", &point_triangle_aabb_cd, "p"_a, "t0"_a,
+        "t1"_a, "t2"_a, "dist"_a);
 
     m.def(
-        "edge_triangle_aabb_cd", &edge_triangle_aabb_cd, py::arg("e0"),
-        py::arg("e1"), py::arg("t0"), py::arg("t1"), py::arg("t2"),
-        py::arg("dist"));
+        "edge_triangle_aabb_cd", &edge_triangle_aabb_cd, "e0"_a, "e1"_a, "t0"_a,
+        "t1"_a, "t2"_a, "dist"_a);
 
     m.def(
-        "point_edge_aabb_ccd", &point_edge_aabb_ccd, py::arg("p_t0"),
-        py::arg("e0_t0"), py::arg("e1_t0"), py::arg("p_t1"), py::arg("e0_t1"),
-        py::arg("e1_t1"), py::arg("dist"));
+        "point_edge_aabb_ccd", &point_edge_aabb_ccd, "p_t0"_a, "e0_t0"_a,
+        "e1_t0"_a, "p_t1"_a, "e0_t1"_a, "e1_t1"_a, "dist"_a);
 
     m.def(
-        "edge_edge_aabb_ccd", &edge_edge_aabb_ccd, py::arg("ea0_t0"),
-        py::arg("ea1_t0"), py::arg("eb0_t0"), py::arg("eb1_t0"),
-        py::arg("ea0_t1"), py::arg("ea1_t1"), py::arg("eb0_t1"),
-        py::arg("eb1_t1"), py::arg("dist"));
+        "edge_edge_aabb_ccd", &edge_edge_aabb_ccd, "ea0_t0"_a, "ea1_t0"_a,
+        "eb0_t0"_a, "eb1_t0"_a, "ea0_t1"_a, "ea1_t1"_a, "eb0_t1"_a, "eb1_t1"_a,
+        "dist"_a);
 
     m.def(
-        "point_triangle_aabb_ccd", &point_triangle_aabb_ccd, py::arg("p_t0"),
-        py::arg("t0_t0"), py::arg("t1_t0"), py::arg("t2_t0"), py::arg("p_t1"),
-        py::arg("t0_t1"), py::arg("t1_t1"), py::arg("t2_t1"), py::arg("dist"));
+        "point_triangle_aabb_ccd", &point_triangle_aabb_ccd, "p_t0"_a,
+        "t0_t0"_a, "t1_t0"_a, "t2_t0"_a, "p_t1"_a, "t0_t1"_a, "t1_t1"_a,
+        "t2_t1"_a, "dist"_a);
 }

--- a/python/src/ccd/additive_ccd.cpp
+++ b/python/src/ccd/additive_ccd.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/ccd/additive_ccd.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_additive_ccd(py::module_& m)
@@ -16,8 +15,8 @@ void define_additive_ccd(py::module_& m)
             Parameters:
                 conservative_rescaling: The conservative rescaling of the time of impact.
             )ipc_Qu8mg5v7",
-            py::arg("max_iterations") = AdditiveCCD::DEFAULT_MAX_ITERATIONS,
-            py::arg("conservative_rescaling") =
+            "max_iterations"_a = AdditiveCCD::DEFAULT_MAX_ITERATIONS,
+            "conservative_rescaling"_a =
                 AdditiveCCD::DEFAULT_CONSERVATIVE_RESCALING)
         .def_readonly_static(
             "DEFAULT_CONSERVATIVE_RESCALING",

--- a/python/src/ccd/bindings.hpp
+++ b/python/src/ccd/bindings.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-namespace py = pybind11;
 
 void define_ccd_aabb(py::module_& m);
 void define_additive_ccd(py::module_& m);

--- a/python/src/ccd/check_initial_distance.cpp
+++ b/python/src/ccd/check_initial_distance.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/ccd/check_initial_distance.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_check_initial_distance(py::module_& m)
@@ -15,5 +14,5 @@ void define_check_initial_distance(py::module_& m)
                 check_initial_distance(initial_distance, min_distance, toi);
             return std::make_tuple(r, toi);
         },
-        py::arg("initial_distance"), py::arg("min_distance"));
+        "initial_distance"_a, "min_distance"_a);
 }

--- a/python/src/ccd/inexact_ccd.cpp
+++ b/python/src/ccd/inexact_ccd.cpp
@@ -4,8 +4,6 @@
 
 #include <ipc/ccd/inexact_ccd.hpp>
 
-namespace py = pybind11;
-
 void define_inexact_ccd(py::module_& m)
 {
 #ifdef IPC_TOOLKIT_WITH_INEXACT_CCD
@@ -20,7 +18,7 @@ void define_inexact_ccd(py::module_& m)
             Parameters:
                 conservative_rescaling: The conservative rescaling of the time of impact.
             )ipc_Qu8mg5v7",
-            py::arg("conservative_rescaling") =
+            "conservative_rescaling"_a =
                 InexactCCD::DEFAULT_CONSERVATIVE_RESCALING)
         .def_readonly_static(
             "DEFAULT_CONSERVATIVE_RESCALING",

--- a/python/src/ccd/inexact_point_edge.cpp
+++ b/python/src/ccd/inexact_point_edge.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/ccd/inexact_point_edge.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_inexact_point_edge(py::module_& m)
@@ -39,6 +38,6 @@ void define_inexact_point_edge(py::module_& m)
             True if a collision was detected, false otherwise.
             Output time of impact
         )ipc_Qu8mg5v7",
-        py::arg("p_t0"), py::arg("e0_t0"), py::arg("e1_t0"), py::arg("p_t1"),
-        py::arg("e0_t1"), py::arg("e1_t1"), py::arg("conservative_rescaling"));
+        "p_t0"_a, "e0_t0"_a, "e1_t0"_a, "p_t1"_a, "e0_t1"_a, "e1_t1"_a,
+        "conservative_rescaling"_a);
 }

--- a/python/src/ccd/narrow_phase_ccd.cpp
+++ b/python/src/ccd/narrow_phase_ccd.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/ccd/narrow_phase_ccd.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 class PyNarrowPhaseCCD : public NarrowPhaseCCD {
@@ -114,9 +113,8 @@ void define_narrow_phase_ccd(py::module_& m)
                     p0_t0, p1_t0, p0_t1, p1_t1, toi, min_distance, tmax);
                 return std::make_tuple(r, toi);
             },
-            py::arg("p0_t0"), py::arg("p1_t0"), py::arg("p0_t1"),
-            py::arg("p1_t1"), py::arg("min_distance") = 0.0,
-            py::arg("tmax") = 1.0)
+            "p0_t0"_a, "p1_t0"_a, "p0_t1"_a, "p1_t1"_a, "min_distance"_a = 0.0,
+            "tmax"_a = 1.0)
         .def(
             "point_edge_ccd",
             [](const NarrowPhaseCCD& self, Eigen::ConstRef<VectorMax3d> p_t0,
@@ -132,9 +130,8 @@ void define_narrow_phase_ccd(py::module_& m)
                     tmax);
                 return std::make_tuple(r, toi);
             },
-            py::arg("p_t0"), py::arg("e0_t0"), py::arg("e1_t0"),
-            py::arg("p_t1"), py::arg("e0_t1"), py::arg("e1_t1"),
-            py::arg("min_distance") = 0.0, py::arg("tmax") = 1.0)
+            "p_t0"_a, "e0_t0"_a, "e1_t0"_a, "p_t1"_a, "e0_t1"_a, "e1_t1"_a,
+            "min_distance"_a = 0.0, "tmax"_a = 1.0)
         .def(
             "point_triangle_ccd",
             [](const NarrowPhaseCCD& self,
@@ -153,10 +150,8 @@ void define_narrow_phase_ccd(py::module_& m)
                     min_distance, tmax);
                 return std::make_tuple(r, toi);
             },
-            py::arg("p_t0"), py::arg("t0_t0"), py::arg("t1_t0"),
-            py::arg("t2_t0"), py::arg("p_t1"), py::arg("t0_t1"),
-            py::arg("t1_t1"), py::arg("t2_t1"), py::arg("min_distance") = 0.0,
-            py::arg("tmax") = 1.0)
+            "p_t0"_a, "t0_t0"_a, "t1_t0"_a, "t2_t0"_a, "p_t1"_a, "t0_t1"_a,
+            "t1_t1"_a, "t2_t1"_a, "min_distance"_a = 0.0, "tmax"_a = 1.0)
         .def(
             "edge_edge_ccd",
             [](const NarrowPhaseCCD& self,
@@ -175,8 +170,7 @@ void define_narrow_phase_ccd(py::module_& m)
                     eb1_t1, toi, min_distance, tmax);
                 return std::make_tuple(r, toi);
             },
-            py::arg("ea0_t0"), py::arg("ea1_t0"), py::arg("eb0_t0"),
-            py::arg("eb1_t0"), py::arg("ea0_t1"), py::arg("ea1_t1"),
-            py::arg("eb0_t1"), py::arg("eb1_t1"), py::arg("min_distance") = 0.0,
-            py::arg("tmax") = 1.0);
+            "ea0_t0"_a, "ea1_t0"_a, "eb0_t0"_a, "eb1_t0"_a, "ea0_t1"_a,
+            "ea1_t1"_a, "eb0_t1"_a, "eb1_t1"_a, "min_distance"_a = 0.0,
+            "tmax"_a = 1.0);
 }

--- a/python/src/ccd/nonlinear_ccd.cpp
+++ b/python/src/ccd/nonlinear_ccd.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/ccd/nonlinear_ccd.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 class PyNonlinearTrajectory : public NonlinearTrajectory {
@@ -33,7 +32,7 @@ void define_nonlinear_ccd(py::module_& m)
         .def(py::init<>())
         .def(
             "__call__", &NonlinearTrajectory::operator(),
-            "Compute the point's position at time t", py::arg("t"))
+            "Compute the point's position at time t", "t"_a)
         .def(
             "max_distance_from_linear",
             &NonlinearTrajectory::max_distance_from_linear,
@@ -44,7 +43,7 @@ void define_nonlinear_ccd(py::module_& m)
                 t0: Start time of the trajectory
                 t1: End time of the trajectory
             )ipc_Qu8mg5v7",
-            py::arg("t0"), py::arg("t1"));
+            "t0"_a, "t1"_a);
 
 #ifdef IPC_TOOLKIT_WITH_FILIB
     py::class_<
@@ -56,12 +55,12 @@ void define_nonlinear_ccd(py::module_& m)
             [](const IntervalNonlinearTrajectory& self, const double t) {
                 return self(t);
             },
-            "Compute the point's position at time t", py::arg("t"))
+            "Compute the point's position at time t", "t"_a)
         .def(
             "__call__",
             py::overload_cast<const filib::Interval&>(
                 &IntervalNonlinearTrajectory::operator(), py::const_),
-            "Compute the point's position over a time interval t", py::arg("t"))
+            "Compute the point's position over a time interval t", "t"_a)
         .def(
             "max_distance_from_linear",
             &IntervalNonlinearTrajectory::max_distance_from_linear,
@@ -75,7 +74,7 @@ void define_nonlinear_ccd(py::module_& m)
                 t0: Start time of the trajectory
                 t1: End time of the trajectory
             )ipc_Qu8mg5v7",
-            py::arg("t0"), py::arg("t1"));
+            "t0"_a, "t1"_a);
 #endif
 
     m.def(
@@ -106,11 +105,10 @@ void define_nonlinear_ccd(py::module_& m)
             True if the two points collide, false otherwise.
             Output time of impact
         )ipc_Qu8mg5v7",
-        py::arg("p0"), py::arg("p1"), py::arg("tmax") = 1.0,
-        py::arg("min_distance") = 0,
-        py::arg("tolerance") = TightInclusionCCD::DEFAULT_TOLERANCE,
-        py::arg("max_iterations") = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
-        py::arg("conservative_rescaling") =
+        "p0"_a, "p1"_a, "tmax"_a = 1.0, "min_distance"_a = 0,
+        "tolerance"_a = TightInclusionCCD::DEFAULT_TOLERANCE,
+        "max_iterations"_a = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
+        "conservative_rescaling"_a =
             TightInclusionCCD::DEFAULT_CONSERVATIVE_RESCALING);
 
     m.def(
@@ -143,11 +141,10 @@ void define_nonlinear_ccd(py::module_& m)
             True if the point and edge collide, false otherwise.
             Output time of impact
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"), py::arg("tmax") = 1.0,
-        py::arg("min_distance") = 0,
-        py::arg("tolerance") = TightInclusionCCD::DEFAULT_TOLERANCE,
-        py::arg("max_iterations") = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
-        py::arg("conservative_rescaling") =
+        "p"_a, "e0"_a, "e1"_a, "tmax"_a = 1.0, "min_distance"_a = 0,
+        "tolerance"_a = TightInclusionCCD::DEFAULT_TOLERANCE,
+        "max_iterations"_a = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
+        "conservative_rescaling"_a =
             TightInclusionCCD::DEFAULT_CONSERVATIVE_RESCALING);
 
     m.def(
@@ -181,11 +178,11 @@ void define_nonlinear_ccd(py::module_& m)
             True if the two edges collide, false otherwise.
             Output time of impact
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"),
-        py::arg("tmax") = 1.0, py::arg("min_distance") = 0,
-        py::arg("tolerance") = TightInclusionCCD::DEFAULT_TOLERANCE,
-        py::arg("max_iterations") = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
-        py::arg("conservative_rescaling") =
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a, "tmax"_a = 1.0,
+        "min_distance"_a = 0,
+        "tolerance"_a = TightInclusionCCD::DEFAULT_TOLERANCE,
+        "max_iterations"_a = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
+        "conservative_rescaling"_a =
             TightInclusionCCD::DEFAULT_CONSERVATIVE_RESCALING);
 
     m.def(
@@ -219,11 +216,10 @@ void define_nonlinear_ccd(py::module_& m)
             True if the point and triangle collide, false otherwise.
             Output time of impact
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"),
-        py::arg("tmax") = 1.0, py::arg("min_distance") = 0,
-        py::arg("tolerance") = TightInclusionCCD::DEFAULT_TOLERANCE,
-        py::arg("max_iterations") = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
-        py::arg("conservative_rescaling") =
+        "p"_a, "t0"_a, "t1"_a, "t2"_a, "tmax"_a = 1.0, "min_distance"_a = 0,
+        "tolerance"_a = TightInclusionCCD::DEFAULT_TOLERANCE,
+        "max_iterations"_a = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
+        "conservative_rescaling"_a =
             TightInclusionCCD::DEFAULT_CONSERVATIVE_RESCALING);
 
     m.def(
@@ -258,9 +254,8 @@ void define_nonlinear_ccd(py::module_& m)
 
             Output time of impact.
         )ipc_Qu8mg5v7",
-        py::arg("distance"), py::arg("max_distance_from_linear"),
-        py::arg("linear_ccd"), py::arg("tmax") = 1.0,
-        py::arg("min_distance") = 0,
-        py::arg("conservative_rescaling") =
+        "distance"_a, "max_distance_from_linear"_a, "linear_ccd"_a,
+        "tmax"_a = 1.0, "min_distance"_a = 0,
+        "conservative_rescaling"_a =
             TightInclusionCCD::DEFAULT_CONSERVATIVE_RESCALING);
 }

--- a/python/src/ccd/point_static_plane.cpp
+++ b/python/src/ccd/point_static_plane.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/ccd/point_static_plane.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_point_static_plane(py::module_& m)
@@ -34,8 +33,7 @@ void define_point_static_plane(py::module_& m)
             True if a collision was detected, false otherwise.
             Output time of impact
         )ipc_Qu8mg5v7",
-        py::arg("p_t0"), py::arg("p_t1"), py::arg("plane_origin"),
-        py::arg("plane_normal"),
-        py::arg("conservative_rescaling") =
+        "p_t0"_a, "p_t1"_a, "plane_origin"_a, "plane_normal"_a,
+        "conservative_rescaling"_a =
             TightInclusionCCD::DEFAULT_CONSERVATIVE_RESCALING);
 }

--- a/python/src/ccd/tight_inclusion_ccd.cpp
+++ b/python/src/ccd/tight_inclusion_ccd.cpp
@@ -5,7 +5,6 @@
 #include <tight_inclusion/ccd.hpp>
 #include <tight_inclusion/interval_root_finder.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_tight_inclusion_ccd(py::module_& m)
@@ -70,16 +69,13 @@ void define_tight_inclusion_ccd(py::module_& m)
                 the earliest time of collision if collision happens (infinity if no collision occurs), and
                 if max_iterations < 0, the solver precision otherwise the input tolerance.
         )ipc_Qu8mg5v7",
-        py::arg("ea0_t0"), py::arg("ea1_t0"), py::arg("eb0_t0"),
-        py::arg("eb1_t0"), py::arg("ea0_t1"), py::arg("ea1_t1"),
-        py::arg("eb0_t1"), py::arg("eb1_t1"), py::arg("min_distance") = 0,
-        py::arg("tmax") = 1,
-        py::arg("tolerance") = TightInclusionCCD::DEFAULT_TOLERANCE,
-        py::arg("max_iterations") = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
-        py::arg("filter") = ticcd::Array3::Constant(-1),
-        py::arg("no_zero_toi") = ticcd::DEFAULT_NO_ZERO_TOI,
-        py::arg("ccd_method") =
-            ticcd::CCDRootFindingMethod::BREADTH_FIRST_SEARCH);
+        "ea0_t0"_a, "ea1_t0"_a, "eb0_t0"_a, "eb1_t0"_a, "ea0_t1"_a, "ea1_t1"_a,
+        "eb0_t1"_a, "eb1_t1"_a, "min_distance"_a = 0, "tmax"_a = 1,
+        "tolerance"_a = TightInclusionCCD::DEFAULT_TOLERANCE,
+        "max_iterations"_a = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
+        "filter"_a = ticcd::Array3::Constant(-1),
+        "no_zero_toi"_a = ticcd::DEFAULT_NO_ZERO_TOI,
+        "ccd_method"_a = ticcd::CCDRootFindingMethod::BREADTH_FIRST_SEARCH);
 
     m_ti.def(
         "point_triangle_ccd",
@@ -125,15 +121,13 @@ void define_tight_inclusion_ccd(py::module_& m)
                 the earliest time of collision if collision happens (infinity if no collision occurs), and
                 if max_iterations < 0, the solver precision otherwise the input tolerance.
         )ipc_Qu8mg5v7",
-        py::arg("v_t0"), py::arg("f0_t0"), py::arg("f1_t0"), py::arg("f2_t0"),
-        py::arg("v_t1"), py::arg("f0_t1"), py::arg("f1_t1"), py::arg("f2_t1"),
-        py::arg("min_distance") = 0, py::arg("tmax") = 1,
-        py::arg("tolerance") = TightInclusionCCD::DEFAULT_TOLERANCE,
-        py::arg("max_iterations") = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
-        py::arg("filter") = ticcd::Array3::Constant(-1),
-        py::arg("no_zero_toi") = ticcd::DEFAULT_NO_ZERO_TOI,
-        py::arg("ccd_method") =
-            ticcd::CCDRootFindingMethod::BREADTH_FIRST_SEARCH);
+        "v_t0"_a, "f0_t0"_a, "f1_t0"_a, "f2_t0"_a, "v_t1"_a, "f0_t1"_a,
+        "f1_t1"_a, "f2_t1"_a, "min_distance"_a = 0, "tmax"_a = 1,
+        "tolerance"_a = TightInclusionCCD::DEFAULT_TOLERANCE,
+        "max_iterations"_a = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
+        "filter"_a = ticcd::Array3::Constant(-1),
+        "no_zero_toi"_a = ticcd::DEFAULT_NO_ZERO_TOI,
+        "ccd_method"_a = ticcd::CCDRootFindingMethod::BREADTH_FIRST_SEARCH);
 
     m_ti.def(
         "compute_ccd_filters",
@@ -161,8 +155,8 @@ void define_tight_inclusion_ccd(py::module_& m)
         Returns:
             The numerical error filters for the input parameters.
         )ipc_Qu8mg5v7",
-        py::arg("min_corner"), py::arg("max_corner"), py::arg("is_vertex_face"),
-        py::arg("using_minimum_separation"));
+        "min_corner"_a, "max_corner"_a, "is_vertex_face"_a,
+        "using_minimum_separation"_a);
 
     py::class_<TightInclusionCCD, NarrowPhaseCCD>(m, "TightInclusionCCD")
         .def(
@@ -173,10 +167,9 @@ void define_tight_inclusion_ccd(py::module_& m)
             Parameters:
                 conservative_rescaling: The conservative rescaling of the time of impact.
             )ipc_Qu8mg5v7",
-            py::arg("tolerance") = TightInclusionCCD::DEFAULT_TOLERANCE,
-            py::arg("max_iterations") =
-                TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
-            py::arg("conservative_rescaling") =
+            "tolerance"_a = TightInclusionCCD::DEFAULT_TOLERANCE,
+            "max_iterations"_a = TightInclusionCCD::DEFAULT_MAX_ITERATIONS,
+            "conservative_rescaling"_a =
                 TightInclusionCCD::DEFAULT_CONSERVATIVE_RESCALING)
         .def_readonly_static(
             "DEFAULT_TOLERANCE", &TightInclusionCCD::DEFAULT_TOLERANCE,

--- a/python/src/collision_mesh.cpp
+++ b/python/src/collision_mesh.cpp
@@ -3,7 +3,6 @@
 #include <ipc/collision_mesh.hpp>
 #include <ipc/utils/logger.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 #ifdef IPC_TOOLKIT_WITH_ABSEIL
@@ -93,7 +92,7 @@ void define_collision_mesh(py::module_& m)
                 explicit_values: A map from vertex pairs to whether they can collide. Only the upper triangle is used. The map is assumed to be symmetric.
                 default_value: The default value to return if the pair is not in the map.
             )ipc_Qu8mg5v7",
-            py::arg("explicit_values"), py::arg("default_value"))
+            "explicit_values"_a, "default_value"_a)
         .def(
             "__call__", &SparseCanCollide::operator(), R"ipc_Qu8mg5v7(
             Can two vertices collide?
@@ -105,14 +104,13 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 The value of the pair if it is in the map, otherwise the default value.
             )ipc_Qu8mg5v7",
-            py::arg("i"), py::arg("j"));
+            "i"_a, "j"_a);
 
     py::class_<VertexPatchesCanCollide>(
         m, "VertexPatchesCanCollide",
         "A functor which returns true if the vertices are in different patches.")
         .def(
-            py::init<Eigen::ConstRef<Eigen::VectorXi>>(),
-            py::arg("vertex_patches"),
+            py::init<Eigen::ConstRef<Eigen::VectorXi>>(), "vertex_patches"_a,
             R"ipc_Qu8mg5v7(
             Construct a new Vertex Patches Can Collide object.
 
@@ -130,7 +128,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 True if the vertices are in different patches.
             )ipc_Qu8mg5v7",
-            py::arg("i"), py::arg("j"));
+            "i"_a, "j"_a);
 
     py::class_<CollisionMesh>(m, "CollisionMesh")
         .def(
@@ -148,9 +146,9 @@ void define_collision_mesh(py::module_& m)
                 faces: The faces of the collision mesh (#F × 3).
                 displacement_map: The displacement mapping from displacements on the full mesh to the collision mesh.
             )ipc_Qu8mg5v7",
-            py::arg("rest_positions"), py::arg("edges") = Eigen::MatrixXi(),
-            py::arg("faces") = Eigen::MatrixXi(),
-            py::arg("displacement_map") = Eigen::SparseMatrix<double>())
+            "rest_positions"_a, "edges"_a = Eigen::MatrixXi(),
+            "faces"_a = Eigen::MatrixXi(),
+            "displacement_map"_a = Eigen::SparseMatrix<double>())
         .def(
             py::init<
                 const std::vector<bool>&, Eigen::ConstRef<Eigen::MatrixXd>,
@@ -167,10 +165,9 @@ void define_collision_mesh(py::module_& m)
                 faces: The faces of the collision mesh indexed into the full mesh vertices (#F × 3).
                 displacement_map: The displacement mapping from displacements on the full mesh to the collision mesh.
             )ipc_Qu8mg5v7",
-            py::arg("include_vertex"), py::arg("full_rest_positions"),
-            py::arg("edges") = Eigen::MatrixXi(),
-            py::arg("faces") = Eigen::MatrixXi(),
-            py::arg("displacement_map") = Eigen::SparseMatrix<double>())
+            "include_vertex"_a, "full_rest_positions"_a,
+            "edges"_a = Eigen::MatrixXi(), "faces"_a = Eigen::MatrixXi(),
+            "displacement_map"_a = Eigen::SparseMatrix<double>())
         .def_static(
             "build_from_full_mesh", &CollisionMesh::build_from_full_mesh,
             R"ipc_Qu8mg5v7(
@@ -184,8 +181,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 Constructed CollisionMesh.
             )ipc_Qu8mg5v7",
-            py::arg("full_rest_positions"), py::arg("edges"),
-            py::arg("faces") = Eigen::MatrixXi())
+            "full_rest_positions"_a, "edges"_a, "faces"_a = Eigen::MatrixXi())
         .def(
             "init_adjacencies", &CollisionMesh::init_adjacencies,
             "Initialize vertex-vertex and edge-vertex adjacencies.")
@@ -247,7 +243,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 The vertex positions of the collision mesh (#V × dim).
             )ipc_Qu8mg5v7",
-            py::arg("full_positions"))
+            "full_positions"_a)
         .def(
             "displace_vertices", &CollisionMesh::displace_vertices,
             R"ipc_Qu8mg5v7(
@@ -259,7 +255,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 The vertex positions of the collision mesh (#V × dim).
             )ipc_Qu8mg5v7",
-            py::arg("full_displacements"))
+            "full_displacements"_a)
         .def(
             "map_displacements", &CollisionMesh::map_displacements,
             R"ipc_Qu8mg5v7(
@@ -271,7 +267,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 The vertex displacements on the collision mesh (#V × dim).
             )ipc_Qu8mg5v7",
-            py::arg("full_displacements"))
+            "full_displacements"_a)
         .def(
             "to_full_vertex_id", &CollisionMesh::to_full_vertex_id,
             R"ipc_Qu8mg5v7(
@@ -283,7 +279,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 Vertex ID in the full mesh.
             )ipc_Qu8mg5v7",
-            py::arg("id"))
+            "id"_a)
         .def(
             "to_full_dof",
             py::overload_cast<Eigen::ConstRef<Eigen::VectorXd>>(
@@ -299,7 +295,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 Vector quantity on the full mesh with size equal to full_ndof().
             )ipc_Qu8mg5v7",
-            py::arg("x"))
+            "x"_a)
         .def(
             "to_full_dof",
             py::overload_cast<const Eigen::SparseMatrix<double>&>(
@@ -315,7 +311,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 Matrix quantity on the full mesh with size equal to full_ndof() × full_ndof().
             )ipc_Qu8mg5v7",
-            py::arg("X"))
+            "X"_a)
         .def_property_readonly(
             "vertex_vertex_adjacencies",
             &CollisionMesh::vertex_vertex_adjacencies,
@@ -341,7 +337,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 True if the vertex is on the boundary of the collision mesh.
             )ipc_Qu8mg5v7",
-            py::arg("vi"))
+            "vi"_a)
         .def(
             "vertex_area", &CollisionMesh::vertex_area,
             R"ipc_Qu8mg5v7(
@@ -353,7 +349,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 Barycentric area of vertex vi.
             )ipc_Qu8mg5v7",
-            py::arg("vi"))
+            "vi"_a)
         .def_property_readonly(
             "vertex_areas", &CollisionMesh::vertex_areas,
             "Get the barycentric area of the vertices.")
@@ -372,7 +368,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 Gradient of the barycentric area of vertex vi wrt the rest positions of all points.
             )ipc_Qu8mg5v7",
-            py::arg("vi"))
+            "vi"_a)
         .def(
             "edge_area", &CollisionMesh::edge_area,
             R"ipc_Qu8mg5v7(
@@ -384,7 +380,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 Barycentric area of edge ei.
             )ipc_Qu8mg5v7",
-            py::arg("ei"))
+            "ei"_a)
         .def(
             "edge_areas", &CollisionMesh::edge_areas,
             "Get the barycentric area of the edges.")
@@ -403,7 +399,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 Gradient of the barycentric area of edge ei wrt the rest positions of all points.
             )ipc_Qu8mg5v7",
-            py::arg("ei"))
+            "ei"_a)
         .def(
             "are_area_jacobians_initialized",
             &CollisionMesh::are_area_jacobians_initialized,
@@ -421,8 +417,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 A vector of bools indicating whether each vertex is on the surface.
             )ipc_Qu8mg5v7",
-            py::arg("num_vertices"), py::arg("edges"),
-            py::arg("codim_vertices") = Eigen::VectorXi())
+            "num_vertices"_a, "edges"_a, "codim_vertices"_a = Eigen::VectorXi())
         .def_static(
             "construct_faces_to_edges",
             &CollisionMesh::construct_faces_to_edges,
@@ -436,7 +431,7 @@ void define_collision_mesh(py::module_& m)
             Returns:
                 Matrix that maps from the faces' edges to rows in the edges matrix.
             )ipc_Qu8mg5v7",
-            py::arg("faces"), py::arg("edges"))
+            "faces"_a, "edges"_a)
         .def_property(
             "can_collide", [](CollisionMesh& self) { return self.can_collide; },
             [](CollisionMesh& self, const py::object& can_collide) {

--- a/python/src/collisions/normal/bindings.hpp
+++ b/python/src/collisions/normal/bindings.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-namespace py = pybind11;
 
 void define_normal_collision(py::module_& m);
 void define_normal_collisions(py::module_& m);

--- a/python/src/collisions/normal/edge_edge.cpp
+++ b/python/src/collisions/normal/edge_edge.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/normal/edge_edge.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_edge_edge_normal_collision(py::module_& m)
@@ -13,25 +12,24 @@ void define_edge_edge_normal_collision(py::module_& m)
             py::init<
                 const index_t, const index_t, const double,
                 const EdgeEdgeDistanceType>(),
-            py::arg("edge0_id"), py::arg("edge1_id"), py::arg("eps_x"),
-            py::arg("dtype") = EdgeEdgeDistanceType::AUTO)
+            "edge0_id"_a, "edge1_id"_a, "eps_x"_a,
+            "dtype"_a = EdgeEdgeDistanceType::AUTO)
         .def(
             py::init<
                 const EdgeEdgeCandidate&, const double,
                 const EdgeEdgeDistanceType>(),
-            py::arg("candidate"), py::arg("eps_x"),
-            py::arg("dtype") = EdgeEdgeDistanceType::AUTO)
+            "candidate"_a, "eps_x"_a, "dtype"_a = EdgeEdgeDistanceType::AUTO)
         // .def(
         //     py::init<
         //         const index_t, const index_t, const double, const double,
         //         const Eigen::SparseVector<double>&,
         //         const EdgeEdgeDistanceType>(),
-        //     py::arg("edge0_id"), py::arg("edge1_id"), py::arg("eps_x"),
-        //     py::arg("weight"), py::arg("weight_gradient"),
-        //     py::arg("dtype") = EdgeEdgeDistanceType::AUTO)
-        .def("__eq__", &EdgeEdgeNormalCollision::operator==, py::arg("other"))
-        .def("__ne__", &EdgeEdgeNormalCollision::operator!=, py::arg("other"))
-        .def("__lt__", &EdgeEdgeNormalCollision::operator<, py::arg("other"))
+        //     "edge0_id"_a, "edge1_id"_a, "eps_x"_a,
+        //     "weight"_a, "weight_gradient"_a,
+        //     "dtype"_a = EdgeEdgeDistanceType::AUTO)
+        .def("__eq__", &EdgeEdgeNormalCollision::operator==, "other"_a)
+        .def("__ne__", &EdgeEdgeNormalCollision::operator!=, "other"_a)
+        .def("__lt__", &EdgeEdgeNormalCollision::operator<, "other"_a)
         .def_readwrite(
             "eps_x", &EdgeEdgeNormalCollision::eps_x,
             "Mollifier activation threshold.")

--- a/python/src/collisions/normal/edge_vertex.cpp
+++ b/python/src/collisions/normal/edge_vertex.cpp
@@ -2,21 +2,18 @@
 
 #include <ipc/collisions/normal/edge_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_edge_vertex_normal_collision(py::module_& m)
 {
     py::class_<EdgeVertexNormalCollision, EdgeVertexCandidate, NormalCollision>(
         m, "EdgeVertexNormalCollision")
-        .def(
-            py::init<index_t, index_t>(), py::arg("edge_id"),
-            py::arg("vertex_id"))
-        .def(py::init<const EdgeVertexCandidate&>(), py::arg("candidate"));
+        .def(py::init<index_t, index_t>(), "edge_id"_a, "vertex_id"_a)
+        .def(py::init<const EdgeVertexCandidate&>(), "candidate"_a);
     // .def(
     //     py::init<
     //         const index_t, const index_t, const double,
     //         const Eigen::SparseVector<double>&>(),
-    //     py::arg("edge_id"), py::arg("vertex_id"), py::arg("weight"),
-    //     py::arg("weight_gradient"));
+    //     "edge_id"_a, "vertex_id"_a, "weight"_a,
+    //     "weight_gradient"_a);
 }

--- a/python/src/collisions/normal/face_vertex.cpp
+++ b/python/src/collisions/normal/face_vertex.cpp
@@ -2,21 +2,18 @@
 
 #include <ipc/collisions/normal/face_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_face_vertex_normal_collision(py::module_& m)
 {
     py::class_<FaceVertexNormalCollision, FaceVertexCandidate, NormalCollision>(
         m, "FaceVertexNormalCollision")
-        .def(
-            py::init<index_t, index_t>(), "", py::arg("face_id"),
-            py::arg("vertex_id"))
-        .def(py::init<const FaceVertexCandidate&>(), py::arg("candidate"));
+        .def(py::init<index_t, index_t>(), "", "face_id"_a, "vertex_id"_a)
+        .def(py::init<const FaceVertexCandidate&>(), "candidate"_a);
     // .def(
     //     py::init<
     //         const index_t, const index_t, const double,
     //         const Eigen::SparseVector<double>&>(),
-    //     py::arg("face_id"), py::arg("vertex_id"), py::arg("weight"),
-    //     py::arg("weight_gradient"));
+    //     "face_id"_a, "vertex_id"_a, "weight"_a,
+    //     "weight_gradient"_a);
 }

--- a/python/src/collisions/normal/normal_collision.cpp
+++ b/python/src/collisions/normal/normal_collision.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/normal/normal_collision.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_normal_collision(py::module_& m)
@@ -22,7 +21,7 @@ void define_normal_collision(py::module_& m)
             Returns:
                 The mollifier threshold.
             )ipc_Qu8mg5v7",
-            py::arg("rest_positions"))
+            "rest_positions"_a)
         .def(
             "mollifier",
             py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
@@ -36,7 +35,7 @@ void define_normal_collision(py::module_& m)
             Returns:
                 The mollifier value.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "mollifier",
             py::overload_cast<Eigen::ConstRef<VectorMax12d>, double>(
@@ -51,7 +50,7 @@ void define_normal_collision(py::module_& m)
             Returns:
                 The mollifier value.
             )ipc_Qu8mg5v7",
-            py::arg("positions"), py::arg("eps_x"))
+            "positions"_a, "eps_x"_a)
         .def(
             "mollifier_gradient",
             py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
@@ -65,7 +64,7 @@ void define_normal_collision(py::module_& m)
             Returns:
                 The mollifier gradient.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "mollifier_gradient",
             py::overload_cast<Eigen::ConstRef<VectorMax12d>, double>(
@@ -80,7 +79,7 @@ void define_normal_collision(py::module_& m)
             Returns:
                 The mollifier gradient.
             )ipc_Qu8mg5v7",
-            py::arg("positions"), py::arg("eps_x"))
+            "positions"_a, "eps_x"_a)
         .def(
             "mollifier_hessian",
             py::overload_cast<Eigen::ConstRef<VectorMax12d>>(
@@ -94,7 +93,7 @@ void define_normal_collision(py::module_& m)
             Returns:
                 The mollifier Hessian.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "mollifier_hessian",
             py::overload_cast<Eigen::ConstRef<VectorMax12d>, double>(
@@ -109,7 +108,7 @@ void define_normal_collision(py::module_& m)
             Returns:
                 The mollifier Hessian.
             )ipc_Qu8mg5v7",
-            py::arg("positions"), py::arg("eps_x"))
+            "positions"_a, "eps_x"_a)
         .def(
             "mollifier_gradient_wrt_x",
             &NormalCollision::mollifier_gradient_wrt_x,
@@ -123,7 +122,7 @@ void define_normal_collision(py::module_& m)
             Returns:
                 The mollifier gradient w.r.t. rest positions.
             )ipc_Qu8mg5v7",
-            py::arg("rest_positions"), py::arg("positions"))
+            "rest_positions"_a, "positions"_a)
         .def(
             "mollifier_gradient_jacobian_wrt_x",
             &NormalCollision::mollifier_gradient_jacobian_wrt_x,
@@ -137,7 +136,7 @@ void define_normal_collision(py::module_& m)
             Returns:
                 The jacobian of the mollifier's gradient w.r.t. rest positions.
             )ipc_Qu8mg5v7",
-            py::arg("rest_positions"), py::arg("positions"))
+            "rest_positions"_a, "positions"_a)
         .def_readwrite(
             "dmin", &NormalCollision::dmin, "The minimum separation distance.")
         .def_readwrite(

--- a/python/src/collisions/normal/normal_collisions.cpp
+++ b/python/src/collisions/normal/normal_collisions.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/normal/normal_collisions.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_normal_collisions(py::module_& m)
@@ -25,9 +24,8 @@ void define_normal_collisions(py::module_& m)
                 dmin: Minimum distance.
                 broad_phase: Broad-phase to use.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("vertices"), py::arg("dhat"),
-            py::arg("dmin") = 0,
-            py::arg("broad_phase") = make_default_broad_phase())
+            "mesh"_a, "vertices"_a, "dhat"_a, "dmin"_a = 0,
+            "broad_phase"_a = make_default_broad_phase())
         .def(
             "build",
             py::overload_cast<
@@ -44,8 +42,7 @@ void define_normal_collisions(py::module_& m)
                 dhat: The activation distance of the barrier.
                 dmin:  Minimum distance.
             )ipc_Qu8mg5v7",
-            py::arg("candidates"), py::arg("mesh"), py::arg("vertices"),
-            py::arg("dhat"), py::arg("dmin") = 0)
+            "candidates"_a, "mesh"_a, "vertices"_a, "dhat"_a, "dmin"_a = 0)
         .def(
             "compute_minimum_distance",
             &NormalCollisions::compute_minimum_distance,
@@ -59,7 +56,7 @@ void define_normal_collisions(py::module_& m)
             Returns:
                 The minimum distance between any non-adjacent elements.
             )ipc_Qu8mg5v7",
-            py::arg("mesh"), py::arg("vertices"))
+            "mesh"_a, "vertices"_a)
         .def(
             "__len__", &NormalCollisions::size, "Get the number of collisions.")
         .def(
@@ -81,7 +78,7 @@ void define_normal_collisions(py::module_& m)
             Returns:
                 A reference to the collision.
             )ipc_Qu8mg5v7",
-            py::arg("i"))
+            "i"_a)
         .def(
             "is_vertex_vertex", &NormalCollisions::is_vertex_vertex,
             R"ipc_Qu8mg5v7(
@@ -93,7 +90,7 @@ void define_normal_collisions(py::module_& m)
             Returns:
                 If the collision at i is a vertex-vertex collision.
             )ipc_Qu8mg5v7",
-            py::arg("i"))
+            "i"_a)
         .def(
             "is_edge_vertex", &NormalCollisions::is_edge_vertex,
             R"ipc_Qu8mg5v7(
@@ -105,7 +102,7 @@ void define_normal_collisions(py::module_& m)
             Returns:
                 If the collision at i is an edge-vertex collision.
             )ipc_Qu8mg5v7",
-            py::arg("i"))
+            "i"_a)
         .def(
             "is_edge_edge", &NormalCollisions::is_edge_edge,
             R"ipc_Qu8mg5v7(
@@ -117,7 +114,7 @@ void define_normal_collisions(py::module_& m)
             Returns:
                 If the collision at i is an edge-edge collision.
             )ipc_Qu8mg5v7",
-            py::arg("i"))
+            "i"_a)
         .def(
             "is_face_vertex", &NormalCollisions::is_face_vertex,
             R"ipc_Qu8mg5v7(
@@ -129,7 +126,7 @@ void define_normal_collisions(py::module_& m)
             Returns:
                 If the collision at i is an face-vertex collision.
             )ipc_Qu8mg5v7",
-            py::arg("i"))
+            "i"_a)
         .def(
             "is_plane_vertex", &NormalCollisions::is_plane_vertex,
             R"ipc_Qu8mg5v7(
@@ -141,10 +138,8 @@ void define_normal_collisions(py::module_& m)
             Returns:
                 If the collision at i is an plane-vertex collision.
             )ipc_Qu8mg5v7",
-            py::arg("i"))
-        .def(
-            "__str__", &NormalCollisions::to_string, py::arg("mesh"),
-            py::arg("vertices"))
+            "i"_a)
+        .def("__str__", &NormalCollisions::to_string, "mesh"_a, "vertices"_a)
         .def_property(
             "use_area_weighting", &NormalCollisions::use_area_weighting,
             &NormalCollisions::set_use_area_weighting,

--- a/python/src/collisions/normal/plane_vertex.cpp
+++ b/python/src/collisions/normal/plane_vertex.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/normal/plane_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_plane_vertex_normal_collision(py::module_& m)
@@ -13,8 +12,7 @@ void define_plane_vertex_normal_collision(py::module_& m)
             py::init<
                 Eigen::ConstRef<VectorMax3d>, Eigen::ConstRef<VectorMax3d>,
                 const index_t>(),
-            py::arg("plane_origin"), py::arg("plane_normal"),
-            py::arg("vertex_id"))
+            "plane_origin"_a, "plane_normal"_a, "vertex_id"_a)
         .def_readwrite(
             "plane_origin", &PlaneVertexNormalCollision::plane_origin,
             "The plane's origin.")

--- a/python/src/collisions/normal/vertex_vertex.cpp
+++ b/python/src/collisions/normal/vertex_vertex.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/normal/vertex_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_vertex_vertex_normal_collision(py::module_& m)
@@ -10,14 +9,12 @@ void define_vertex_vertex_normal_collision(py::module_& m)
     py::class_<
         VertexVertexNormalCollision, VertexVertexCandidate, NormalCollision>(
         m, "VertexVertexNormalCollision")
-        .def(
-            py::init<index_t, index_t>(), "", py::arg("vertex0_id"),
-            py::arg("vertex1_id"))
-        .def(py::init<const VertexVertexCandidate&>(), py::arg("vv_candidate"));
+        .def(py::init<index_t, index_t>(), "", "vertex0_id"_a, "vertex1_id"_a)
+        .def(py::init<const VertexVertexCandidate&>(), "vv_candidate"_a);
     // .def(
     //     py::init<
     //         const index_t, const index_t, const double,
     //         const Eigen::SparseVector<double>&>(),
-    //     py::arg("vertex0_id"), py::arg("vertex1_id"), py::arg("weight"),
-    //     py::arg("weight_gradient"));
+    //     "vertex0_id"_a, "vertex1_id"_a, "weight"_a,
+    //     "weight_gradient"_a);
 }

--- a/python/src/collisions/tangential/bindings.hpp
+++ b/python/src/collisions/tangential/bindings.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-namespace py = pybind11;
 
 void define_tangential_collision(py::module_& m);
 void define_tangential_collisions(py::module_& m);

--- a/python/src/collisions/tangential/edge_edge.cpp
+++ b/python/src/collisions/tangential/edge_edge.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/tangential/edge_edge.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_edge_edge_tangential_collision(py::module_& m)
@@ -10,11 +9,11 @@ void define_edge_edge_tangential_collision(py::module_& m)
     py::class_<
         EdgeEdgeTangentialCollision, EdgeEdgeCandidate, TangentialCollision>(
         m, "EdgeEdgeTangentialCollision")
-        .def(py::init<const EdgeEdgeNormalCollision&>(), py::arg("collision"))
+        .def(py::init<const EdgeEdgeNormalCollision&>(), "collision"_a)
         .def(
             py::init<
                 const EdgeEdgeNormalCollision&, Eigen::ConstRef<VectorMax12d>,
                 const NormalPotential&, const double>(),
-            py::arg("collision"), py::arg("positions"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"));
+            "collision"_a, "positions"_a, "normal_potential"_a,
+            "normal_stiffness"_a);
 }

--- a/python/src/collisions/tangential/edge_vertex.cpp
+++ b/python/src/collisions/tangential/edge_vertex.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/tangential/edge_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_edge_vertex_tangential_collision(py::module_& m)
@@ -10,11 +9,11 @@ void define_edge_vertex_tangential_collision(py::module_& m)
     py::class_<
         EdgeVertexTangentialCollision, EdgeVertexCandidate,
         TangentialCollision>(m, "EdgeVertexTangentialCollision")
-        .def(py::init<const EdgeVertexNormalCollision&>(), py::arg("collision"))
+        .def(py::init<const EdgeVertexNormalCollision&>(), "collision"_a)
         .def(
             py::init<
                 const EdgeVertexNormalCollision&, Eigen::ConstRef<VectorMax12d>,
                 const NormalPotential&, const double>(),
-            py::arg("collision"), py::arg("positions"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"));
+            "collision"_a, "positions"_a, "normal_potential"_a,
+            "normal_stiffness"_a);
 }

--- a/python/src/collisions/tangential/face_vertex.cpp
+++ b/python/src/collisions/tangential/face_vertex.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/tangential/face_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_face_vertex_tangential_collision(py::module_& m)
@@ -10,11 +9,11 @@ void define_face_vertex_tangential_collision(py::module_& m)
     py::class_<
         FaceVertexTangentialCollision, FaceVertexCandidate,
         TangentialCollision>(m, "FaceVertexTangentialCollision")
-        .def(py::init<const FaceVertexNormalCollision&>(), py::arg("collision"))
+        .def(py::init<const FaceVertexNormalCollision&>(), "collision"_a)
         .def(
             py::init<
                 const FaceVertexNormalCollision&, Eigen::ConstRef<VectorMax12d>,
                 const NormalPotential&, const double>(),
-            py::arg("collision"), py::arg("positions"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"));
+            "collision"_a, "positions"_a, "normal_potential"_a,
+            "normal_stiffness"_a);
 }

--- a/python/src/collisions/tangential/tangential_collision.cpp
+++ b/python/src/collisions/tangential/tangential_collision.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/tangential/tangential_collision.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_tangential_collision(py::module_& m)
@@ -26,7 +25,7 @@ void define_tangential_collision(py::module_& m)
             Returns:
                 Tangent basis of the collision.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "compute_tangent_basis_jacobian",
             &TangentialCollision::compute_tangent_basis_jacobian,
@@ -39,7 +38,7 @@ void define_tangential_collision(py::module_& m)
             Returns:
                 Jacobian of the tangent basis of the collision.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "compute_closest_point",
             &TangentialCollision::compute_closest_point,
@@ -52,7 +51,7 @@ void define_tangential_collision(py::module_& m)
             Returns:
                 Barycentric coordinates of the closest point.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "compute_closest_point_jacobian",
             &TangentialCollision::compute_closest_point_jacobian,
@@ -65,7 +64,7 @@ void define_tangential_collision(py::module_& m)
             Returns:
                 Jacobian of the barycentric coordinates of the closest point.
             )ipc_Qu8mg5v7",
-            py::arg("positions"))
+            "positions"_a)
         .def(
             "relative_velocity", &TangentialCollision::relative_velocity,
             R"ipc_Qu8mg5v7(
@@ -77,7 +76,7 @@ void define_tangential_collision(py::module_& m)
             Returns:
                 Relative velocity of the collision.
             )ipc_Qu8mg5v7",
-            py::arg("velocities"))
+            "velocities"_a)
         .def(
             "relative_velocity_matrix",
             py::overload_cast<>(
@@ -104,7 +103,7 @@ void define_tangential_collision(py::module_& m)
             Returns:
                 A matrix M such that `relative_velocity = M * velocities`.
             )ipc_Qu8mg5v7",
-            py::arg("closest_point"))
+            "closest_point"_a)
         .def(
             "relative_velocity_matrix_jacobian",
             &TangentialCollision::relative_velocity_matrix_jacobian,
@@ -117,7 +116,7 @@ void define_tangential_collision(py::module_& m)
             Returns:
                 Jacobian of the relative velocity premultiplier wrt the closest points.
             )ipc_Qu8mg5v7",
-            py::arg("closest_point"))
+            "closest_point"_a)
         .def_readwrite(
             "normal_force_magnitude",
             &TangentialCollision::normal_force_magnitude,

--- a/python/src/collisions/tangential/tangential_collisions.cpp
+++ b/python/src/collisions/tangential/tangential_collisions.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/tangential/tangential_collisions.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_tangential_collisions(py::module_& m)
@@ -15,9 +14,8 @@ void define_tangential_collisions(py::module_& m)
                 const CollisionMesh&, Eigen::ConstRef<Eigen::MatrixXd>,
                 const NormalCollisions&, const NormalPotential&, double,
                 double>(&TangentialCollisions::build),
-            py::arg("mesh"), py::arg("vertices"), py::arg("collisions"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"),
-            py::arg("mu"))
+            "mesh"_a, "vertices"_a, "collisions"_a, "normal_potential"_a,
+            "normal_stiffness"_a, "mu"_a)
         .def(
             "build",
             [](TangentialCollisions& self, const CollisionMesh& mesh,
@@ -30,9 +28,8 @@ void define_tangential_collisions(py::module_& m)
                     mesh, vertices, collisions, normal_potential,
                     normal_stiffness, mus);
             },
-            py::arg("mesh"), py::arg("vertices"), py::arg("collisions"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"),
-            py::arg("mus"))
+            "mesh"_a, "vertices"_a, "collisions"_a, "normal_potential"_a,
+            "normal_stiffness"_a, "mus"_a)
         .def(
             "build",
             py::overload_cast<
@@ -41,9 +38,8 @@ void define_tangential_collisions(py::module_& m)
                 Eigen::ConstRef<Eigen::VectorXd>,
                 const std::function<double(double, double)>&>(
                 &TangentialCollisions::build),
-            py::arg("mesh"), py::arg("vertices"), py::arg("collisions"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"),
-            py::arg("mus"), py::arg("blend_mu"))
+            "mesh"_a, "vertices"_a, "collisions"_a, "normal_potential"_a,
+            "normal_stiffness"_a, "mus"_a, "blend_mu"_a)
         .def(
             "__len__", &TangentialCollisions::size,
             "Get the number of friction collisions.")
@@ -68,10 +64,10 @@ void define_tangential_collisions(py::module_& m)
             Returns:
                 A reference to the collision.
             )ipc_Qu8mg5v7",
-            py::arg("i"))
+            "i"_a)
         .def_static(
             "default_blend_mu", &TangentialCollisions::default_blend_mu,
-            py::arg("mu0"), py::arg("mu1"))
+            "mu0"_a, "mu1"_a)
         .def_readwrite("vv_collisions", &TangentialCollisions::vv_collisions)
         .def_readwrite("ev_collisions", &TangentialCollisions::ev_collisions)
         .def_readwrite("ee_collisions", &TangentialCollisions::ee_collisions)

--- a/python/src/collisions/tangential/vertex_vertex.cpp
+++ b/python/src/collisions/tangential/vertex_vertex.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/collisions/tangential/vertex_vertex.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_vertex_vertex_tangential_collision(py::module_& m)
@@ -10,14 +9,12 @@ void define_vertex_vertex_tangential_collision(py::module_& m)
     py::class_<
         VertexVertexTangentialCollision, VertexVertexCandidate,
         TangentialCollision>(m, "VertexVertexTangentialCollision")
-        .def(
-            py::init<const VertexVertexNormalCollision&>(),
-            py::arg("collision"))
+        .def(py::init<const VertexVertexNormalCollision&>(), "collision"_a)
         .def(
             py::init<
                 const VertexVertexNormalCollision&,
                 Eigen::ConstRef<VectorMax12d>, const NormalPotential&,
                 const double>(),
-            py::arg("collision"), py::arg("positions"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"));
+            "collision"_a, "positions"_a, "normal_potential"_a,
+            "normal_stiffness"_a);
 }

--- a/python/src/common.hpp
+++ b/python/src/common.hpp
@@ -9,6 +9,9 @@
 #include <pybind11/eigen.h>
 #include <pybind11/functional.h>
 
+namespace py = pybind11;
+using namespace py::literals;
+
 #include <Eigen/Core>
 #include <Eigen/Sparse>
 
@@ -17,7 +20,7 @@ void assert_2D_or_3D_vector(
     const Eigen::MatrixBase<Derived>& v, const std::string& name)
 {
     if ((v.size() != 2 && v.size() != 3) || (v.rows() != 1 && v.cols() != 1)) {
-        throw pybind11::value_error(
+        throw py::value_error(
             "Parameter " + name + " has invalid size: expected " + name
             + " to be a 2D or 3D vector but got " + name + ".shape = ["
             + std::to_string(v.rows()) + ", " + std::to_string(v.cols()) + "]");
@@ -29,7 +32,7 @@ void assert_3D_vector(
     const Eigen::MatrixBase<Derived>& v, const std::string& name)
 {
     if (v.size() != 3 || (v.rows() != 1 && v.cols() != 1)) {
-        throw pybind11::value_error(
+        throw py::value_error(
             "Parameter " + name + " has invalid size: expected " + name
             + " to be a 3D vector but got " + name + ".shape = ["
             + std::to_string(v.rows()) + ", " + std::to_string(v.cols()) + "]");
@@ -41,7 +44,7 @@ inline void assert_is_sparse_vector(
     const Eigen::SparseMatrix<T>& M, const std::string& name)
 {
     if (M.cols() != 1) {
-        throw pybind11::value_error(
+        throw py::value_error(
             "Parameter " + name + " has invalid size: expected " + name
             + " to be a sparse vector but got " + name + ".shape = ["
             + std::to_string(M.rows()) + ", " + std::to_string(M.cols()) + "]");

--- a/python/src/distance/bindings.hpp
+++ b/python/src/distance/bindings.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-namespace py = pybind11;
 
 void define_distance_type(py::module_& m);
 void define_edge_edge_mollifier(py::module_& m);

--- a/python/src/distance/distance_type.cpp
+++ b/python/src/distance/distance_type.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/distance/distance_type.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_distance_type(py::module_& m)
@@ -99,7 +98,7 @@ void define_distance_type(py::module_& m)
         Returns:
             The distance type of the point-edge pair.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"));
+        "p"_a, "e0"_a, "e1"_a);
 
     m.def(
         "point_triangle_distance_type", &point_triangle_distance_type,
@@ -115,7 +114,7 @@ void define_distance_type(py::module_& m)
         Returns:
             The distance type of the point-triangle pair.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"));
+        "p"_a, "t0"_a, "t1"_a, "t2"_a);
 
     m.def(
         "edge_edge_distance_type", &edge_edge_distance_type,
@@ -131,7 +130,7 @@ void define_distance_type(py::module_& m)
         Returns:
             The distance type of the edge-edge pair.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "edge_edge_parallel_distance_type", &edge_edge_parallel_distance_type,
@@ -147,5 +146,5 @@ void define_distance_type(py::module_& m)
         Returns:
             The distance type of the edge-edge pair.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 }

--- a/python/src/distance/edge_edge.cpp
+++ b/python/src/distance/edge_edge.cpp
@@ -3,7 +3,6 @@
 #include <ipc/distance/distance_type.hpp>
 #include <ipc/distance/edge_edge.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_edge_edge_distance(py::module_& m)
@@ -26,8 +25,8 @@ void define_edge_edge_distance(py::module_& m)
         Returns:
             The distance between the two edges.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"),
-        py::arg("dtype") = EdgeEdgeDistanceType::AUTO);
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a,
+        "dtype"_a = EdgeEdgeDistanceType::AUTO);
 
     m.def(
         "edge_edge_distance_gradient", &edge_edge_distance_gradient,
@@ -47,8 +46,8 @@ void define_edge_edge_distance(py::module_& m)
         Returns:
             The gradient of the distance wrt ea0, ea1, eb0, and eb1.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"),
-        py::arg("dtype") = EdgeEdgeDistanceType::AUTO);
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a,
+        "dtype"_a = EdgeEdgeDistanceType::AUTO);
 
     m.def(
         "edge_edge_distance_hessian", &edge_edge_distance_hessian,
@@ -68,6 +67,6 @@ void define_edge_edge_distance(py::module_& m)
         Returns:
             The hessian of the distance wrt ea0, ea1, eb0, and eb1.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"),
-        py::arg("dtype") = EdgeEdgeDistanceType::AUTO);
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a,
+        "dtype"_a = EdgeEdgeDistanceType::AUTO);
 }

--- a/python/src/distance/edge_edge_mollifier.cpp
+++ b/python/src/distance/edge_edge_mollifier.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/distance/edge_edge_mollifier.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_edge_edge_mollifier(py::module_& m)
@@ -21,7 +20,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The squared norm of the edge-edge cross product.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "edge_edge_cross_squarednorm_gradient",
@@ -43,7 +42,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The gradient of the squared norm of the edge cross product wrt ea0, ea1, eb0, and eb1.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "edge_edge_cross_squarednorm_hessian",
@@ -65,7 +64,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The hessian of the squared norm of the edge cross product wrt ea0, ea1, eb0, and eb1.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "edge_edge_mollifier",
@@ -80,7 +79,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The mollifier coefficient to premultiply the edge-edge distance.
         )ipc_Qu8mg5v7",
-        py::arg("x"), py::arg("eps_x"));
+        "x"_a, "eps_x"_a);
 
     m.def(
         "edge_edge_mollifier_gradient",
@@ -96,7 +95,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The gradient of the mollifier function for edge-edge distance wrt x.
         )ipc_Qu8mg5v7",
-        py::arg("x"), py::arg("eps_x"));
+        "x"_a, "eps_x"_a);
 
     m.def(
         "edge_edge_mollifier_derivative_wrt_eps_x",
@@ -111,7 +110,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The derivative of the mollifier function for edge-edge distance wrt eps_x.
         )ipc_Qu8mg5v7",
-        py::arg("x"), py::arg("eps_x"));
+        "x"_a, "eps_x"_a);
 
     m.def(
         "edge_edge_mollifier_hessian",
@@ -127,7 +126,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The hessian of the mollifier function for edge-edge distance wrt x.
         )ipc_Qu8mg5v7",
-        py::arg("x"), py::arg("eps_x"));
+        "x"_a, "eps_x"_a);
 
     m.def(
         "edge_edge_mollifier_gradient_derivative_wrt_eps_x",
@@ -142,7 +141,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The derivative of the gradient of the mollifier function for edge-edge distance wrt eps_x.
         )ipc_Qu8mg5v7",
-        py::arg("x"), py::arg("eps_x"));
+        "x"_a, "eps_x"_a);
 
     m.def(
         "edge_edge_mollifier",
@@ -167,8 +166,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The mollifier coefficient to premultiply the edge-edge distance.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"),
-        py::arg("eps_x"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a, "eps_x"_a);
 
     m.def(
         "edge_edge_mollifier_gradient",
@@ -191,8 +189,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The gradient of the mollifier.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"),
-        py::arg("eps_x"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a, "eps_x"_a);
 
     m.def(
         "edge_edge_mollifier_hessian",
@@ -215,8 +212,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The hessian of the mollifier.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"),
-        py::arg("eps_x"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a, "eps_x"_a);
 
     m.def(
         "edge_edge_mollifier_gradient_wrt_x",
@@ -237,9 +233,8 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The derivative of the mollifier wrt rest positions.
         )ipc_Qu8mg5v7",
-        py::arg("ea0_rest"), py::arg("ea1_rest"), py::arg("eb0_rest"),
-        py::arg("eb1_rest"), py::arg("ea0"), py::arg("ea1"), py::arg("eb0"),
-        py::arg("eb1"));
+        "ea0_rest"_a, "ea1_rest"_a, "eb0_rest"_a, "eb1_rest"_a, "ea0"_a,
+        "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "edge_edge_mollifier_gradient_jacobian_wrt_x",
@@ -263,9 +258,8 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             The jacobian of the mollifier's gradient wrt rest positions.
         )ipc_Qu8mg5v7",
-        py::arg("ea0_rest"), py::arg("ea1_rest"), py::arg("eb0_rest"),
-        py::arg("eb1_rest"), py::arg("ea0"), py::arg("ea1"), py::arg("eb0"),
-        py::arg("eb1"));
+        "ea0_rest"_a, "ea1_rest"_a, "eb0_rest"_a, "eb1_rest"_a, "ea0"_a,
+        "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "edge_edge_mollifier_threshold", &edge_edge_mollifier_threshold,
@@ -283,8 +277,7 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             Threshold for edge-edge mollification.
         )ipc_Qu8mg5v7",
-        py::arg("ea0_rest"), py::arg("ea1_rest"), py::arg("eb0_rest"),
-        py::arg("eb1_rest"));
+        "ea0_rest"_a, "ea1_rest"_a, "eb0_rest"_a, "eb1_rest"_a);
 
     m.def(
         "edge_edge_mollifier_threshold_gradient",
@@ -303,6 +296,5 @@ void define_edge_edge_mollifier(py::module_& m)
         Returns:
             Gradient of the threshold for edge-edge mollification.
         )ipc_Qu8mg5v7",
-        py::arg("ea0_rest"), py::arg("ea1_rest"), py::arg("eb0_rest"),
-        py::arg("eb1_rest"));
+        "ea0_rest"_a, "ea1_rest"_a, "eb0_rest"_a, "eb1_rest"_a);
 }

--- a/python/src/distance/line_line.cpp
+++ b/python/src/distance/line_line.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/distance/line_line.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_line_line_distance(py::module_& m)
@@ -27,7 +26,7 @@ void define_line_line_distance(py::module_& m)
         Returns:
             The distance between the two lines.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "line_line_distance_gradient", &line_line_distance_gradient,
@@ -49,7 +48,7 @@ void define_line_line_distance(py::module_& m)
         Returns:
             The gradient of the distance wrt ea0, ea1, eb0, and eb1.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "line_line_distance_hessian", &line_line_distance_hessian,
@@ -71,5 +70,5 @@ void define_line_line_distance(py::module_& m)
         Returns:
             The hessian of the distance wrt ea0, ea1, eb0, and eb1.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 }

--- a/python/src/distance/point_edge.cpp
+++ b/python/src/distance/point_edge.cpp
@@ -3,7 +3,6 @@
 #include <ipc/distance/distance_type.hpp>
 #include <ipc/distance/point_edge.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_point_edge_distance(py::module_& m)
@@ -25,8 +24,7 @@ void define_point_edge_distance(py::module_& m)
         Returns:
             The distance between the point and edge.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"),
-        py::arg("dtype") = PointEdgeDistanceType::AUTO);
+        "p"_a, "e0"_a, "e1"_a, "dtype"_a = PointEdgeDistanceType::AUTO);
 
     m.def(
         "point_edge_distance_gradient", &point_edge_distance_gradient,
@@ -45,8 +43,7 @@ void define_point_edge_distance(py::module_& m)
         Returns:
             grad The gradient of the distance wrt p, e0, and e1.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"),
-        py::arg("dtype") = PointEdgeDistanceType::AUTO);
+        "p"_a, "e0"_a, "e1"_a, "dtype"_a = PointEdgeDistanceType::AUTO);
 
     m.def(
         "point_edge_distance_hessian", &point_edge_distance_hessian,
@@ -65,6 +62,5 @@ void define_point_edge_distance(py::module_& m)
         Returns:
             hess The hessian of the distance wrt p, e0, and e1.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"),
-        py::arg("dtype") = PointEdgeDistanceType::AUTO);
+        "p"_a, "e0"_a, "e1"_a, "dtype"_a = PointEdgeDistanceType::AUTO);
 }

--- a/python/src/distance/point_line.cpp
+++ b/python/src/distance/point_line.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/distance/point_line.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_point_line_distance(py::module_& m)
@@ -23,7 +22,7 @@ void define_point_line_distance(py::module_& m)
         Returns:
             The distance between the point and line.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"));
+        "p"_a, "e0"_a, "e1"_a);
 
     m.def(
         "point_line_distance_gradient", &point_line_distance_gradient,
@@ -41,7 +40,7 @@ void define_point_line_distance(py::module_& m)
         Returns:
             The gradient of the distance wrt p, e0, and e1.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"));
+        "p"_a, "e0"_a, "e1"_a);
 
     m.def(
         "point_line_distance_hessian", &point_line_distance_hessian,
@@ -59,5 +58,5 @@ void define_point_line_distance(py::module_& m)
         Returns:
             The hessian of the distance wrt p, e0, and e1.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"));
+        "p"_a, "e0"_a, "e1"_a);
 }

--- a/python/src/distance/point_plane.cpp
+++ b/python/src/distance/point_plane.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/distance/point_plane.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_point_plane_distance(py::module_& m)
@@ -27,7 +26,7 @@ void define_point_plane_distance(py::module_& m)
         Returns:
             The distance between the point and plane.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("origin"), py::arg("normal"));
+        "p"_a, "origin"_a, "normal"_a);
 
     m.def(
         "point_plane_distance",
@@ -51,7 +50,7 @@ void define_point_plane_distance(py::module_& m)
         Returns:
             The distance between the point and plane.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"));
+        "p"_a, "t0"_a, "t1"_a, "t2"_a);
 
     m.def(
         "point_plane_distance_gradient",
@@ -74,7 +73,7 @@ void define_point_plane_distance(py::module_& m)
         Returns:
             The gradient of the distance wrt p.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("origin"), py::arg("normal"));
+        "p"_a, "origin"_a, "normal"_a);
 
     m.def(
         "point_plane_distance_gradient",
@@ -99,7 +98,7 @@ void define_point_plane_distance(py::module_& m)
         Returns:
             The gradient of the distance wrt p, t0, t1, and t2.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"));
+        "p"_a, "t0"_a, "t1"_a, "t2"_a);
 
     m.def(
         "point_plane_distance_hessian",
@@ -122,7 +121,7 @@ void define_point_plane_distance(py::module_& m)
         Returns:
             The hessian of the distance wrt p.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("origin"), py::arg("normal"));
+        "p"_a, "origin"_a, "normal"_a);
 
     m.def(
         "point_plane_distance_hessian",
@@ -147,5 +146,5 @@ void define_point_plane_distance(py::module_& m)
         Returns:
             The hessian of the distance wrt p, t0, t1, and t2.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"));
+        "p"_a, "t0"_a, "t1"_a, "t2"_a);
 }

--- a/python/src/distance/point_point.cpp
+++ b/python/src/distance/point_point.cpp
@@ -3,7 +3,6 @@
 #include <ipc/distance/point_point.hpp>
 #include <ipc/distance/point_triangle.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_point_point_distance(py::module_& m)
@@ -23,7 +22,7 @@ void define_point_point_distance(py::module_& m)
         Returns:
             The distance between p0 and p1.
         )ipc_Qu8mg5v7",
-        py::arg("p0"), py::arg("p1"));
+        "p0"_a, "p1"_a);
 
     m.def(
         "point_point_distance_gradient", &point_point_distance_gradient,
@@ -40,7 +39,7 @@ void define_point_point_distance(py::module_& m)
         Returns:
             The computed gradient.
         )ipc_Qu8mg5v7",
-        py::arg("p0"), py::arg("p1"));
+        "p0"_a, "p1"_a);
 
     m.def(
         "point_point_distance_hessian", &point_point_distance_hessian,
@@ -57,5 +56,5 @@ void define_point_point_distance(py::module_& m)
         Returns:
             The computed hessian.
         )ipc_Qu8mg5v7",
-        py::arg("p0"), py::arg("p1"));
+        "p0"_a, "p1"_a);
 }

--- a/python/src/distance/point_triangle.cpp
+++ b/python/src/distance/point_triangle.cpp
@@ -3,7 +3,6 @@
 #include <ipc/distance/distance_type.hpp>
 #include <ipc/distance/point_triangle.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_point_triangle_distance(py::module_& m)
@@ -26,8 +25,8 @@ void define_point_triangle_distance(py::module_& m)
         Returns:
             The distance between the point and triangle.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"),
-        py::arg("dtype") = PointTriangleDistanceType::AUTO);
+        "p"_a, "t0"_a, "t1"_a, "t2"_a,
+        "dtype"_a = PointTriangleDistanceType::AUTO);
 
     m.def(
         "point_triangle_distance_gradient", &point_triangle_distance_gradient,
@@ -47,8 +46,8 @@ void define_point_triangle_distance(py::module_& m)
         Returns:
             The gradient of the distance wrt p, t0, t1, and t2.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"),
-        py::arg("dtype") = PointTriangleDistanceType::AUTO);
+        "p"_a, "t0"_a, "t1"_a, "t2"_a,
+        "dtype"_a = PointTriangleDistanceType::AUTO);
 
     m.def(
         "point_triangle_distance_hessian", &point_triangle_distance_hessian,
@@ -68,6 +67,6 @@ void define_point_triangle_distance(py::module_& m)
         Returns:
             The hessian of the distance wrt p, t0, t1, and t2.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"),
-        py::arg("dtype") = PointTriangleDistanceType::AUTO);
+        "p"_a, "t0"_a, "t1"_a, "t2"_a,
+        "dtype"_a = PointTriangleDistanceType::AUTO);
 }

--- a/python/src/friction/bindings.hpp
+++ b/python/src/friction/bindings.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-namespace py = pybind11;
 
 void define_smooth_friction_mollifier(py::module_& m);

--- a/python/src/friction/smooth_friction_mollifier.cpp
+++ b/python/src/friction/smooth_friction_mollifier.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/friction/smooth_friction_mollifier.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_smooth_friction_mollifier(py::module_& m)
@@ -28,7 +27,7 @@ void define_smooth_friction_mollifier(py::module_& m)
         Returns:
             The value of the mollifier function at y.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_v"));
+        "y"_a, "eps_v"_a);
 
     m.def(
         "smooth_friction_f1", &smooth_friction_f1,
@@ -49,7 +48,7 @@ void define_smooth_friction_mollifier(py::module_& m)
         Returns:
             The value of the derivative of the smooth friction mollifier at y.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_v"));
+        "y"_a, "eps_v"_a);
 
     m.def(
         "smooth_friction_f2", &smooth_friction_f2,
@@ -70,7 +69,7 @@ void define_smooth_friction_mollifier(py::module_& m)
         Returns:
             The value of the second derivative of the smooth friction mollifier at y.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_v"));
+        "y"_a, "eps_v"_a);
 
     m.def(
         "smooth_friction_f1_over_x", &smooth_friction_f1_over_x,
@@ -91,7 +90,7 @@ void define_smooth_friction_mollifier(py::module_& m)
         Returns:
             The value of the derivative of smooth_friction_f0 divided by y.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_v"));
+        "y"_a, "eps_v"_a);
 
     m.def(
         "smooth_friction_f2_x_minus_f1_over_x3",
@@ -113,5 +112,5 @@ void define_smooth_friction_mollifier(py::module_& m)
         Returns:
             The derivative of f1 times y minus f1 all divided by y cubed.
         )ipc_Qu8mg5v7",
-        py::arg("y"), py::arg("eps_v"));
+        "y"_a, "eps_v"_a);
 }

--- a/python/src/implicits/bindings.hpp
+++ b/python/src/implicits/bindings.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-namespace py = pybind11;
 
 void define_plane_implicit(py::module_& m);

--- a/python/src/implicits/plane.cpp
+++ b/python/src/implicits/plane.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/implicits/plane.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_plane_implicit(py::module_& m)
@@ -37,8 +36,8 @@ void define_plane_implicit(py::module_& m)
         Returns:
             The constructed set of collisions.
         )ipc_Qu8mg5v7",
-        py::arg("points"), py::arg("plane_origins"), py::arg("plane_normals"),
-        py::arg("dhat"), py::arg("dmin") = 0);
+        "points"_a, "plane_origins"_a, "plane_normals"_a, "dhat"_a,
+        "dmin"_a = 0);
 
     m.def(
         "construct_point_plane_collisions",
@@ -72,8 +71,8 @@ void define_plane_implicit(py::module_& m)
         Returns:
             The constructed set of collisions.
         )ipc_Qu8mg5v7",
-        py::arg("points"), py::arg("plane_origins"), py::arg("plane_normals"),
-        py::arg("dhat"), py::arg("dmin"), py::arg("can_collide"));
+        "points"_a, "plane_origins"_a, "plane_normals"_a, "dhat"_a, "dmin"_a,
+        "can_collide"_a);
 
     m.def(
         "is_step_point_plane_collision_free",
@@ -99,8 +98,7 @@ void define_plane_implicit(py::module_& m)
         Returns:
             True if <b>any</b> collisions occur.
         )ipc_Qu8mg5v7",
-        py::arg("points_t0"), py::arg("points_t1"), py::arg("plane_origins"),
-        py::arg("plane_normals"));
+        "points_t0"_a, "points_t1"_a, "plane_origins"_a, "plane_normals"_a);
 
     m.def(
         "is_step_point_plane_collision_free",
@@ -129,8 +127,8 @@ void define_plane_implicit(py::module_& m)
         Returns:
             True if <b>any</b> collisions occur.
         )ipc_Qu8mg5v7",
-        py::arg("points_t0"), py::arg("points_t1"), py::arg("plane_origins"),
-        py::arg("plane_normals"), py::arg("can_collide"));
+        "points_t0"_a, "points_t1"_a, "plane_origins"_a, "plane_normals"_a,
+        "can_collide"_a);
 
     m.def(
         "compute_point_plane_collision_free_stepsize",
@@ -159,8 +157,7 @@ void define_plane_implicit(py::module_& m)
         Returns:
             A step-size $\in [0, 1]$ that is collision free.
         )ipc_Qu8mg5v7",
-        py::arg("points_t0"), py::arg("points_t1"), py::arg("plane_origins"),
-        py::arg("plane_normals"));
+        "points_t0"_a, "points_t1"_a, "plane_origins"_a, "plane_normals"_a);
 
     m.def(
         "compute_point_plane_collision_free_stepsize",
@@ -191,6 +188,6 @@ void define_plane_implicit(py::module_& m)
         Returns:
             A step-size $\in [0, 1]$ that is collision free.
         )ipc_Qu8mg5v7",
-        py::arg("points_t0"), py::arg("points_t1"), py::arg("plane_origins"),
-        py::arg("plane_normals"), py::arg("can_collide"));
+        "points_t0"_a, "points_t1"_a, "plane_origins"_a, "plane_normals"_a,
+        "can_collide"_a);
 }

--- a/python/src/ipc.cpp
+++ b/python/src/ipc.cpp
@@ -5,7 +5,6 @@
 
 #include <igl/edges.h>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_ipc(py::module_& m)
@@ -31,10 +30,9 @@ void define_ipc(py::module_& m)
         Returns:
             True if <b>any</b> collisions occur.
         )ipc_Qu8mg5v7",
-        py::arg("mesh"), py::arg("vertices_t0"), py::arg("vertices_t1"),
-        py::arg("min_distance") = 0.0,
-        py::arg("broad_phase") = make_default_broad_phase(),
-        py::arg("narrow_phase_ccd") = DEFAULT_NARROW_PHASE_CCD);
+        "mesh"_a, "vertices_t0"_a, "vertices_t1"_a, "min_distance"_a = 0.0,
+        "broad_phase"_a = make_default_broad_phase(),
+        "narrow_phase_ccd"_a = DEFAULT_NARROW_PHASE_CCD);
 
     m.def(
         "compute_collision_free_stepsize", &compute_collision_free_stepsize,
@@ -55,10 +53,9 @@ void define_ipc(py::module_& m)
         Returns:
             A step-size :math:`\in [0, 1]` that is collision free. A value of 1.0 if a full step and 0.0 is no step.
         )ipc_Qu8mg5v7",
-        py::arg("mesh"), py::arg("vertices_t0"), py::arg("vertices_t1"),
-        py::arg("min_distance") = 0.0,
-        py::arg("broad_phase") = make_default_broad_phase(),
-        py::arg("narrow_phase_ccd") = DEFAULT_NARROW_PHASE_CCD);
+        "mesh"_a, "vertices_t0"_a, "vertices_t1"_a, "min_distance"_a = 0.0,
+        "broad_phase"_a = make_default_broad_phase(),
+        "narrow_phase_ccd"_a = DEFAULT_NARROW_PHASE_CCD);
 
     m.def(
         "has_intersections", &has_intersections,
@@ -73,8 +70,7 @@ void define_ipc(py::module_& m)
         Returns:
             A boolean for if the mesh has intersections.
         )ipc_Qu8mg5v7",
-        py::arg("mesh"), py::arg("vertices"),
-        py::arg("broad_phase") = make_default_broad_phase());
+        "mesh"_a, "vertices"_a, "broad_phase"_a = make_default_broad_phase());
 
     m.def(
         "edges",
@@ -92,5 +88,5 @@ void define_ipc(py::module_& m)
         Returns:
             #E by 2 list of edges in no particular order
         )ipc_Qu8mg5v7",
-        py::arg("F"));
+        "F"_a);
 }

--- a/python/src/potentials/barrier_potential.cpp
+++ b/python/src/potentials/barrier_potential.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/potentials/barrier_potential.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_barrier_potential(py::module_& m)
@@ -16,7 +15,7 @@ void define_barrier_potential(py::module_& m)
             Parameters:
                 dhat: The activation distance of the barrier.
             )ipc_Qu8mg5v7",
-            py::arg("dhat"), py::arg("use_physical_barrier") = false)
+            "dhat"_a, "use_physical_barrier"_a = false)
         .def(
             py::init<
                 const std::shared_ptr<Barrier>, const double, const bool>(),
@@ -27,8 +26,7 @@ void define_barrier_potential(py::module_& m)
                 barrier: The barrier function.
                 dhat: The activation distance of the barrier.
             )ipc_Qu8mg5v7",
-            py::arg("barrier"), py::arg("dhat"),
-            py::arg("use_physical_barrier") = false)
+            "barrier"_a, "dhat"_a, "use_physical_barrier"_a = false)
         .def_property(
             "dhat", &BarrierPotential::dhat, &BarrierPotential::set_dhat,
             "Barrier activation distance.")

--- a/python/src/potentials/bindings.hpp
+++ b/python/src/potentials/bindings.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-namespace py = pybind11;
 
 void define_barrier_potential(py::module_& m);
 void define_friction_potential(py::module_& m);

--- a/python/src/potentials/friction_potential.cpp
+++ b/python/src/potentials/friction_potential.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/potentials/friction_potential.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_friction_potential(py::module_& m)
@@ -16,7 +15,7 @@ void define_friction_potential(py::module_& m)
             Parameters:
                 eps_v: The smooth friction mollifier parameter :math:`\\epsilon_{v}`.
             )ipc_Qu8mg5v7",
-            py::arg("eps_v"))
+            "eps_v"_a)
         .def_property(
             "eps_v", &FrictionPotential::eps_v, &FrictionPotential::set_eps_v,
             "The smooth friction mollifier parameter :math:`\\epsilon_{v}`.");

--- a/python/src/potentials/normal_adhesion_potential.cpp
+++ b/python/src/potentials/normal_adhesion_potential.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/potentials/normal_adhesion_potential.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_normal_adhesion_potential(py::module_& m)
@@ -11,8 +10,7 @@ void define_normal_adhesion_potential(py::module_& m)
         m, "NormalAdhesionPotential")
         .def(
             py::init<const double, const double, const double, const double>(),
-            py::arg("dhat_p"), py::arg("dhat_a"), py::arg("Y"),
-            py::arg("eps_c"))
+            "dhat_p"_a, "dhat_a"_a, "Y"_a, "eps_c"_a)
         .def_readwrite(
             "dhat_p", &NormalAdhesionPotential::dhat_p,
             "The distance of largest adhesion force (:math:`\\hat{d}_{p}`) (:math:`0 < \\hat{d}_{p} < \\hat{d}_{a}`).")

--- a/python/src/potentials/normal_potential.cpp
+++ b/python/src/potentials/normal_potential.cpp
@@ -3,7 +3,6 @@
 
 #include <ipc/potentials/normal_potential.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_normal_potential(py::module_& m)
@@ -32,7 +31,7 @@ void define_normal_potential(py::module_& m)
             Returns:
                 The derivative of the force with respect to X, the rest vertices.
             )ipc_Qu8mg5v7",
-            py::arg("collisions"), py::arg("mesh"), py::arg("vertices"))
+            "collisions"_a, "mesh"_a, "vertices"_a)
         .def(
             "shape_derivative",
             [](const NormalPotential& self, const NormalCollision& collision,
@@ -54,8 +53,7 @@ void define_normal_potential(py::module_& m)
                 positions: The collision stencil's positions.
                 ,out]: out Store the triplets of the shape derivative here.
             )ipc_Qu8mg5v7",
-            py::arg("collision"), py::arg("vertex_ids"),
-            py::arg("rest_positions"), py::arg("positions"))
+            "collision"_a, "vertex_ids"_a, "rest_positions"_a, "positions"_a)
         .def(
             "force_magnitude", &NormalPotential::force_magnitude,
             R"ipc_Qu8mg5v7(
@@ -69,8 +67,7 @@ void define_normal_potential(py::module_& m)
             Returns:
                 The force magnitude.
             )ipc_Qu8mg5v7",
-            py::arg("distance_squared"), py::arg("dmin"),
-            py::arg("barrier_stiffness"))
+            "distance_squared"_a, "dmin"_a, "barrier_stiffness"_a)
         .def(
             "force_magnitude_gradient",
             &NormalPotential::force_magnitude_gradient,
@@ -86,6 +83,6 @@ void define_normal_potential(py::module_& m)
             Returns:
                 The gradient of the force.
             )ipc_Qu8mg5v7",
-            py::arg("distance_squared"), py::arg("distance_squared_gradient"),
-            py::arg("dmin"), py::arg("barrier_stiffness"));
+            "distance_squared"_a, "distance_squared_gradient"_a, "dmin"_a,
+            "barrier_stiffness"_a);
 }

--- a/python/src/potentials/potential.hpp
+++ b/python/src/potentials/potential.hpp
@@ -2,7 +2,6 @@
 
 #include <ipc/potentials/potential.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 /// @brief Define the methods of the templated generic Potential class.
@@ -32,7 +31,7 @@ void define_potential_methods(PyClass& potential)
             Returns:
                 The potential for a set of collisions.
             )ipc_Qu8mg5v7",
-            py::arg("collisions"), py::arg("mesh"), py::arg("X"))
+            "collisions"_a, "mesh"_a, "X"_a)
         .def(
             "gradient",
             py::overload_cast<
@@ -50,7 +49,7 @@ void define_potential_methods(PyClass& potential)
             Returns:
                 The gradient of the potential w.r.t. X. This will have a size of |X|.
             )ipc_Qu8mg5v7",
-            py::arg("collisions"), py::arg("mesh"), py::arg("X"))
+            "collisions"_a, "mesh"_a, "X"_a)
         .def(
             "hessian",
             py::overload_cast<
@@ -69,8 +68,8 @@ void define_potential_methods(PyClass& potential)
             Returns:
                 The Hessian of the potential w.r.t. X. This will have a size of |X|×|X|.
             )ipc_Qu8mg5v7",
-            py::arg("collisions"), py::arg("mesh"), py::arg("X"),
-            py::arg("project_hessian_to_psd") = PSDProjectionMethod::NONE)
+            "collisions"_a, "mesh"_a, "X"_a,
+            "project_hessian_to_psd"_a = PSDProjectionMethod::NONE)
         .def(
             "__call__",
             py::overload_cast<const TCollision&, Eigen::ConstRef<VectorMax12d>>(
@@ -85,7 +84,7 @@ void define_potential_methods(PyClass& potential)
             Returns:
                 The potential.
             )ipc_Qu8mg5v7",
-            py::arg("collision"), py::arg("x"))
+            "collision"_a, "x"_a)
         .def(
             "gradient",
             py::overload_cast<const TCollision&, Eigen::ConstRef<VectorMax12d>>(
@@ -100,7 +99,7 @@ void define_potential_methods(PyClass& potential)
             Returns:
                 The gradient of the potential.
             )ipc_Qu8mg5v7",
-            py::arg("collision"), py::arg("x"))
+            "collision"_a, "x"_a)
         .def(
             "hessian",
             py::overload_cast<
@@ -117,6 +116,6 @@ void define_potential_methods(PyClass& potential)
             Returns:
                 The hessian of the potential.
             )ipc_Qu8mg5v7",
-            py::arg("collision"), py::arg("x"),
-            py::arg("project_hessian_to_psd") = PSDProjectionMethod::NONE);
+            "collision"_a, "x"_a,
+            "project_hessian_to_psd"_a = PSDProjectionMethod::NONE);
 }

--- a/python/src/potentials/tangential_adhesion_potential.cpp
+++ b/python/src/potentials/tangential_adhesion_potential.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/potentials/tangential_adhesion_potential.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_tangential_adhesion_potential(py::module_& m)
@@ -17,7 +16,7 @@ void define_tangential_adhesion_potential(py::module_& m)
             Parameters:
                 eps_a: The tangential adhesion mollifier parameter :math:`\epsilon_a`.
             )ipc_Qu8mg5v7",
-            py::arg("eps_a"))
+            "eps_a"_a)
         .def_property(
             "eps_a", &TangentialAdhesionPotential::eps_a,
             &TangentialAdhesionPotential::set_eps_a,

--- a/python/src/potentials/tangential_potential.cpp
+++ b/python/src/potentials/tangential_potential.cpp
@@ -3,7 +3,6 @@
 
 #include <ipc/potentials/tangential_potential.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_tangential_potential(py::module_& m)
@@ -53,10 +52,9 @@ void define_tangential_potential(py::module_& m)
             Returns:
                 The friction force.
             )ipc_Qu8mg5v7",
-            py::arg("collisions"), py::arg("mesh"), py::arg("rest_positions"),
-            py::arg("lagged_displacements"), py::arg("velocities"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"),
-            py::arg("dmin") = 0, py::arg("no_mu") = false)
+            "collisions"_a, "mesh"_a, "rest_positions"_a,
+            "lagged_displacements"_a, "velocities"_a, "normal_potential"_a,
+            "normal_stiffness"_a, "dmin"_a = 0, "no_mu"_a = false)
         .def(
             "force_jacobian",
             py::overload_cast<
@@ -83,10 +81,9 @@ void define_tangential_potential(py::module_& m)
             Returns:
                 The Jacobian of the friction force wrt the velocities.
             )ipc_Qu8mg5v7",
-            py::arg("collisions"), py::arg("mesh"), py::arg("rest_positions"),
-            py::arg("lagged_displacements"), py::arg("velocities"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"),
-            py::arg("wrt"), py::arg("dmin") = 0)
+            "collisions"_a, "mesh"_a, "rest_positions"_a,
+            "lagged_displacements"_a, "velocities"_a, "normal_potential"_a,
+            "normal_stiffness"_a, "wrt"_a, "dmin"_a = 0)
         .def(
             "force",
             py::overload_cast<
@@ -110,10 +107,9 @@ void define_tangential_potential(py::module_& m)
             Returns:
                 Friction force
             )ipc_Qu8mg5v7",
-            py::arg("collision"), py::arg("rest_positions"),
-            py::arg("lagged_displacements"), py::arg("velocities"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"),
-            py::arg("dmin") = 0, py::arg("no_mu") = false)
+            "collision"_a, "rest_positions"_a, "lagged_displacements"_a,
+            "velocities"_a, "normal_potential"_a, "normal_stiffness"_a,
+            "dmin"_a = 0, "no_mu"_a = false)
         .def(
             "force_jacobian",
             py::overload_cast<
@@ -138,8 +134,7 @@ void define_tangential_potential(py::module_& m)
             Returns:
                 Friction force Jacobian
             )ipc_Qu8mg5v7",
-            py::arg("collision"), py::arg("rest_positions"),
-            py::arg("lagged_displacements"), py::arg("velocities"),
-            py::arg("normal_potential"), py::arg("normal_stiffness"),
-            py::arg("wrt"), py::arg("dmin") = 0);
+            "collision"_a, "rest_positions"_a, "lagged_displacements"_a,
+            "velocities"_a, "normal_potential"_a, "normal_stiffness"_a, "wrt"_a,
+            "dmin"_a = 0);
 }

--- a/python/src/tangent/bindings.hpp
+++ b/python/src/tangent/bindings.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-namespace py = pybind11;
 
 void define_closest_point(py::module_& m);
 void define_relative_velocity(py::module_& m);

--- a/python/src/tangent/closest_point.cpp
+++ b/python/src/tangent/closest_point.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/tangent/closest_point.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_closest_point(py::module_& m)
@@ -27,7 +26,7 @@ void define_closest_point(py::module_& m)
         Returns:
             barycentric coordinates of the closest point
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"));
+        "p"_a, "e0"_a, "e1"_a);
 
     m.def(
         "point_edge_closest_point_jacobian",
@@ -49,7 +48,7 @@ void define_closest_point(py::module_& m)
         Returns:
             Jacobian of the closest point
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"));
+        "p"_a, "e0"_a, "e1"_a);
 
     m.def(
         "edge_edge_closest_point",
@@ -71,7 +70,7 @@ void define_closest_point(py::module_& m)
         Returns:
             Barycentric coordinates of the closest points
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "edge_edge_closest_point_jacobian",
@@ -93,7 +92,7 @@ void define_closest_point(py::module_& m)
         Returns:
             Jacobian of the closest points
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "point_triangle_closest_point",
@@ -115,7 +114,7 @@ void define_closest_point(py::module_& m)
         Returns:
             Barycentric coordinates of the closest point
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"));
+        "p"_a, "t0"_a, "t1"_a, "t2"_a);
 
     m.def(
         "point_triangle_closest_point_jacobian",
@@ -137,5 +136,5 @@ void define_closest_point(py::module_& m)
         Returns:
             Jacobian of the closest point
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"));
+        "p"_a, "t0"_a, "t1"_a, "t2"_a);
 }

--- a/python/src/tangent/relative_velocity.cpp
+++ b/python/src/tangent/relative_velocity.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/tangent/relative_velocity.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_relative_velocity(py::module_& m)
@@ -19,7 +18,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The relative velocity of the two points
         )ipc_Qu8mg5v7",
-        py::arg("dp0"), py::arg("dp1"));
+        "dp0"_a, "dp1"_a);
 
     m.def(
         "point_point_relative_velocity_matrix",
@@ -33,7 +32,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The relative velocity premultiplier matrix
         )ipc_Qu8mg5v7",
-        py::arg("dim"));
+        "dim"_a);
 
     m.def(
         "point_point_relative_velocity_matrix_jacobian",
@@ -47,7 +46,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The Jacobian of the relative velocity premultiplier matrix
         )ipc_Qu8mg5v7",
-        py::arg("dim"));
+        "dim"_a);
 
     m.def(
         "point_edge_relative_velocity", &point_edge_relative_velocity,
@@ -63,7 +62,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The relative velocity of the point and the edge
         )ipc_Qu8mg5v7",
-        py::arg("dp"), py::arg("de0"), py::arg("de1"), py::arg("alpha"));
+        "dp"_a, "de0"_a, "de1"_a, "alpha"_a);
 
     m.def(
         "point_edge_relative_velocity_matrix",
@@ -78,7 +77,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The relative velocity premultiplier matrix
         )ipc_Qu8mg5v7",
-        py::arg("dim"), py::arg("alpha"));
+        "dim"_a, "alpha"_a);
 
     m.def(
         "point_edge_relative_velocity_matrix_jacobian",
@@ -93,7 +92,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The Jacobian of the relative velocity premultiplier matrix
         )ipc_Qu8mg5v7",
-        py::arg("dim"), py::arg("alpha"));
+        "dim"_a, "alpha"_a);
 
     m.def(
         "edge_edge_relative_velocity", &edge_edge_relative_velocity,
@@ -110,8 +109,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The relative velocity of the edges
         )ipc_Qu8mg5v7",
-        py::arg("dea0"), py::arg("dea1"), py::arg("deb0"), py::arg("deb1"),
-        py::arg("coords"));
+        "dea0"_a, "dea1"_a, "deb0"_a, "deb1"_a, "coords"_a);
 
     m.def(
         "edge_edge_relative_velocity_matrix",
@@ -126,7 +124,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The relative velocity matrix
         )ipc_Qu8mg5v7",
-        py::arg("dim"), py::arg("coords"));
+        "dim"_a, "coords"_a);
 
     m.def(
         "edge_edge_relative_velocity_matrix_jacobian",
@@ -141,7 +139,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The Jacobian of the relative velocity matrix
         )ipc_Qu8mg5v7",
-        py::arg("dim"), py::arg("coords"));
+        "dim"_a, "coords"_a);
 
     m.def(
         "point_triangle_relative_velocity", &point_triangle_relative_velocity,
@@ -158,8 +156,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The relative velocity of the point to the triangle
         )ipc_Qu8mg5v7",
-        py::arg("dp"), py::arg("dt0"), py::arg("dt1"), py::arg("dt2"),
-        py::arg("coords"));
+        "dp"_a, "dt0"_a, "dt1"_a, "dt2"_a, "coords"_a);
 
     m.def(
         "point_triangle_relative_velocity_matrix",
@@ -174,7 +171,7 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The relative velocity matrix
         )ipc_Qu8mg5v7",
-        py::arg("dim"), py::arg("coords"));
+        "dim"_a, "coords"_a);
 
     m.def(
         "point_triangle_relative_velocity_matrix_jacobian",
@@ -189,5 +186,5 @@ void define_relative_velocity(py::module_& m)
         Returns:
             The Jacobian of the relative velocity matrix
         )ipc_Qu8mg5v7",
-        py::arg("dim"), py::arg("coords"));
+        "dim"_a, "coords"_a);
 }

--- a/python/src/tangent/tangent_basis.cpp
+++ b/python/src/tangent/tangent_basis.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/tangent/tangent_basis.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_tangent_basis(py::module_& m)
@@ -24,7 +23,7 @@ void define_tangent_basis(py::module_& m)
         Returns:
             A 3x2 matrix whose columns are the basis vectors.
         )ipc_Qu8mg5v7",
-        py::arg("p0"), py::arg("p1"));
+        "p0"_a, "p1"_a);
 
     m.def(
         "point_point_tangent_basis_jacobian",
@@ -43,7 +42,7 @@ void define_tangent_basis(py::module_& m)
         Returns:
             A 6*3x2 matrix whose columns are the basis vectors.
         )ipc_Qu8mg5v7",
-        py::arg("p0"), py::arg("p1"));
+        "p0"_a, "p1"_a);
 
     m.def(
         "point_edge_tangent_basis",
@@ -65,7 +64,7 @@ void define_tangent_basis(py::module_& m)
         Returns:
             A 3x2 matrix whose columns are the basis vectors.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"));
+        "p"_a, "e0"_a, "e1"_a);
 
     m.def(
         "point_edge_tangent_basis_jacobian",
@@ -87,7 +86,7 @@ void define_tangent_basis(py::module_& m)
         Returns:
             A 9*3x2 matrix whose columns are the basis vectors.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("e0"), py::arg("e1"));
+        "p"_a, "e0"_a, "e1"_a);
 
     m.def(
         "edge_edge_tangent_basis",
@@ -109,7 +108,7 @@ void define_tangent_basis(py::module_& m)
         Returns:
             A 3x2 matrix whose columns are the basis vectors.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "edge_edge_tangent_basis_jacobian",
@@ -131,7 +130,7 @@ void define_tangent_basis(py::module_& m)
         Returns:
             A 12*3x2 matrix whose columns are the basis vectors.
         )ipc_Qu8mg5v7",
-        py::arg("ea0"), py::arg("ea1"), py::arg("eb0"), py::arg("eb1"));
+        "ea0"_a, "ea1"_a, "eb0"_a, "eb1"_a);
 
     m.def(
         "point_triangle_tangent_basis",
@@ -160,7 +159,7 @@ void define_tangent_basis(py::module_& m)
         Returns:
             A 3x2 matrix whose columns are the basis vectors.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"));
+        "p"_a, "t0"_a, "t1"_a, "t2"_a);
 
     m.def(
         "point_triangle_tangent_basis_jacobian",
@@ -182,5 +181,5 @@ void define_tangent_basis(py::module_& m)
         Returns:
             A 12*3x2 matrix whose columns are the basis vectors.
         )ipc_Qu8mg5v7",
-        py::arg("p"), py::arg("t0"), py::arg("t1"), py::arg("t2"));
+        "p"_a, "t0"_a, "t1"_a, "t2"_a);
 }

--- a/python/src/utils/area_gradient.cpp
+++ b/python/src/utils/area_gradient.cpp
@@ -3,7 +3,6 @@
 #include <ipc/utils/area_gradient.hpp>
 #include <ipc/utils/eigen_ext.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_area_gradient(py::module_& m)
@@ -20,7 +19,7 @@ void define_area_gradient(py::module_& m)
         Returns:
             The gradient of the edge's length wrt e0, and e1.
         )ipc_Qu8mg5v7",
-        py::arg("e0"), py::arg("e1"));
+        "e0"_a, "e1"_a);
 
     m.def(
         "triangle_area_gradient", &triangle_area_gradient,
@@ -35,5 +34,5 @@ void define_area_gradient(py::module_& m)
         Returns:
             The gradient of the triangle's area t0, t1, and t2.
         )ipc_Qu8mg5v7",
-        py::arg("t0"), py::arg("t1"), py::arg("t2"));
+        "t0"_a, "t1"_a, "t2"_a);
 }

--- a/python/src/utils/bindings.hpp
+++ b/python/src/utils/bindings.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-namespace py = pybind11;
 
 void define_area_gradient(py::module_& m);
 void define_eigen_ext(py::module_& m);

--- a/python/src/utils/eigen_ext.cpp
+++ b/python/src/utils/eigen_ext.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/utils/eigen_ext.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_eigen_ext(py::module_& m)
@@ -23,7 +22,7 @@ void define_eigen_ext(py::module_& m)
         Returns:
             Projected matrix
         )ipc_Qu8mg5v7",
-        py::arg("A"), py::arg("eps") = 1e-8);
+        "A"_a, "eps"_a = 1e-8);
 
     py::enum_<PSDProjectionMethod>(
         m, "PSDProjectionMethod",
@@ -52,5 +51,5 @@ void define_eigen_ext(py::module_& m)
         Returns:
             Projected matrix
         )ipc_Qu8mg5v7",
-        py::arg("A"), py::arg("method") = PSDProjectionMethod::CLAMP);
+        "A"_a, "method"_a = PSDProjectionMethod::CLAMP);
 }

--- a/python/src/utils/intersection.cpp
+++ b/python/src/utils/intersection.cpp
@@ -4,15 +4,13 @@
 
 #include <igl/predicates/segment_segment_intersect.h>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_intersection(py::module_& m)
 {
     m.def(
-        "is_edge_intersecting_triangle", &is_edge_intersecting_triangle,
-        py::arg("e0"), py::arg("e1"), py::arg("t0"), py::arg("t1"),
-        py::arg("t2"));
+        "is_edge_intersecting_triangle", &is_edge_intersecting_triangle, "e0"_a,
+        "e1"_a, "t0"_a, "t1"_a, "t2"_a);
 
     m.def(
         "segment_segment_intersect",
@@ -35,5 +33,5 @@ void define_intersection(py::module_& m)
         Returns:
             true if they intersect
         )ipc_Qu8mg5v7",
-        py::arg("A"), py::arg("B"), py::arg("C"), py::arg("D"));
+        "A"_a, "B"_a, "C"_a, "D"_a);
 }

--- a/python/src/utils/interval.cpp
+++ b/python/src/utils/interval.cpp
@@ -3,7 +3,6 @@
 
 #include <ipc/utils/interval.hpp>
 
-namespace py = pybind11;
 #ifdef IPC_TOOLKIT_WITH_FILIB
 using namespace filib;
 #endif
@@ -44,8 +43,8 @@ void define_interval(py::module_& m)
 
     py::class_<Interval>(m_filib, "Interval")
         .def(py::init())
-        .def(py::init<double>(), py::arg("x"))
-        .def(py::init<double, double>(), py::arg("x"), py::arg("y"))
+        .def(py::init<double>(), "x"_a)
+        .def(py::init<double, double>(), "x"_a, "y"_a)
         .def(
             "__str__",
             [](const Interval& self) {

--- a/python/src/utils/logger.cpp
+++ b/python/src/utils/logger.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/utils/logger.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_logger(py::module_& m)
@@ -24,5 +23,5 @@ void define_logger(py::module_& m)
         [](const spdlog::level::level_enum& level) {
             logger().set_level(level);
         },
-        "Set log level", py::arg("level"));
+        "Set log level", "level"_a);
 }

--- a/python/src/utils/thread_limiter.cpp
+++ b/python/src/utils/thread_limiter.cpp
@@ -8,7 +8,6 @@
 
 #include <ipc/utils/logger.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 static std::shared_ptr<tbb::global_control> thread_limiter;
@@ -40,7 +39,7 @@ void define_thread_limiter(py::module_& m)
         "get maximum number of threads to use");
     m.def(
         "set_num_threads", &set_num_threads,
-        "set maximum number of threads to use", py::arg("nthreads"));
+        "set maximum number of threads to use", "nthreads"_a);
 
     std::atexit([]() { thread_limiter.reset(); });
 }

--- a/python/src/utils/vertex_to_min_edge.cpp
+++ b/python/src/utils/vertex_to_min_edge.cpp
@@ -2,12 +2,10 @@
 
 #include <ipc/utils/vertex_to_min_edge.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_vertex_to_min_edge(py::module_& m)
 {
     m.def(
-        "vertex_to_min_edge", &vertex_to_min_edge, py::arg("num_vertices"),
-        py::arg("edges"));
+        "vertex_to_min_edge", &vertex_to_min_edge, "num_vertices"_a, "edges"_a);
 }

--- a/python/src/utils/world_bbox_diagonal_length.cpp
+++ b/python/src/utils/world_bbox_diagonal_length.cpp
@@ -2,7 +2,6 @@
 
 #include <ipc/utils/world_bbox_diagonal_length.hpp>
 
-namespace py = pybind11;
 using namespace ipc;
 
 void define_world_bbox_diagonal_length(py::module_& m)
@@ -18,5 +17,5 @@ void define_world_bbox_diagonal_length(py::module_& m)
         Returns:
             The diagonal length of the world bounding box.
         )ipc_Qu8mg5v7",
-        py::arg("vertices"));
+        "vertices"_a);
 }


### PR DESCRIPTION
# Description

Switch from `py::arg` to `_a` literals.