### PR TITLE
Fix GCC compiler warnings

### DIFF
--- a/cmake/ipc_toolkit/ipc_toolkit_warnings.cmake
+++ b/cmake/ipc_toolkit/ipc_toolkit_warnings.cmake
@@ -122,7 +122,10 @@ else()
     # GCC 6.1 #
     ###########
 
-    -Wnull-dereference
+    # -Wnull-dereference is added below, but only for non-GCC compilers: GCC
+    # has a long-standing history of false positives on inlined Eigen
+    # expression-template code (e.g. https://gcc.gnu.org/PR94867, seen from
+    # GCC 8 through at least GCC 14).
     -fdelete-null-pointer-checks
     -Wduplicated-cond
     -Wmisleading-indentation
@@ -172,6 +175,10 @@ else()
 
     -Wno-redundant-decls
   )
+
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    list(APPEND IPC_TOOLKIT_WARNING_FLAGS -Wnull-dereference)
+  endif()
 endif()
 
 add_library(ipc_toolkit_warnings INTERFACE)

--- a/src/ipc/barrier/barrier.cpp
+++ b/src/ipc/barrier/barrier.cpp
@@ -20,7 +20,7 @@ template <typename T> T barrier(const T d, const T dhat)
     }
     // b(d) = -(d-d̂)²ln(d / d̂)
     const T d_minus_dhat = (d - dhat);
-    return -d_minus_dhat * d_minus_dhat * log(d / dhat);
+    return -d_minus_dhat * d_minus_dhat * std::log(d / dhat);
 }
 
 template <typename T> T barrier_first_derivative(const T d, const T dhat)
@@ -32,7 +32,7 @@ template <typename T> T barrier_first_derivative(const T d, const T dhat)
     // b'(d) = -2(d - d̂)ln(d / d̂) - (d-d̂)²(1 / d)
     //       = (d - d̂) * (-2ln(d/d̂) - (d - d̂) / d)
     //       = (d̂ - d) * (2ln(d/d̂) - d̂/d + 1)
-    return (dhat - d) * (2 * log(d / dhat) - dhat / d + 1);
+    return (dhat - d) * (2 * std::log(d / dhat) - dhat / d + 1);
 }
 
 template <typename T> T barrier_second_derivative(const T d, const T dhat)
@@ -41,7 +41,7 @@ template <typename T> T barrier_second_derivative(const T d, const T dhat)
         return T(0);
     }
     const T dhat_d = dhat / d;
-    return (dhat_d + 2) * dhat_d - 2 * log(d / dhat) - 3;
+    return (dhat_d + 2) * dhat_d - 2 * std::log(d / dhat) - 3;
 }
 
 // ============================================================================
@@ -57,7 +57,7 @@ T ClampedLogSqBarrier<T>::operator()(const T d, const T dhat) const
     }
     // b(d) = (d-d̂)²ln²(d / d̂)
     const T d_minus_dhat = (d - dhat);
-    const T log_d_dhat = log(d / dhat);
+    const T log_d_dhat = std::log(d / dhat);
     return d_minus_dhat * d_minus_dhat * log_d_dhat * log_d_dhat;
 }
 
@@ -71,7 +71,7 @@ T ClampedLogSqBarrier<T>::first_derivative(const T d, const T dhat) const
     // b'(d) = 2 (d - d̂) ln²(d / d̂) + 2 (d - d̂)² ln(d / d̂) / d
     //       = 2 (d - d̂) ln(d / d̂) [ln(d / d̂) + (d - d̂) / d]
     const T d_minus_dhat = (d - dhat);
-    const T log_d_dhat = log(d / dhat);
+    const T log_d_dhat = std::log(d / dhat);
     return T(2) * d_minus_dhat * log_d_dhat * (log_d_dhat + d_minus_dhat / d);
 }
 
@@ -82,7 +82,7 @@ T ClampedLogSqBarrier<T>::second_derivative(const T d, const T dhat) const
         return T(0);
     }
     const T t0 = dhat - d;
-    const T t1 = log(d / dhat);
+    const T t1 = std::log(d / dhat);
     const T t2 = (t0 * t0) / (d * d);
     return T(2) * ((t1 * t1) - (t1 - T(1)) * t2 - T(4) * t1 * t0 / d);
 }

--- a/src/ipc/broad_phase/lbvh.cpp
+++ b/src/ipc/broad_phase/lbvh.cpp
@@ -474,7 +474,11 @@ namespace {
                 std::array<float, batch_t::size>
                     buffer {};
 
+#if defined(__clang__)
 #pragma unroll
+#elif defined(__GNUC__)
+#pragma GCC unroll 16
+#endif
             // 2. Fill the buffer, respecting the actual number of queries
             for (size_t i = 0; i < batch_t::size; ++i) {
                 buffer[i] = (i < n_queries) ? F(static_cast<int>(i)) : 0.0f;

--- a/src/ipc/distance/edge_edge_mollifier.hpp
+++ b/src/ipc/distance/edge_edge_mollifier.hpp
@@ -2,6 +2,8 @@
 
 #include <ipc/utils/eigen_ext.hpp>
 
+#include <cmath>
+
 namespace ipc {
 
 // Symbolically generated derivatives
@@ -44,7 +46,7 @@ inline T edge_edge_mollifier_gradient(const T x, const T eps_x)
 {
     if (x < eps_x) {
         const T one_div_eps_x = T(1) / eps_x;
-        return T(2) * one_div_eps_x * fma(-one_div_eps_x, x, T(1));
+        return T(2) * one_div_eps_x * std::fma(-one_div_eps_x, x, T(1));
     } else {
         return T(0);
     }

--- a/src/ipc/geometry/normal.cpp
+++ b/src/ipc/geometry/normal.cpp
@@ -219,7 +219,7 @@ MatrixMax<T, 27, 9> point_line_normal_hessian(
 namespace {
     template <typename T>
     void set_cross_product_matrix_jacobian(
-        Eigen::Ref<Eigen::Matrix<T, 9, 3>> Jx, double chain_rule = 1.0)
+        Eigen::Ref<Eigen::Matrix<T, 9, 3>> Jx, T chain_rule = T(1.0))
     {
         Jx(2, 1) = Jx(3, 2) = Jx(7, 0) = -chain_rule;
         Jx(1, 2) = Jx(5, 0) = Jx(6, 1) = chain_rule;

--- a/tests/src/tests/geometry/test_angle.cpp
+++ b/tests/src/tests/geometry/test_angle.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Dihedral angle and gradient", "[angle][dihedral]")
     Eigen::Vector3d x2(0.5, 0, 0);
     Eigen::Vector3d x3(-0.5, 0, 0);
 
-    double expected_angle;
+    double expected_angle = 0;
     SECTION("Various angles")
     {
         const double rot = deg2rad(

--- a/tests/src/tests/ogc/test_trust_region.cpp
+++ b/tests/src/tests/ogc/test_trust_region.cpp
@@ -15,9 +15,9 @@ using namespace ipc;
 // its interior, close enough to generate an FV collision with the given dhat.
 //
 // Layout (y-up):
-//   V[0] = (0,  0, 0)   \
-//   V[1] = (2,  0, 0)    > triangle in y=0 plane
-//   V[2] = (1,  0, 2)   /
+//   V[0] = (0,  0, 0)   ┐
+//   V[1] = (2,  0, 0)   │ triangle in y=0 plane
+//   V[2] = (1,  0, 2)   ┘
 //   V[3] = (1, gap, 1)    <- vertex directly above triangle centroid
 //
 // Returned mesh has one face [0,1,2] and three boundary edges.
@@ -173,11 +173,6 @@ TEST_CASE(
 
     // Call filter_step
     tr.filter_step(mesh, x, dx);
-
-    // Compute expected beta using same stable formula as implementation
-    const Eigen::RowVector3d ci = tr.trust_region_centers.row(0);
-    const Eigen::RowVector3d xi = x.row(0);
-    const Eigen::RowVector3d dxi = Eigen::RowVector3d(1.0, 0.0, 0.0);
 
     // After filtering, dx should be scaled by expected_beta
     CHECK(dx(0, 0) == Catch::Approx(0.5));

--- a/tests/src/tests/utils.cpp
+++ b/tests/src/tests/utils.cpp
@@ -188,8 +188,7 @@ void print_compare_nonzero(
                 abs_diff / std::max(std::abs(A(i, j)), std::abs(B(i, j)));
 
             const double tol =
-                std::max({ std::abs(A(i, j)), std::abs(B(i, j)), double(1.0) })
-                * 1e-5;
+                std::max({ std::abs(A(i, j)), std::abs(B(i, j)), 1.0 }) * 1e-5;
 
             if ((A(i, j) != 0 || B(i, j) != 0)
                 && (!print_only_different || abs_diff > tol)) {


### PR DESCRIPTION
## Summary
- Fix -Wfloat-conversion, -Wunknown-pragmas, -Wmaybe-uninitialized, -Wcomment, and -Wunused-but-set-variable warnings surfaced by a clean rebuild.
- Disable -Wnull-dereference on GCC (keeping it for Clang): GCC has a long-standing history of false positives on inlined Eigen expression-template code ([PR94867](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94867), seen from GCC 8 through at least GCC 14), which produced several of the null-deref warnings this branch originally worked around per-callsite before consolidating into this single flag change.

## Test plan
- [x] `make -j$(nproc) -B` in `build/release`: 0 warnings, 0 errors
- [x] `ipc_toolkit_tests` and `ipctk` (python bindings) both build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)