### PR TITLE
Fix CUDA architecture selection and optimize LBVH Morton codes

### DIFF
--- a/src/ipc/broad_phase/lbvh.cpp
+++ b/src/ipc/broad_phase/lbvh.cpp
@@ -149,13 +149,14 @@ void LBVH::init_bvh(
     {
         IPC_TOOLKIT_PROFILE_BLOCK("compute_morton_codes");
 
-        const Eigen::Array3d mesh_width = mesh_aabb.max - mesh_aabb.min;
+        const Eigen::Array3d mesh_width_inv =
+            1.0 / (mesh_aabb.max - mesh_aabb.min);
         tbb::parallel_for(size_t(0), boxes.size(), [&](size_t i) {
             const auto& box = boxes[i];
 
             const Eigen::Array3d center = 0.5 * (box.min + box.max);
             const Eigen::Array3d mapped_center =
-                (center - mesh_aabb.min) / mesh_width;
+                (center - mesh_aabb.min) * mesh_width_inv;
 
             if (dim == 2) {
                 morton_codes[i].morton_code =

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,9 +76,15 @@ if(IPC_TOOLKIT_WITH_CUDA)
   # other libraries and executables.
   set_target_properties(ipc_toolkit_tests PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
-  # Use the same CUDA architectures Scalable CCD
-  # get_target_property(CMAKE_CUDA_ARCHITECTURES scalable_ccd CUDA_ARCHITECTURES)
-  set_target_properties(ipc_toolkit_tests PROPERTIES CUDA_ARCHITECTURES "native")
+  # Use the CUDA architectures specified by the user (e.g. via
+  # -DCMAKE_CUDA_ARCHITECTURES) and only fall back to auto-detecting the local
+  # GPU ("native") when none were given. "native" requires a physical GPU, so
+  # the fallback fails in GPU-less environments such as CI/Docker builds.
+  if(DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set_target_properties(ipc_toolkit_tests PROPERTIES CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+  else()
+    set_target_properties(ipc_toolkit_tests PROPERTIES CUDA_ARCHITECTURES "native")
+  endif()
 endif()
 
 if (IPC_TOOLKIT_TESTS_CCD_BENCHMARK)


### PR DESCRIPTION
# Description

Two independent small fixes, split out of the CUDA branch so they can land on their own.

- **`tests/CMakeLists.txt`** — the test target hard-coded `CUDA_ARCHITECTURES "native"`, which makes CMake probe for a physical GPU. Configuring therefore fails outright in GPU-less environments (CI runners, Docker image builds), even when the caller already passed `-DCMAKE_CUDA_ARCHITECTURES`. We now use whatever the user supplied and fall back to `"native"` only when they supplied nothing.
- **`src/ipc/broad_phase/lbvh.cpp`** — `LBVH::init_bvh` divided by `mesh_width` inside the `tbb::parallel_for` over boxes. Hoisting `1 / mesh_width` out of the loop turns three divides per box into three multiplies.

## Behavior

- The CMake change is inert for anyone who already passes `CMAKE_CUDA_ARCHITECTURES`, and unchanged for anyone building on the machine they target.
- The Morton hoist can differ in the last bit, since `a * (1/b)` does not always round to `a / b`. At worst that shifts the Morton sort order for a near-tie, changing the tree shape. The candidate set the query returns is unaffected — the traversal is exhaustive over overlapping nodes, not order-dependent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves existing functionality)

# How Has This Been Tested?

- [x] `[broad_phase] ~[!benchmark]` — 13 test cases, 1,464,038 assertions, all passing. Covers `LBVH::detect_*_candidates` and `Compare BP against brute force`, which checks the LBVH candidate set against brute force.
- [x] Full `ipc_toolkit`, `ipc_toolkit_tests`, and `ipctk` builds.

The CMake change is **not** covered: this was a `IPC_TOOLKIT_WITH_CUDA=OFF` build, so the edited branch never executed. It needs a CUDA configure to exercise.

**Test Configuration**:
* OS and Version: macOS 26.6 (arm64)
* Compiler and Version: AppleClang 21.0, `CMAKE_BUILD_TYPE=Release`, `IPC_TOOLKIT_BUILD_TESTS=ON`, `IPC_TOOLKIT_WITH_CUDA=OFF`

# Checklist

- [x] I have followed the project [style guide](https://ipctk.xyz/style_guide.html)
- [x] My code follows the clang-format style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
