### PR TITLE
Raise error on codim edges for GCP

### DIFF
--- a/src/ipc/smooth_contact/primitives/edge3.cpp
+++ b/src/ipc/smooth_contact/primitives/edge3.cpp
@@ -449,7 +449,8 @@ Edge3::Edge3(
             vertices.row(m_vertex_ids[1]), vertices.row(m_vertex_ids[2]),
             vertices.row(m_vertex_ids[3]), params, otypes, orientable);
     } else {
-        log_and_throw_error("Codimensional objects in 3D are not supported yet!");
+        log_and_throw_error(
+            "Codimensional objects in 3D are not supported yet!");
 
         if (has_neighbor_1 || has_neighbor_2) {
             m_vertex_ids = { { neighbors[0], neighbors[1],

--- a/src/ipc/smooth_contact/primitives/edge3.hpp
+++ b/src/ipc/smooth_contact/primitives/edge3.hpp
@@ -22,11 +22,14 @@ public:
     int n_dofs() const override { return n_vertices() * DIM; }
 
     double potential(
-        Eigen::ConstRef<Eigen::Vector3d> d, Eigen::ConstRef<VectorMax12d> x) const;
+        Eigen::ConstRef<Eigen::Vector3d> d,
+        Eigen::ConstRef<VectorMax12d> x) const;
     Vector15d grad(
-        Eigen::ConstRef<Eigen::Vector3d> d, Eigen::ConstRef<VectorMax12d> x) const;
+        Eigen::ConstRef<Eigen::Vector3d> d,
+        Eigen::ConstRef<VectorMax12d> x) const;
     Matrix15d hessian(
-        Eigen::ConstRef<Eigen::Vector3d> d, Eigen::ConstRef<VectorMax12d> x) const;
+        Eigen::ConstRef<Eigen::Vector3d> d,
+        Eigen::ConstRef<VectorMax12d> x) const;
 
 private:
     OrientationTypes otypes;


### PR DESCRIPTION
GCP has not fully supported 3D codim objects yet. To avoid random seg fault, raise a runtime error when codim edges are found. The codim implementation is ongoing.