### PR TITLE
2d bug fix

### DIFF
--- a/src/ipc/smooth_contact/primitives/edge2.cpp
+++ b/src/ipc/smooth_contact/primitives/edge2.cpp
@@ -13,11 +13,12 @@ Edge2::Edge2(
 {
     m_vertex_ids = { { mesh.edges()(id, 0), mesh.edges()(id, 1) } };
 
-    m_is_active = (mesh.is_orient_vertex(m_vertex_ids[0])
-                   && mesh.is_orient_vertex(m_vertex_ids[1]))
-        && Math<double>::cross2(
-               d, vertices.row(m_vertex_ids[1]) - vertices.row(m_vertex_ids[0]))
-            > 0;
+    if (mesh.is_orient_vertex(m_vertex_ids[0])
+        && mesh.is_orient_vertex(m_vertex_ids[1]))
+        m_is_active = Math<double>::cross2(
+            d, vertices.row(m_vertex_ids[1]) - vertices.row(m_vertex_ids[0])) > 0;
+    else
+        m_is_active = true;
 }
 
 int Edge2::n_vertices() const { return N_EDGE_NEIGHBORS_2D; }

--- a/src/ipc/smooth_contact/primitives/edge2.cpp
+++ b/src/ipc/smooth_contact/primitives/edge2.cpp
@@ -14,11 +14,15 @@ Edge2::Edge2(
     m_vertex_ids = { { mesh.edges()(id, 0), mesh.edges()(id, 1) } };
 
     if (mesh.is_orient_vertex(m_vertex_ids[0])
-        && mesh.is_orient_vertex(m_vertex_ids[1]))
-        m_is_active = Math<double>::cross2(
-            d, vertices.row(m_vertex_ids[1]) - vertices.row(m_vertex_ids[0])) > 0;
-    else
+        && mesh.is_orient_vertex(m_vertex_ids[1])) {
+        m_is_active =
+            Math<double>::cross2(
+                d,
+                vertices.row(m_vertex_ids[1]) - vertices.row(m_vertex_ids[0]))
+            > 0;
+    } else {
         m_is_active = true;
+    }
 }
 
 int Edge2::n_vertices() const { return N_EDGE_NEIGHBORS_2D; }

--- a/src/ipc/smooth_contact/primitives/edge2.cpp
+++ b/src/ipc/smooth_contact/primitives/edge2.cpp
@@ -15,7 +15,7 @@ Edge2::Edge2(
 
     m_is_active = (mesh.is_orient_vertex(m_vertex_ids[0])
                    && mesh.is_orient_vertex(m_vertex_ids[1]))
-        || Math<double>::cross2(
+        && Math<double>::cross2(
                d, vertices.row(m_vertex_ids[1]) - vertices.row(m_vertex_ids[0]))
             > 0;
 }


### PR DESCRIPTION
# Description

2D GCP has a bug due to Edge2's active check being trivially loose. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test: Visualized gradients for a simple 2D example where dhat is greater than the object thickness. Spurious exterior gradients appear without the bug fix. 

# Checklist

- [ ] I have followed the project [style guide](https://ipctk.xyz/style_guide.html)
- [ ] My code follows the clang-format style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules