### PR TITLE
Fix missing PSD projection of mollified m≤0 hessian blocks

### DIFF
--- a/src/ipc/potentials/normal_potential.cpp
+++ b/src/ipc/potentials/normal_potential.cpp
@@ -188,9 +188,9 @@ MatrixMax12d NormalPotential::hessian(
     if (collision.is_mollified() && m <= 0) {
         // The mollified hessian is w·f·∇²m here (∇m = 0 when m = 0). Because
         // m == 0 (⟺ ‖cross‖² == 0, exactly parallel edges) is a global minimum
-        // of the mollifier, hess_m = ∇²m is PSD and f = f(d) > 0. The block is
-        // therefore a scalar multiple of a PSD matrix, so its PSD projection
-        // reduces to projecting the scalar w·f -- no eigendecomposition needed.
+        // of the mollifier, hess_m = ∇²m is PSD. The block is therefore a scalar
+        // multiple of a PSD matrix, so its PSD projection reduces to projecting
+        // the scalar w·f -- no eigendecomposition needed.
         const double f = (*this)(d, collision.dmin);
         const MatrixMax12d hess_m = collision.mollifier_hessian(positions);
         double scale = collision.weight * f;

--- a/src/ipc/potentials/normal_potential.cpp
+++ b/src/ipc/potentials/normal_potential.cpp
@@ -8,6 +8,9 @@
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_reduce.h>
 
+#include <algorithm>
+#include <cmath>
+
 namespace ipc {
 
 // -- Cumulative methods -------------------------------------------------------
@@ -183,9 +186,20 @@ MatrixMax12d NormalPotential::hessian(
     // m(x) before evaluating barrier derivatives.
     const double m = collision.mollifier(positions); // m(x)
     if (collision.is_mollified() && m <= 0) {
+        // The mollified hessian is w·f·∇²m here (∇m = 0 when m = 0). Because
+        // m == 0 (⟺ ‖cross‖² == 0, exactly parallel edges) is a global minimum
+        // of the mollifier, hess_m = ∇²m is PSD and f = f(d) > 0. The block is
+        // therefore a scalar multiple of a PSD matrix, so its PSD projection
+        // reduces to projecting the scalar w·f -- no eigendecomposition needed.
         const double f = (*this)(d, collision.dmin);
         const MatrixMax12d hess_m = collision.mollifier_hessian(positions);
-        return (collision.weight * f) * hess_m;
+        double scale = collision.weight * f;
+        if (project_hessian_to_psd == PSDProjectionMethod::CLAMP) {
+            scale = std::max(scale, 0.0); // NSD (w < 0) projects to zero
+        } else if (project_hessian_to_psd == PSDProjectionMethod::ABS) {
+            scale = std::abs(scale);
+        }
+        return scale * hess_m;
     }
 
     // ∇d(x)

--- a/src/ipc/potentials/normal_potential.cpp
+++ b/src/ipc/potentials/normal_potential.cpp
@@ -186,11 +186,12 @@ MatrixMax12d NormalPotential::hessian(
     // m(x) before evaluating barrier derivatives.
     const double m = collision.mollifier(positions); // m(x)
     if (collision.is_mollified() && m <= 0) {
-        // The mollified hessian is w·f·∇²m here (∇m = 0 when m = 0). Because
-        // m == 0 (⟺ ‖cross‖² == 0, exactly parallel edges) is a global minimum
-        // of the mollifier, hess_m = ∇²m is PSD. The block is therefore a scalar
-        // multiple of a PSD matrix, so its PSD projection reduces to projecting
-        // the scalar w·f -- no eigendecomposition needed.
+        // The mollified hessian is weight * f * hess_m here (the mollifier
+        // gradient is zero when m = 0). At m == 0 the edges are exactly
+        // parallel -- a global minimum of the mollifier -- so hess_m is PSD,
+        // and f = f(d) > 0. The block is therefore a scalar multiple of a PSD
+        // matrix, so its PSD projection reduces to projecting the scalar
+        // weight * f (no eigendecomposition needed).
         const double f = (*this)(d, collision.dmin);
         const MatrixMax12d hess_m = collision.mollifier_hessian(positions);
         double scale = collision.weight * f;

--- a/tests/src/tests/potential/test_barrier_potential.cpp
+++ b/tests/src/tests/potential/test_barrier_potential.cpp
@@ -472,10 +472,11 @@ TEST_CASE(
 {
     // The cube's edges are axis-aligned, so IMPROVED_MAX_APPROX's near-parallel
     // negative-weight collisions have mollifier m == 0 exactly. That exercises
-    // NormalPotential::hessian()'s early-return branch, which returns the block
-    // (weight * f) * hess_m WITHOUT PSD projection. In debug builds an assert
-    // there checks the returned block is actually PSD -- if it fires, the CPU
-    // is returning a non-PSD block unprojected (a latent bug).
+    // NormalPotential::hessian()'s m <= 0 early-return branch.
+    //
+    // Before the fix, that branch returned (weight * f) * hess_m without applying
+    // the requested PSD projection, so negative-weight collisions could introduce
+    // non-PSD blocks into the assembled "PSD-projected" hessian.
     Eigen::MatrixXd vertices;
     Eigen::MatrixXi edges, faces;
     REQUIRE(tests::load_mesh("cube.ply", vertices, edges, faces));

--- a/tests/src/tests/potential/test_barrier_potential.cpp
+++ b/tests/src/tests/potential/test_barrier_potential.cpp
@@ -466,6 +466,47 @@ TEST_CASE(
     }
 }
 
+TEST_CASE(
+    "Mollified m<=0 hessian block is PSD",
+    "[potential][barrier_potential][hessian]")
+{
+    // The cube's edges are axis-aligned, so IMPROVED_MAX_APPROX's near-parallel
+    // negative-weight collisions have mollifier m == 0 exactly. That exercises
+    // NormalPotential::hessian()'s early-return branch, which returns the block
+    // (weight * f) * hess_m WITHOUT PSD projection. In debug builds an assert
+    // there checks the returned block is actually PSD -- if it fires, the CPU
+    // is returning a non-PSD block unprojected (a latent bug).
+    Eigen::MatrixXd vertices;
+    Eigen::MatrixXi edges, faces;
+    REQUIRE(tests::load_mesh("cube.ply", vertices, edges, faces));
+    const CollisionMesh mesh(vertices, edges, faces);
+
+    const double dhat = std::sqrt(2.0);
+    NormalCollisions collisions;
+    collisions.set_use_area_weighting(true);
+    collisions.set_collision_set_type(
+        NormalCollisions::CollisionSetType::IMPROVED_MAX_APPROX);
+    collisions.build(mesh, vertices, dhat);
+    REQUIRE(!collisions.empty());
+
+    const BarrierPotential barrier_potential(dhat, /*stiffness=*/1.0);
+
+    // Triggers the m <= 0 early-return (and its debug PSD assert) for every
+    // mollified collision that reaches it.
+    const Eigen::SparseMatrix<double> H = barrier_potential.hessian(
+        collisions, mesh, vertices, PSDProjectionMethod::CLAMP);
+    REQUIRE(H.nonZeros() > 0);
+
+    // With per-block CLAMP projection (including the m <= 0 blocks), the
+    // assembled hessian must be PSD. Before the fix, the m <= 0 branch returned
+    // negative-definite blocks unprojected, making this fail.
+    const Eigen::MatrixXd H_dense(H);
+    const Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(H_dense);
+    const double min_eig = eigensolver.eigenvalues().minCoeff();
+    const double scale = eigensolver.eigenvalues().cwiseAbs().maxCoeff();
+    CHECK(min_eig >= -1e-10 * std::max(scale, 1.0));
+}
+
 // -- Benchmarking ------------------------------------------------------------
 
 TEST_CASE(

--- a/tests/src/tests/potential/test_barrier_potential.cpp
+++ b/tests/src/tests/potential/test_barrier_potential.cpp
@@ -490,6 +490,25 @@ TEST_CASE(
     collisions.build(mesh, vertices, dhat);
     REQUIRE(!collisions.empty());
 
+    // Ensure the test actually exercises NormalPotential::hessian()'s m <= 0
+    // early-return branch (and the negative-weight case that motivated the fix).
+    int m_le_0_count = 0;
+    int m_le_0_negative_weight_count = 0;
+    for (const auto& c : collisions) {
+        if (!c.is_mollified()) {
+            continue;
+        }
+        const double m = c.mollifier(c.dof(vertices, mesh.edges(), mesh.faces()));
+        if (m <= 0) {
+            m_le_0_count++;
+            if (c.weight < 0) {
+                m_le_0_negative_weight_count++;
+            }
+        }
+    }
+    REQUIRE(m_le_0_count > 0);
+    REQUIRE(m_le_0_negative_weight_count > 0);
+
     const BarrierPotential barrier_potential(dhat, /*stiffness=*/1.0);
 
     // Triggers the m <= 0 early-return (and its debug PSD assert) for every

--- a/tests/src/tests/potential/test_barrier_potential.cpp
+++ b/tests/src/tests/potential/test_barrier_potential.cpp
@@ -15,6 +15,8 @@
 #include <finitediff.hpp>
 #include <igl/edges.h>
 
+#include <Eigen/Eigenvalues>
+
 using namespace ipc;
 
 TEST_CASE(
@@ -474,9 +476,10 @@ TEST_CASE(
     // negative-weight collisions have mollifier m == 0 exactly. That exercises
     // NormalPotential::hessian()'s m <= 0 early-return branch.
     //
-    // Before the fix, that branch returned (weight * f) * hess_m without applying
-    // the requested PSD projection, so negative-weight collisions could introduce
-    // non-PSD blocks into the assembled "PSD-projected" hessian.
+    // Before the fix, that branch returned (weight * f) * hess_m without
+    // applying the requested PSD projection, so negative-weight collisions
+    // could introduce non-PSD blocks into the assembled "PSD-projected"
+    // hessian.
     Eigen::MatrixXd vertices;
     Eigen::MatrixXi edges, faces;
     REQUIRE(tests::load_mesh("cube.ply", vertices, edges, faces));
@@ -491,14 +494,17 @@ TEST_CASE(
     REQUIRE(!collisions.empty());
 
     // Ensure the test actually exercises NormalPotential::hessian()'s m <= 0
-    // early-return branch (and the negative-weight case that motivated the fix).
+    // early-return branch (and the negative-weight case that motivated the
+    // fix).
     int m_le_0_count = 0;
     int m_le_0_negative_weight_count = 0;
-    for (const auto& c : collisions) {
+    for (size_t i = 0; i < collisions.size(); i++) {
+        const NormalCollision& c = collisions[i];
         if (!c.is_mollified()) {
             continue;
         }
-        const double m = c.mollifier(c.dof(vertices, mesh.edges(), mesh.faces()));
+        const double m =
+            c.mollifier(c.dof(vertices, mesh.edges(), mesh.faces()));
         if (m <= 0) {
             m_le_0_count++;
             if (c.weight < 0) {
@@ -520,7 +526,7 @@ TEST_CASE(
     // With per-block CLAMP projection (including the m <= 0 blocks), the
     // assembled hessian must be PSD. Before the fix, the m <= 0 branch returned
     // negative-definite blocks unprojected, making this fail.
-    const Eigen::MatrixXd H_dense(H);
+    const Eigen::MatrixXd H_dense = H.toDense();
     const Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(H_dense);
     const double min_eig = eigensolver.eigenvalues().minCoeff();
     const double scale = eigensolver.eigenvalues().cwiseAbs().maxCoeff();


### PR DESCRIPTION
## Problem

`NormalPotential::hessian()` has an early-return for the mollified case when the mollifier `m == 0` (exactly parallel edges):

```cpp
if (collision.is_mollified() && m <= 0) {
    const double f = (*this)(d, collision.dmin);
    const MatrixMax12d hess_m = collision.mollifier_hessian(positions);
    return (collision.weight * f) * hess_m;   // ← returned WITHOUT PSD projection
}
```

Every other return path applies `project_to_psd`, but this one did not. For positive weights the block `(weight·f)·hess_m` is PSD, so skipping projection was harmless. However, `IMPROVED_MAX_APPROX` produces **negative-weight** collisions, which flip the block to negative-(semi)definite — so the assembled "PSD-projected" hessian could contain non-PSD contributions. This was found via a GPU-vs-CPU hessian parity mismatch that reproduces on the cube (axis-aligned edges → `m == 0` exactly) with `IMPROVED_MAX_APPROX` + area weighting + `CLAMP`/`ABS` projection.

## Fix

Project the block like the other paths. Because `m == 0` (⟺ `‖cross‖² == 0`) is a **global minimum of the mollifier**, `hess_m = ∇²m` is PSD, and `f = f(d) > 0`. The block is therefore a scalar multiple of a PSD matrix, so its PSD projection reduces to projecting the scalar `weight·f`:

- `NONE` → `weight·f · hess_m`
- `CLAMP` → `max(weight·f, 0) · hess_m` (negative weight → zero)
- `ABS` → `|weight·f| · hess_m`

No eigendecomposition is needed, so this is also cheaper than a general projection in the common parallel-edge case. `NONE` behavior is unchanged, so existing finite-difference gradient/hessian tests are unaffected.

## Testing

- Added a regression test that asserts the assembled `CLAMP` hessian is PSD for a cube under `IMPROVED_MAX_APPROX` (exercises the `m == 0` branch). It fails before this change and passes after.
- Full `[barrier_potential]` suite passes (7418 assertions, 13 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)