### PR TITLE
Fix MSVC duplicate symbol errors for PrimitiveDistance

### DIFF
--- a/src/ipc/smooth_contact/distance/primitive_distance.hpp
+++ b/src/ipc/smooth_contact/distance/primitive_distance.hpp
@@ -212,6 +212,92 @@ public:
     }
 };
 
+// Explicit specialization declarations — prevent implicit instantiation of the
+// inline primary template body in other translation units (MSVC requires this).
+#ifndef IPC_TOOLKIT_DEBUG_AUTODIFF
+template <>
+std::tuple<
+    Eigen::Vector<double, PrimitiveDistance<Edge3, Edge3>::DIM>,
+    Eigen::Matrix<
+        double,
+        PrimitiveDistance<Edge3, Edge3>::DIM,
+        PrimitiveDistance<Edge3, Edge3>::N_CORE_DOFS>,
+    std::array<
+        Eigen::Matrix<
+            double,
+            PrimitiveDistance<Edge3, Edge3>::N_CORE_DOFS,
+            PrimitiveDistance<Edge3, Edge3>::N_CORE_DOFS>,
+        PrimitiveDistance<Edge3, Edge3>::DIM>>
+PrimitiveDistance<Edge3, Edge3>::compute_closest_direction_hessian(
+    const Eigen::Vector<double, PrimitiveDistance<Edge3, Edge3>::N_CORE_DOFS>&
+        x,
+    EdgeEdgeDistanceType dtype);
+
+template <>
+std::tuple<
+    Eigen::Vector<double, PrimitiveDistance<Point2, Point2>::DIM>,
+    Eigen::Matrix<
+        double,
+        PrimitiveDistance<Point2, Point2>::DIM,
+        PrimitiveDistance<Point2, Point2>::N_CORE_DOFS>,
+    std::array<
+        Eigen::Matrix<
+            double,
+            PrimitiveDistance<Point2, Point2>::N_CORE_DOFS,
+            PrimitiveDistance<Point2, Point2>::N_CORE_DOFS>,
+        PrimitiveDistance<Point2, Point2>::DIM>>
+PrimitiveDistance<Point2, Point2>::compute_closest_direction_hessian(
+    const Eigen::Vector<double, PrimitiveDistance<Point2, Point2>::N_CORE_DOFS>&
+        x,
+    PointPointDistanceType dtype);
+
+template <>
+std::tuple<
+    Eigen::Vector<double, PrimitiveDistance<Point3, Point3>::DIM>,
+    Eigen::Matrix<
+        double,
+        PrimitiveDistance<Point3, Point3>::DIM,
+        PrimitiveDistance<Point3, Point3>::N_CORE_DOFS>,
+    std::array<
+        Eigen::Matrix<
+            double,
+            PrimitiveDistance<Point3, Point3>::N_CORE_DOFS,
+            PrimitiveDistance<Point3, Point3>::N_CORE_DOFS>,
+        PrimitiveDistance<Point3, Point3>::DIM>>
+PrimitiveDistance<Point3, Point3>::compute_closest_direction_hessian(
+    const Eigen::Vector<double, PrimitiveDistance<Point3, Point3>::N_CORE_DOFS>&
+        x,
+    PointPointDistanceType dtype);
+
+template <>
+GradientType<PrimitiveDistance<Edge3, Edge3>::N_CORE_DOFS + 1>
+PrimitiveDistance<Edge3, Edge3>::compute_mollifier_gradient(
+    const Eigen::Vector<double, PrimitiveDistance<Edge3, Edge3>::N_CORE_DOFS>&
+        x,
+    double dist_sqr);
+
+template <>
+GradientType<PrimitiveDistance<Face, Point3>::N_CORE_DOFS + 1>
+PrimitiveDistance<Face, Point3>::compute_mollifier_gradient(
+    const Eigen::Vector<double, PrimitiveDistance<Face, Point3>::N_CORE_DOFS>&
+        x,
+    double dist_sqr);
+
+template <>
+HessianType<PrimitiveDistance<Edge3, Edge3>::N_CORE_DOFS + 1>
+PrimitiveDistance<Edge3, Edge3>::compute_mollifier_hessian(
+    const Eigen::Vector<double, PrimitiveDistance<Edge3, Edge3>::N_CORE_DOFS>&
+        x,
+    double dist_sqr);
+
+template <>
+HessianType<PrimitiveDistance<Face, Point3>::N_CORE_DOFS + 1>
+PrimitiveDistance<Face, Point3>::compute_mollifier_hessian(
+    const Eigen::Vector<double, PrimitiveDistance<Face, Point3>::N_CORE_DOFS>&
+        x,
+    double dist_sqr);
+#endif
+
 } // namespace ipc
 
 #include "primitive_distance.tpp"


### PR DESCRIPTION
# Description

Add explicit specialization declarations in primitive_distance.hpp for the seven methods that have optimized definitions in primitive_distance.cpp (compute_closest_direction_hessian for Edge3/Edge3, Point2/Point2, Point3/Point3; compute_mollifier_gradient and compute_mollifier_hessian for Edge3/Edge3 and Face/Point3). Without these declarations, MSVC instantiates the inline primary template body in every including translation unit, producing duplicate symbol linker errors. GCC/Clang handle this via COMDAT merging; MSVC does not.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)